### PR TITLE
Use GHC version for coercion rules

### DIFF
--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -294,7 +294,7 @@ import qualified GHC.Exts as GHCExts
 import Text.Read
 import Data.Data
 #endif
-#if MIN_VERSION_base(4,8,0)
+#if __GLASGOW_HASKELL__ >= 709
 import Data.Coerce
 #endif
 
@@ -1668,9 +1668,8 @@ map f (Bin sx kx x l r) = Bin sx kx (f x) (map f l) (map f r)
 "map/map" forall f g xs . map f (map g xs) = map (f . g) xs
  #-}
 #endif
-#if MIN_VERSION_base(4,8,0)
--- Safe coercions were introduced in 4.7.0, but I am not sure if they played
--- well enough with RULES to do what we want.
+#if __GLASGOW_HASKELL__ >= 709
+-- Safe coercions were introduced in 7.8, but did not work well with RULES yet.
 {-# RULES
 "map/coerce" map coerce = coerce
  #-}

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -279,7 +279,7 @@ import Data.Utils.StrictFold
 import Data.Utils.StrictPair
 
 import Data.Bits (shiftL, shiftR)
-#if MIN_VERSION_base(4,8,0)
+#if __GLASGOW_HASKELL__ >= 709
 import Data.Coerce
 #endif
 
@@ -941,9 +941,8 @@ map f (Bin sx kx x l r) = let x' = f x in x' `seq` Bin sx kx x' (map f l) (map f
 "map/map" forall f g xs . map f (map g xs) = map (f . g) xs
  #-}
 #endif
-#if MIN_VERSION_base(4,8,0)
--- Safe coercions were introduced in 4.7.0, but I am not sure if they played
--- well enough with RULES to do what we want.
+#if __GLASGOW_HASKELL__ >= 709
+-- Safe coercions were introduced in 7.8, but did not work well with RULES yet.
 {-# RULES
 "mapSeq/coerce" map coerce = coerce
  #-}

--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -165,7 +165,7 @@ import Text.Read (Lexeme(Ident), lexP, parens, prec,
     readPrec, readListPrec, readListPrecDefault)
 import Data.Data
 #endif
-#if MIN_VERSION_base(4,8,0)
+#if __GLASGOW_HASKELL__ >= 709
 import Data.Coerce
 #endif
 
@@ -197,9 +197,8 @@ fmapSeq f (Seq xs) = Seq (fmap (fmap f) xs)
 "fmapSeq/fmapSeq" forall f g xs . fmapSeq f (fmapSeq g xs) = fmapSeq (f . g) xs
  #-}
 #endif
-#if MIN_VERSION_base(4,8,0)
--- Safe coercions were introduced in 4.7.0, but I am not sure if they played
--- well enough with RULES to do what we want.
+#if __GLASGOW_HASKELL__ >= 709
+-- Safe coercions were introduced in 7.8, but did not work well with RULES yet.
 {-# RULES
 "fmapSeq/coerce" fmapSeq coerce = coerce
  #-}


### PR DESCRIPTION
Using the library version didn't make much sense, especially since the
tests-ghc tests had to switch on compiler version anyway, but also
because compiling without cabal would prevent the code from being used.
The conditional fake MIN_VERSION_base definition should probably stay up
top where I moved it, though, in case someone needs to use it to adjust
imports or exports in the future--the top seems an inherently better
place for that.
