### PR TITLE
Applicative and Alternative instances for Seq

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -198,9 +198,17 @@ instance Monad Seq where
     xs >>= f = foldl' add empty xs
       where add ys x = ys >< f x
 
+instance Applicative Seq where
+    pure = singleton
+    (<*>) = ap
+
 instance MonadPlus Seq where
     mzero = empty
     mplus = (><)
+
+instance Control.Applicative.Alternative Seq where
+  Control.Applicative.empty = empty
+  (Control.Applicative.<|>) = (><)
 
 instance Eq a => Eq (Seq a) where
     xs == ys = length xs == length ys && toList xs == toList ys


### PR DESCRIPTION
The Alternative instance is basically the same as the pre-existing MonadPlus instance, except names are qualified (empty clashes with empty).
The Applicative instance is similar to the Monad instance, and relies on ap.
