### PR TITLE
Reorder FingerTree constructors

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -563,9 +563,9 @@ seqDataType = mkDataType "Data.Sequence.Seq" [emptyConstr, consConstr]
 -- Finger trees
 
 data FingerTree a
-    = Empty
+    = Deep {-# UNPACK #-} !Int !(Digit a) (FingerTree (Node a)) !(Digit a)
     | Single a
-    | Deep {-# UNPACK #-} !Int !(Digit a) (FingerTree (Node a)) !(Digit a)
+    | Empty
 #if TESTING
     deriving Show
 #endif


### PR DESCRIPTION
Most particularly, move the `Deep` constructor from the bottom to
the top to speed up indexing.
