### PR TITLE
Add Functor instance to Data.Graph.SCC

### DIFF
--- a/Data/Graph.hs
+++ b/Data/Graph.hs
@@ -93,6 +93,10 @@ instance NFData a => NFData (SCC a) where
     rnf (AcyclicSCC v) = rnf v
     rnf (CyclicSCC vs) = rnf vs
 
+instance Functor SCC where
+    fmap f (AcyclicSCC v) = AcyclicSCC (f v)
+    fmap f (CyclicSCC vs) = CyclicSCC (fmap f vs)
+
 -- | The vertices of a list of strongly connected components.
 flattenSCCs :: [SCC a] -> [a]
 flattenSCCs = concatMap flattenSCC


### PR DESCRIPTION
Occasionally useful. Not sure if DeriveFunctor is allowed or not so I wrote the instance by hand.
