### PR TITLE
add Generics instance for Map, Set, IntMap, and IntSet

### DIFF
--- a/Data/IntSet/Base.hs
+++ b/Data/IntSet/Base.hs
@@ -7,6 +7,7 @@
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE EmptyDataDecls #-}
 #endif
 
 #include "containers.h"
@@ -192,6 +193,7 @@ import Text.Read
 import GHC.Exts (Int(..), build)
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
+import GHC.Generics hiding (Prefix, prec, (:*:))
 #endif
 import GHC.Prim (indexInt8OffAddr#)
 #endif
@@ -284,6 +286,31 @@ fromListConstr = mkConstr intSetDataType "fromList" [] Prefix
 intSetDataType :: DataType
 intSetDataType = mkDataType "Data.IntSet.Base.IntSet" [fromListConstr]
 
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
+
+{--------------------------------------------------------------------
+  A Generic instance
+--------------------------------------------------------------------}
+
+type Rep0IntSet = D1 D1IntSet (C1 C1IntSet (S1 NoSelector (Rec0 [Key])))
+
+instance Generic IntSet where
+    type Rep IntSet = Rep0IntSet
+    from s = M1 (M1 (M1 (K1 $ toList s)))
+    to (M1 (M1 (M1 (K1 t)))) = fromList t
+
+data D1IntSet
+data C1IntSet
+
+instance Datatype D1IntSet where
+    datatypeName _ = "IntSet"
+    moduleName   _ = "Data.IntSet.Base"
+
+instance Constructor C1IntSet where
+    conName     _ = "IntSet"
+    conIsRecord _ = False
 #endif
 
 {--------------------------------------------------------------------

--- a/Data/Set/Base.hs
+++ b/Data/Set/Base.hs
@@ -8,6 +8,8 @@
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE EmptyDataDecls #-}
 #endif
 
 #include "containers.h"
@@ -213,6 +215,7 @@ import Data.Utils.StrictPair
 import GHC.Exts ( build )
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
+import GHC.Generics hiding (Prefix, prec, (:*:))
 #endif
 import Text.Read
 import Data.Data
@@ -329,6 +332,29 @@ fromListConstr = mkConstr setDataType "fromList" [] Prefix
 setDataType :: DataType
 setDataType = mkDataType "Data.Set.Base.Set" [fromListConstr]
 
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
+
+{--------------------------------------------------------------------
+  A Generic instance
+--------------------------------------------------------------------}
+data D1Set
+data C1Set
+
+instance Datatype D1Set where
+  datatypeName _ = "Set"
+  moduleName   _ = "Data.Set.Base"
+
+instance Constructor C1Set  where
+  conName _ = "Set.fromList"
+
+type Rep0Set a = D1 D1Set (C1 C1Set (S1 NoSelector (Rec0 [a])))
+
+instance (Eq a, Ord a) => Generic (Set a) where
+  type Rep (Set a) = Rep0Set a
+  from s = M1 (M1 (M1 (K1 $ toList s)))
+  to (M1 (M1 (M1 (K1 l)))) = fromList l
 #endif
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
we want Generics for everything (otherwise we can't derive Generics for any data types which contain these without creating orphan instances)

the end-goal is to have all of these: https://gist.github.com/kuk0/92fff1c91c526ffb0a9e
and be able to derive instances for e.g. TextShow or Text.PrettyPrint.Generic.Pretty
