### PR TITLE
Add function Set.lookupElem

### DIFF
--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -92,6 +92,7 @@ module Data.Set (
             -- * Indexed
             , lookupIndex
             , findIndex
+            , lookupElem
             , elemAt
             , deleteAt
 

--- a/Data/Set/Base.hs
+++ b/Data/Set/Base.hs
@@ -142,6 +142,7 @@ module Data.Set.Base (
             -- * Indexed
             , lookupIndex
             , findIndex
+            , lookupElem
             , elemAt
             , deleteAt
 
@@ -1160,6 +1161,24 @@ lookupIndex = go 0
 #if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE lookupIndex #-}
 #endif
+
+-- | /O(log n)/. Lookup an element by its /index/, i.e. by its zero-based
+-- index in the sorted sequence of elements.
+--
+-- > fromJust (lookupElem 0 (fromList [5,3])) == 3
+-- > fromJust (lookupElem 1 (fromList [5,3])) == 5
+-- > isJust   (lookupElem 2 (fromList [5,3])) == False
+
+lookupElem :: Int -> Set a -> Maybe a
+STRICT_1_OF_2(lookupElem)
+lookupElem _ Tip = Nothing
+lookupElem i (Bin _ x l r)
+  = case compare i sizeL of
+      LT -> lookupElem i l
+      GT -> lookupElem (i-sizeL-1) r
+      EQ -> Just x
+  where
+    sizeL = size l
 
 -- | /O(log n)/. Retrieve an element by its /index/, i.e. by its zero-based
 -- index in the sorted sequence of elements. If the /index/ is out of range (less

--- a/tests/set-properties.hs
+++ b/tests/set-properties.hs
@@ -18,6 +18,7 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testCase "lookupGE" test_lookupGE
                    , testCase "lookupIndex" test_lookupIndex
                    , testCase "findIndex" test_findIndex
+                   , testCase "lookupElem" test_lookupElem
                    , testCase "elemAt" test_elemAt
                    , testCase "deleteAt" test_deleteAt
                    , testProperty "prop_Valid" prop_Valid
@@ -110,6 +111,12 @@ test_findIndex :: Assertion
 test_findIndex = do
     findIndex 3 (fromList [5,3]) @?= 0
     findIndex 5 (fromList [5,3]) @?= 1
+
+test_lookupElem :: Assertion
+test_lookupElem = do
+    fromJust (lookupElem 0 (fromList [5,3])) @?= 3
+    fromJust (lookupElem 1 (fromList [5,3])) @?= 5
+    isJust   (lookupElem 2 (fromList [5,3])) @?= False
 
 test_elemAt :: Assertion
 test_elemAt = do


### PR DESCRIPTION
This patch adds a new function `lookupElem` to `Data.Set` which performs the same function as `elemAt` but has a return type of `Maybe a`, returning `Nothing` instead of calling `error` if the index is out of range.

I haven't written a corresponding `lookupElem` function for `Data.Map` as I wanted to propose the addition first and gauge feedback on it.
