### PR TITLE
Add LANGUAGE RoleAnnotations for ghc 7.8

### DIFF
--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -5,6 +5,9 @@
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Map.Base

--- a/Data/Set/Base.hs
+++ b/Data/Set/Base.hs
@@ -5,6 +5,9 @@
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Set.Base


### PR DESCRIPTION
As I understand, this was missing. I had error

```
Data/Set/Base.hs:239:1:
    Illegal role annotation for Set;
    did you intend to use RoleAnnotations?
    while checking a role annotation for `Set'
```

when trying to run `cabal test` on master.
