### PR TITLE
Use the new Typeable class in GHC >= 7.7

### DIFF
--- a/include/Typeable.h
+++ b/include/Typeable.h
@@ -20,9 +20,15 @@
 --  // generate the instances.
 
 #define INSTANCE_TYPEABLE0(tycon,tcname,str) deriving instance Typeable tycon
+#if __GLASGOW_HASKELL__ >= 707
+#define INSTANCE_TYPEABLE1(tycon,tcname,str) deriving instance Typeable tycon
+#define INSTANCE_TYPEABLE2(tycon,tcname,str) deriving instance Typeable tycon
+#define INSTANCE_TYPEABLE3(tycon,tcname,str) deriving instance Typeable tycon
+#else
 #define INSTANCE_TYPEABLE1(tycon,tcname,str) deriving instance Typeable1 tycon
 #define INSTANCE_TYPEABLE2(tycon,tcname,str) deriving instance Typeable2 tycon
 #define INSTANCE_TYPEABLE3(tycon,tcname,str) deriving instance Typeable3 tycon
+#endif
 
 #else /* !__GLASGOW_HASKELL__ */
 


### PR DESCRIPTION
Hi,

This patch to containers makes it use Typeable instead of Typeable1..3 if GHC >= 7.7. A similar change has already been implemented in the GHC copy of the containers repo; as soon as this patch is applied here, we can remove that temporary fix.

Thanks,
Pedro
