### PR TITLE
Fix subtle bug in binary search

### DIFF
--- a/Data/Graph.hs
+++ b/Data/Graph.hs
@@ -244,7 +244,7 @@ graphFromEdges edges0
                                    EQ -> Just mid
                                    GT -> findVertex (mid+1) b
                               where
-                                mid = (a + b) `div` 2
+                                mid = a + (b - a) `div` 2
 
 -------------------------------------------------------------------------
 --                                                                      -


### PR DESCRIPTION
Fix a bug in binary search code that could cause overflow with finite types like Int.
