### PR TITLE
Remove NFData instances from benchmark code

### DIFF
--- a/benchmarks/IntMap.hs
+++ b/benchmarks/IntMap.hs
@@ -11,11 +11,6 @@ import qualified Data.IntMap as M
 import Data.Maybe (fromMaybe)
 import Prelude hiding (lookup)
 
-instance (NFData a) => NFData (M.IntMap a) where
-    rnf M.Nil = ()
-    rnf (M.Tip x y) = rnf x `seq` rnf y
-    rnf (M.Bin p m l r) = rnf p `seq` rnf m `seq` rnf l `seq` rnf r
-
 main = do
     let m = M.fromAscList elems :: M.IntMap Int
     defaultMainWith

--- a/benchmarks/IntSet.hs
+++ b/benchmarks/IntSet.hs
@@ -10,11 +10,6 @@ import Criterion.Main
 import Data.List (foldl')
 import qualified Data.IntSet as S
 
-instance NFData S.IntSet where
-    rnf S.Nil = ()
-    rnf (S.Tip a b) = rnf a `seq` rnf b
-    rnf (S.Bin p m l r) = rnf p `seq` rnf m `seq` rnf l `seq` rnf r
-
 main = do
     let s = S.fromAscList elems :: S.IntSet
         s_even = S.fromAscList elems_even :: S.IntSet

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -11,10 +11,6 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import Prelude hiding (lookup)
 
-instance (NFData k, NFData a) => NFData (M.Map k a) where
-    rnf M.Tip = ()
-    rnf (M.Bin _ k a l r) = rnf k `seq` rnf a `seq` rnf l `seq` rnf r
-
 main = do
     let m = M.fromAscList elems :: M.Map Int Int
         m_even = M.fromAscList elems_even :: M.Map Int Int

--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -8,9 +8,6 @@ import qualified Data.Sequence as S
 import qualified Data.Foldable
 import System.Random
 
-instance NFData a => NFData (S.Seq a) where
-    rnf = Data.Foldable.foldr seq ()
-
 main = do
     let s10 = S.fromList [1..10] :: S.Seq Int
         s100 = S.fromList [1..100] :: S.Seq Int

--- a/benchmarks/Set.hs
+++ b/benchmarks/Set.hs
@@ -11,10 +11,6 @@ import Criterion.Main
 import Data.List (foldl')
 import qualified Data.Set as S
 
-instance NFData a => NFData (S.Set a) where
-    rnf S.Tip = ()
-    rnf (S.Bin _ a l r) = rnf a `seq` rnf l `seq` rnf r
-
 main = do
     let s = S.fromAscList elems :: S.Set Int
         s_even = S.fromAscList elems_even :: S.Set Int


### PR DESCRIPTION
The benchmarks still had redundent NFData instances.  With this patch they compile and run OK on Haskell Platform 2011.4.
