### PR TITLE
Fixity declarations for member, notMember, union, intersection

### DIFF
--- a/Data/IntMap/Base.hs
+++ b/Data/IntMap/Base.hs
@@ -395,7 +395,7 @@ member k = k `seq` go
     go (Tip kx _) = k == kx
     go Nil = False
 
-infix 4 member
+infix 4 `member`
 
 -- | /O(min(n,W))/. Is the key not a member of the map?
 --
@@ -405,7 +405,7 @@ infix 4 member
 notMember :: Key -> IntMap a -> Bool
 notMember k m = not $ member k m
 
-infix 4 notMember
+infix 4 `notMember`
 
 -- | /O(min(n,W))/. Lookup the value at a key in the map. See also 'Data.Map.lookup'.
 
@@ -822,7 +822,7 @@ union :: IntMap a -> IntMap a -> IntMap a
 union m1 m2
   = mergeWithKey' Bin const id id m1 m2
 
-infixl 5 union
+infixl 5 `union`
 
 -- | /O(n+m)/. The union with a combining function.
 --
@@ -887,7 +887,7 @@ intersection :: IntMap a -> IntMap b -> IntMap a
 intersection m1 m2
   = mergeWithKey' bin const (const Nil) (const Nil) m1 m2
 
-infixl 5 intersection
+infixl 5 `intersection`
 
 -- | /O(n+m)/. The intersection with a combining function.
 --

--- a/Data/IntSet/Base.hs
+++ b/Data/IntSet/Base.hs
@@ -332,13 +332,13 @@ member x = x `seq` go
     go (Tip y bm) = prefixOf x == y && bitmapOf x .&. bm /= 0
     go Nil = False
 
-infix 4 member
+infix 4 `member`
 
 -- | /O(min(n,W))/. Is the element not in the set?
 notMember :: Key -> IntSet -> Bool
 notMember k = not . member k
 
-infix 4 notMember
+infix 4 `notMember`
 
 -- | /O(log n)/. Find largest element smaller than the given one.
 --
@@ -527,7 +527,7 @@ union t@(Bin _ _ _ _) Nil = t
 union (Tip kx bm) t = insertBM kx bm t
 union Nil t = t
 
-infixl 5 union
+infixl 5 `union`
 
 {--------------------------------------------------------------------
   Difference
@@ -602,7 +602,7 @@ intersection (Tip kx1 bm1) t2 = intersectBM t2
 
 intersection Nil _ = Nil
 
-infixl 5 intersection
+infixl 5 `intersection`
 
 {--------------------------------------------------------------------
   Subset

--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -456,7 +456,7 @@ member = go
 {-# INLINE member #-}
 #endif
 
-infix 4 member
+infix 4 `member`
 
 -- | /O(log n)/. Is the key not a member of the map? See also 'member'.
 --
@@ -471,7 +471,7 @@ notMember k m = not $ member k m
 {-# INLINE notMember #-}
 #endif
 
-infix 4 notMember
+infix 4 `notMember`
 
 -- | /O(log n)/. Find the value at a key.
 -- Calls 'error' when the element can not be found.
@@ -1234,7 +1234,7 @@ union t1 t2 = hedgeUnion NothingS NothingS t1 t2
 {-# INLINABLE union #-}
 #endif
 
-infixl 5 union
+infixl 5 `union`
 
 -- left-biased hedge union
 hedgeUnion :: Ord a => MaybeS a -> MaybeS a -> Map a b -> Map a b -> Map a b
@@ -1356,7 +1356,7 @@ intersection t1 t2 = hedgeInt NothingS NothingS t1 t2
 {-# INLINABLE intersection #-}
 #endif
 
-infixl 5 intersection
+infixl 5 `intersection`
 
 hedgeInt :: Ord k => MaybeS k -> MaybeS k -> Map k a -> Map k b -> Map k a
 hedgeInt _ _ _   Tip = Tip

--- a/Data/Set/Base.hs
+++ b/Data/Set/Base.hs
@@ -318,7 +318,7 @@ member = go
 {-# INLINE member #-}
 #endif
 
-infix 4 member
+infix 4 `member`
 
 -- | /O(log n)/. Is the element not in the set?
 notMember :: Ord a => a -> Set a -> Bool
@@ -329,7 +329,7 @@ notMember a t = not $ member a t
 {-# INLINE notMember #-}
 #endif
 
-infix 4 notMember
+infix 4 `notMember`
 
 -- | /O(log n)/. Find largest element smaller than the given one.
 --
@@ -582,7 +582,7 @@ union t1 t2 = hedgeUnion NothingS NothingS t1 t2
 {-# INLINABLE union #-}
 #endif
 
-infixl 5 union
+infixl 5 `union`
 
 hedgeUnion :: Ord a => MaybeS a -> MaybeS a -> Set a -> Set a -> Set a
 hedgeUnion _   _   t1  Tip = t1
@@ -642,7 +642,7 @@ intersection t1 t2 = hedgeInt NothingS NothingS t1 t2
 {-# INLINABLE intersection #-}
 #endif
 
-infixl 5 intersection
+infixl 5 `intersection`
 
 hedgeInt :: Ord a => MaybeS a -> MaybeS a -> Set a -> Set a -> Set a
 hedgeInt _ _ _   Tip = Tip


### PR DESCRIPTION
As discussed at issue #47. I added the following declarations to Data.Set, Data.IntSet, Data.Map, and Data.IntMap:

infix 4 member
infix 4 notMember
infixl 5 union
infixl 5 intersection

I did not add an infix declaration for `difference`, because there already exists the `\\` operator, and it is declared "infixl 9". I don't think "infixl 9" is very logical (I would have preferred `\\` to have the same precedence as `++`), but I also didn't want to change an existing declaration, nor declare `difference` to have a different fixity than `\\`. Therefore, I have left `difference` unchanged, with no fixity declaration, which means it defaults to "infixl 9" anyway.
