### PR TITLE
Relax build deps to allow GHC-7.4's deepseq-1.3.0

### DIFF
--- a/containers.cabal
+++ b/containers.cabal
@@ -20,7 +20,7 @@ source-repository head
     location: http://github.com/haskell/containers.git
 
 Library
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4
     if impl(ghc>=6.10)
         build-depends: ghc-prim
 
@@ -68,7 +68,7 @@ Test-suite map-lazy-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -85,7 +85,7 @@ Test-suite map-strict-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING -DSTRICT
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -102,7 +102,7 @@ Test-suite set-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -117,7 +117,7 @@ Test-suite intmap-lazy-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -134,7 +134,7 @@ Test-suite intmap-strict-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING -DSTRICT
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -151,7 +151,7 @@ Test-suite intset-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -166,7 +166,7 @@ Test-suite seq-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.3, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 


### PR DESCRIPTION
jfyi, I also gave the current master branch a test-drive with GHC 7.4.0.20111218, and it passed all tests:

```
$ cabal test
Running 7 test suites...
Test suite seq-properties: RUNNING...
Test suite seq-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-seq-properties.log
Test suite intset-properties: RUNNING...
Test suite intset-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-intset-properties.log
Test suite intmap-strict-properties: RUNNING...
Test suite intmap-strict-properties: PASS
Test suite logged to:
dist/test/containers-0.5.0.0-intmap-strict-properties.log
Test suite intmap-lazy-properties: RUNNING...
Test suite intmap-lazy-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-intmap-lazy-properties.log
Test suite set-properties: RUNNING...
Test suite set-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-set-properties.log
Test suite map-strict-properties: RUNNING...
Test suite map-strict-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-map-strict-properties.log
Test suite map-lazy-properties: RUNNING...
Test suite map-lazy-properties: PASS
Test suite logged to: dist/test/containers-0.5.0.0-map-lazy-properties.log
7 of 7 test suites (7 of 7 test cases) passed.
```
