### PR TITLE
Use defensive `Data.Foldable` import

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -149,7 +149,7 @@ import Control.DeepSeq (NFData(rnf))
 import Control.Monad (MonadPlus(..), ap)
 import Data.Monoid (Monoid(..))
 import Data.Functor (Functor(..))
-import Data.Foldable
+import Data.Foldable (Foldable(foldl, foldl1, foldr, foldr1), foldl', toList)
 import Data.Traversable
 import Data.Typeable
 


### PR DESCRIPTION
With this `import`-style containers will compile warning free
with existing GHC versions as well as GHC HEAD (in its current form)

This change is also needed because `Data.Foldable` is planned to export
`null` and `length` which will otherwise clash with `Data.Sequence`
