### PR TITLE
Implementation of `successor` function for IntMap

### DIFF
--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -69,6 +69,7 @@ module Data.IntMap.Lazy (
             , member
             , notMember
             , IM.lookup
+            , successor
             , findWithDefault
 
             -- * Construction

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -73,6 +73,7 @@ module Data.IntMap.Strict (
             , member
             , notMember
             , lookup
+            , successor
             , findWithDefault
 
             -- * Construction


### PR DESCRIPTION
PATRICIA trees support the "successor" operation with O(min(n,W)) runtime complexity. That is, given some input key `k'`, find the `(k, v)` pair with the smallest `k` greater than or equal to `k'`. This is useful for efficiently implementing certain hashing schemes such as [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing).

This pull request is an implementation of an O(min(n,W)) `successor` function:

```
successor :: Key -> IntMap a -> Maybe (Key, a)
```

Note that you can implement `successor` in terms of `splitLookup` and `findMin`, but the use of `splitLookup` slows things down unnecessarily.

Cheers,
Mike
