### PR TITLE
Add support for `deepseq-1.4`

### DIFF
--- a/Data/IntSet/Base.hs
+++ b/Data/IntSet/Base.hs
@@ -162,7 +162,7 @@ module Data.IntSet.Base (
     , bitmapOf
     ) where
 
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData(rnf))
 import Data.Bits
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
@@ -1099,7 +1099,7 @@ INSTANCE_TYPEABLE0(IntSet,intSetTc,"IntSet")
 -- The IntSet constructors consist only of strict fields of Ints and
 -- IntSets, thus the default NFData instance which evaluates to whnf
 -- should suffice
-instance NFData IntSet
+instance NFData IntSet where rnf x = seq x ()
 
 {--------------------------------------------------------------------
   Debugging

--- a/containers.cabal
+++ b/containers.cabal
@@ -31,7 +31,7 @@ source-repository head
     location: http://github.com/haskell/containers.git
 
 Library
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5
     if impl(ghc>=6.10)
         build-depends: ghc-prim
 
@@ -83,7 +83,7 @@ Test-suite map-lazy-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -100,7 +100,7 @@ Test-suite map-strict-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING -DSTRICT
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -117,7 +117,7 @@ Test-suite set-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -134,7 +134,7 @@ Test-suite intmap-lazy-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -151,7 +151,7 @@ Test-suite intmap-strict-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING -DSTRICT
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -168,7 +168,7 @@ Test-suite intset-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -185,7 +185,7 @@ Test-suite deprecated-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -200,7 +200,7 @@ Test-suite seq-properties
     type: exitcode-stdio-1.0
     cpp-options: -DTESTING
 
-    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.4, ghc-prim
+    build-depends: base >= 4.2 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
@@ -218,7 +218,7 @@ test-suite map-strictness-properties
     array,
     base >= 4.2 && < 5,
     ChasingBottoms,
-    deepseq >= 1.2 && < 1.4,
+    deepseq >= 1.2 && < 1.5,
     QuickCheck >= 2.4.0.1,
     ghc-prim,
     test-framework >= 0.3.3,
@@ -235,7 +235,7 @@ test-suite intmap-strictness-properties
     array,
     base >= 4.2 && < 5,
     ChasingBottoms,
-    deepseq >= 1.2 && < 1.4,
+    deepseq >= 1.2 && < 1.5,
     QuickCheck >= 2.4.0.1,
     ghc-prim,
     test-framework >= 0.3.3,


### PR DESCRIPTION
This change avoids relying on `rnf`'s default method implementation
which has changed in `deepseq-1.4.0.0`
