### PR TITLE
repair broken URL in IntMap documentation

### DIFF
--- a/Data/IntMap.hs
+++ b/Data/IntMap.hs
@@ -39,7 +39,7 @@
 --
 --    * Chris Okasaki and Andy Gill,  \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <http://citeseer.ist.psu.edu/okasaki98fast.html>
+--      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452>
 --
 --    * D.R. Morrison, \"/PATRICIA -- Practical Algorithm To Retrieve
 --      Information Coded In Alphanumeric/\", Journal of the ACM, 15(4),


### PR DESCRIPTION
the URL in the current version is broken (or paywalled)