### PR TITLE
tree: Fix imports for the Applicative/Monad change

### DIFF
--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -32,7 +32,7 @@ module Data.Tree(
     ) where
 
 import Control.Applicative (Applicative(..), (<$>))
-import Control.Monad
+import Control.Monad (liftM)
 import Data.Monoid (Monoid(..))
 import Data.Sequence (Seq, empty, singleton, (<|), (|>), fromList,
             ViewL(..), ViewR(..), viewl, viewr)


### PR DESCRIPTION
Due to various problems with orphans and cycles in base, while
implementing the Applicative/Monad Proposal, Alternative joined
MonadPlus in Control.Monad.

A knock-on effect of this is that Control.Monad now exports 'empty',
which conflicts with Data.Sequence in this case. Luckily the fix is
actually quite easy: just restrict the imports to liftM, since that's
all we use anyway.
