### PR TITLE
Add traverseWithKey_ variant to avoid allocation

### DIFF
--- a/Data/IntMap/Base.hs
+++ b/Data/IntMap/Base.hs
@@ -111,6 +111,7 @@ module Data.IntMap.Base (
     , map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey
@@ -210,7 +211,7 @@ module Data.IntMap.Base (
     , foldlStrict
     ) where
 
-import Control.Applicative (Applicative(pure, (<*>)), (<$>))
+import Control.Applicative (Applicative(pure, (<*>)), (<$>), (*>))
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad (liftM)
 import Data.Bits
@@ -1267,6 +1268,17 @@ traverseWithKey f = go
     go (Tip k v) = Tip k <$> f k v
     go (Bin p m l r) = Bin p m <$> go l <*> go r
 {-# INLINE traverseWithKey #-}
+
+-- | /O(n)/.
+-- This is a version of 'traverseWithKey' that doesn't require allocating a new 'IntMap'.
+-- It is useful for iterating over the contents of the map for side effect only.
+traverseWithKey_ :: Applicative t => (Key -> a -> t ()) -> IntMap a -> t ()
+traverseWithKey_ f = go
+  where
+    go Nil = pure ()
+    go (Tip k v) = f k v
+    go (Bin _ _ l r) = go l *> go r 
+{-# INLINE traverseWithKey_ #-}
 
 -- | /O(n)/. The function @'mapAccum'@ threads an accumulating
 -- argument through the map in ascending order of keys.

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -121,6 +121,7 @@ module Data.IntMap.Lazy (
     , IM.map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -127,6 +127,7 @@ module Data.IntMap.Strict (
     , map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey

--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -157,6 +157,7 @@ module Data.Map.Base (
     , map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey
@@ -1664,6 +1665,18 @@ traverseWithKey f = go
     go (Bin 1 k v _ _) = (\v' -> Bin 1 k v' Tip Tip) <$> f k v
     go (Bin s k v l r) = flip (Bin s k) <$> go l <*> f k v <*> go r
 {-# INLINE traverseWithKey #-}
+
+
+-- | /O(n)/.
+-- This is a version of 'traverseWithKey' that doesn't require allocating a new 'Map'.
+-- It is useful for iterating over the contents of the map for side effect only.
+traverseWithKey_ :: Applicative t => (k -> a -> t ()) -> Map k a -> t ()
+traverseWithKey_ f = go
+  where
+    go Tip             = pure ()
+    go (Bin _ k v l r) = f k v *> go l *> go r 
+{-# INLINE traverseWithKey_ #-}
+
 
 -- | /O(n)/. The function 'mapAccum' threads an accumulating
 -- argument through the map in ascending order of keys.

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -117,6 +117,7 @@ module Data.Map.Lazy (
     , M.map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -124,6 +124,7 @@ module Data.Map.Strict
     , map
     , mapWithKey
     , traverseWithKey
+    , traverseWithKey_
     , mapAccum
     , mapAccumWithKey
     , mapAccumRWithKey


### PR DESCRIPTION
We're in the process of discussing this on the mailing list.  I'm putting this here for when/if people are ready for it.
