### PR TITLE
Added `foldMapWithKey`.

### DIFF
--- a/Data/IntMap/Base.hs
+++ b/Data/IntMap/Base.hs
@@ -123,6 +123,8 @@ module Data.IntMap.Base (
     , foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'
@@ -1669,6 +1671,19 @@ foldlWithKey' f z = \t ->      -- Use lambda t to be inlinable with two argument
     go z' (Tip kx x)    = f z' kx x
     go z' (Bin _ _ l r) = go (go z' l) r
 {-# INLINE foldlWithKey' #-}
+
+-- | /O(n)/. Fold the keys and values in the map using the given monoid, such that
+--
+-- @'foldMapWithKey' f = 'Prelude.fold' . 'mapWithKey' f@
+--
+-- This can be an asymptotically faster than 'foldrWithKey' or 'foldlWithKey' for some monoids.
+foldMapWithKey :: Monoid m => (Key -> a -> m) -> IntMap a -> m
+foldMapWithKey f = go
+  where
+    go Nil           = mempty
+    go (Tip kx x)    = f kx x
+    go (Bin _ _ l r) = go l `mappend` go r
+{-# INLINE foldMapWithKey #-}
 
 {--------------------------------------------------------------------
   List variations

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -133,6 +133,8 @@ module Data.IntMap.Lazy (
     , IM.foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -139,6 +139,8 @@ module Data.IntMap.Strict (
     , foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'

--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -169,6 +169,8 @@ module Data.Map.Base (
     , foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'
@@ -1872,6 +1874,18 @@ foldlWithKey' f z = go z
     go z' Tip              = z'
     go z' (Bin _ kx x l r) = go (f (go z' l) kx x) r
 {-# INLINE foldlWithKey' #-}
+
+-- | /O(n)/. Fold the keys and values in the map using the given monoid, such that
+--
+-- @'foldMapWithKey' f = 'Prelude.fold' . 'mapWithKey' f@
+--
+-- This can be an asymptotically faster than 'foldrWithKey' or 'foldlWithKey' for some monoids.
+foldMapWithKey :: Monoid m => (k -> a -> m) -> Map k a -> m
+foldMapWithKey f = go
+  where
+    go Tip             = mempty
+    go (Bin _ k v l r) = go l `mappend` f k v `mappend` go r
+{-# INLINE foldMapWithKey #-}
 
 {--------------------------------------------------------------------
   List variations

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -129,6 +129,8 @@ module Data.Map.Lazy (
     , M.foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -136,6 +136,8 @@ module Data.Map.Strict
     , foldl
     , foldrWithKey
     , foldlWithKey
+    , foldMapWithKey
+
     -- ** Strict folds
     , foldr'
     , foldl'


### PR DESCRIPTION
I've needed this repeatedly over the years and it makes an asymptotic difference in parts of ekmett/lens, so I figured I'd submit it.

This is asymptotically more efficient than using `fold . mapWithKey` for many monoids because it doesn't have to build up an entire new map just to `fold` it.

There isn't a sensible strict variant.
