### PR TITLE
Remove wrong document in {Set, Map}.hs related to key comparison

### DIFF
--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -2436,13 +2436,6 @@ splitLookup k t = k `seq`
     [glue l r]        Glues [l] and [r] together. Assumes that [l] and
                       [r] are already balanced with respect to each other.
     [merge l r]       Merges two trees and restores balance.
-
-  Note: in contrast to Adam's paper, we use (<=) comparisons instead
-  of (<) comparisons in [link], [merge] and [balance].
-  Quickcheck (on [difference]) showed that this was necessary in order
-  to maintain the invariants. It is quite unsatisfactory that I haven't
-  been able to find out why this is actually the case! Fortunately, it
-  doesn't hurt to be a bit more conservative.
 --------------------------------------------------------------------}
 
 {--------------------------------------------------------------------

--- a/Data/Set/Base.hs
+++ b/Data/Set/Base.hs
@@ -1259,13 +1259,6 @@ deleteAt i t = i `seq`
     [glue l r]        Glues [l] and [r] together. Assumes that [l] and
                       [r] are already balanced with respect to each other.
     [merge l r]       Merges two trees and restores balance.
-
-  Note: in contrast to Adam's paper, we use (<=) comparisons instead
-  of (<) comparisons in [link], [merge] and [balance].
-  Quickcheck (on [difference]) showed that this was necessary in order
-  to maintain the invariants. It is quite unsatisfactory that I haven't
-  been able to find out why this is actually the case! Fortunately, it
-  doesn't hurt to be a bit more conservative.
 --------------------------------------------------------------------}
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
As we no longer use (<=) comparison but use (<) comparison instead since [this commit](https://github.com/haskell/containers/commit/4193a09336772748bdec0cdab5da4257d224c814),
the document is not correct to explain the current implementation.

There's one thing I'm not quite sure of. Anybody agrees that I could remove the following sentence as well?
```
Quickcheck (on [difference]) showed that this was necessary in order
to maintain the invariants. It is quite unsatisfactory that I haven't
been able to find out why this is actually the case! Fortunately, it
doesn't hurt to be a bit more conservative.
```

This is bothering me as
  1. the doc might have referred to the problem which was [fixed later](https://github.com/haskell/containers/commit/5f2e1f8e4e6966ac41066d04624991ae81a7eb55) with regard to [4242](https://ghc.haskell.org/trac/ghc/ticket/4242). Thus no problem at all to remove it.
  2. the doc might be saying another thing so we shouldn't have [changed (<=) into (<)](https://github.com/haskell/containers/commit/4193a09336772748bdec0cdab5da4257d224c814).

Honestly, I don't get what the doc is mentioning. It absolutely comes from the [first commit of Map.hs](https://github.com/haskell/containers/commit/bbbba97cbcf12039810533e3a2daf2eefdefe7f0) and might be added when people ported DData by Daan Leijen (the original author of DData).
(I ended up failing to specify `who added the doc` and `why somebody cared about the problem` after reading mailing list [Jan 2005](https://mail.haskell.org/pipermail/libraries/2005-January/002894.html))

Based on the thorough investigation by Kazu Yamamoto, Yoichi Hirai and Milan Straka[1, 2, 3], I think there shouldn't be any problems with the current implementation. So the doc is no longer meaningful to us. But just to make sure...

@foxik 
What do you think? Let me ping you as you're quite familiar with this matter I suppose :)

[1] Discussion on Mailing List [Sep 2010 by Yamamoto](https://mail.haskell.org/pipermail/libraries/2010-September/014254.html) [Sep 2010 by Straka](https://mail.haskell.org/pipermail/libraries/2010-September/014343.html) 
[2] [Balancing weight-balanced trees](https://yoichihirai.com/bst.pdf)
[3] [Adams' Trees Revisited - Correct and Efficient Implementation](http://fox.ucw.cz/papers/bbtree/)