### PR TITLE
Add traverseWithIndex

### DIFF
--- a/containers.cabal
+++ b/containers.cabal
@@ -216,7 +216,8 @@ Test-suite seq-properties
     build-depends:
         QuickCheck,
         test-framework,
-        test-framework-quickcheck2
+        test-framework-quickcheck2,
+        transformers
 
 test-suite map-strictness-properties
   hs-source-dirs: tests, .


### PR DESCRIPTION
Hack Milan's `mapWithIndex` into `traverseWithIndex`.

Add `default ()` to make sure we never accidentally use defaulting.