### PR TITLE
Data.Graph: refer to a better version of the King and Launchbury article

### DIFF
--- a/Data/Graph.hs
+++ b/Data/Graph.hs
@@ -17,7 +17,7 @@
 --
 -- A version of the graph algorithms described in:
 --
---   /Lazy Depth-First Search and Linear Graph Algorithms in Haskell/,
+--   /Structuring Depth-First Search Algorithms in Haskell/,
 --   by David King and John Launchbury.
 --
 -----------------------------------------------------------------------------


### PR DESCRIPTION
I put both articles side by side, and the first is clearly an earlier draft of the latter.
