### PR TITLE
Tighten Safe Haskell bounds, fixes new warning in GHC 7.10.

### DIFF
--- a/Data/IntMap.hs
+++ b/Data/IntMap.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 -----------------------------------------------------------------------------
 -- |

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
+#if !defined(TESTING) && __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Data/Utils/StrictFold.hs
+++ b/Data/Utils/StrictFold.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 module Data.Utils.StrictFold (foldlStrict) where
 

--- a/Data/Utils/StrictPair.hs
+++ b/Data/Utils/StrictPair.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 #if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 #endif
 module Data.Utils.StrictPair (StrictPair(..), toPair) where
 


### PR DESCRIPTION
Some of the Safe Haskell bounds can be improved. This also fixes warnings that will appear in 7.10 where we have a new warning flag (`--fwarn-trustworthy-safe`) that warns when a trustworthy module could be instead marked safe.
