### PR TITLE
Add `at` for Data.Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ GNUmakefile
 dist-install
 ghc.mk
 .stack-work
+/benchmarks/bench-Map
+/benchmarks/bench-Set
+/benchmarks/bench-IntSet
+/benchmarks/bench-IntMap
+/benchmarks/bench-Sequence

--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -137,6 +137,7 @@ module Data.Map.Base (
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , at
 
     -- * Combine
 
@@ -930,6 +931,27 @@ alter = go
 {-# INLINABLE alter #-}
 #else
 {-# INLINE alter #-}
+#endif
+
+at :: (Functor f, Ord k) =>
+      k -> (Maybe a -> f (Maybe a)) -> Map k a -> f (Map k a)
+at = go
+  where
+    STRICT_1_OF_3(go)
+    go k f Tip = (`fmap` f Nothing) $ \ mx -> case mx of
+               Nothing -> Tip
+               Just x  -> singleton k x
+
+    go k f (Bin sx kx x l r) = case compare k kx of
+               LT -> (\ m -> balance kx x m r) `fmap` go k f l
+               GT -> (\ m -> balance kx x l m) `fmap` go k f r
+               EQ -> (`fmap` f (Just x)) $ \ mx' -> case mx' of
+                       Just x' -> Bin sx kx x' l r
+                       Nothing -> glue l r
+#if __GLASGOW_HASKELL__ >= 700
+{-# INLINABLE at #-}
+#else
+{-# INLINE at #-}
 #endif
 
 {--------------------------------------------------------------------

--- a/Data/Map/Base.hs
+++ b/Data/Map/Base.hs
@@ -9,9 +9,19 @@
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
+#define USE_MAGIC_PROXY 1
+#endif
+
+#if USE_MAGIC_PROXY
+{-# LANGUAGE MagicHash #-}
 #endif
 
 #include "containers.h"
+
+#if !(WORD_SIZE_IN_BITS >= 61)
+#define DEFINE_ALTERF_FALLBACK 1
+#endif
+
 
 -----------------------------------------------------------------------------
 -- |
@@ -137,7 +147,7 @@ module Data.Map.Base (
     , updateWithKey
     , updateLookupWithKey
     , alter
-    , at
+    , alterF
 
     -- * Combine
 
@@ -255,14 +265,23 @@ module Data.Map.Base (
     , valid
 
     -- Used by the strict version
+#if DEFINE_ALTERF_FALLBACK
+    , alterFYoneda
+    , alterFCutoff
+#endif
     , bin
     , balance
     , balanced
     , balanceL
     , balanceR
     , delta
-    , link
     , insertMax
+    , link
+    , lookupTrace
+    , insertAlong
+    , deleteAlong
+    , replaceAlong
+    , TraceResult (..)
     , merge
     , glue
     , trim
@@ -280,7 +299,7 @@ import Data.Traversable (Traversable(traverse))
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
 #endif
-
+import Control.Applicative (Const (..))
 import Control.DeepSeq (NFData(rnf))
 import Data.Bits (shiftL, shiftR)
 import qualified Data.Foldable as Foldable
@@ -290,9 +309,16 @@ import Prelude hiding (lookup, map, filter, foldr, foldl, null)
 import qualified Data.Set.Base as Set
 import Data.Utils.StrictFold
 import Data.Utils.StrictPair
+import Data.Utils.BitQueue
+#if DEFINE_ALTERF_FALLBACK
+import Data.Utils.BitUtil (wordSize)
+#endif
 
 #if __GLASGOW_HASKELL__
-import GHC.Exts ( build )
+import GHC.Exts (build)
+#if USE_MAGIC_PROXY
+import GHC.Exts (Proxy#, proxy# )
+#endif
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
 #endif
@@ -933,25 +959,189 @@ alter = go
 {-# INLINE alter #-}
 #endif
 
-at :: (Functor f, Ord k) =>
-      k -> (Maybe a -> f (Maybe a)) -> Map k a -> f (Map k a)
-at = go
-  where
-    STRICT_1_OF_3(go)
-    go k f Tip = (`fmap` f Nothing) $ \ mx -> case mx of
-               Nothing -> Tip
-               Just x  -> singleton k x
+-- | /O(log n)/. The expression (@'alterF' f k map@) alters the value @x@ at @k@, or absence thereof.
+-- 'alterF' can be used to inspect, insert, delete, or update a value in a 'Map'.
+-- In short : @'lookup' k <$> 'alterF' f k m = f ('lookup' k m)@.
+--
+-- Example:
+-- @
+-- interactiveAlter :: Int -> Map Int String -> IO (Map Int String)
+-- interactiveAlter k m = alterF f k m where
+--   f Nothing -> do
+--      putStrLn $ show k ++
+--          " was not found in the map. Would you like to add it?"
+--      getUserResponse1 :: IO (Maybe String)
+--   f (Just old) -> do
+--      putStrLn "The key is currently bound to " ++ show old ++
+--          ". Would you like to change or delete it?"
+--      getUserresponse2 :: IO (Maybe String)
+-- @
+--
+-- 'alterF' is the most general operation for working with an individual
+-- key that may or may not be in a given map. When used with trivial
+-- functors like 'Identity' and 'Const', it is often slightly slower than
+-- more specialized combinators like 'lookup' and 'insert'. However, when
+-- the functor is non-trivial and key comparison is not particularly cheap,
+-- it is the fastest way.
+--
+-- Note: 'alterF' is a flipped version of the 'at' combinator from
+-- 'Control.Lens.At'.
+alterF :: (Functor f, Ord k) =>
+      (Maybe a -> f (Maybe a)) -> k -> Map k a -> f (Map k a)
+#if DEFINE_ALTERF_FALLBACK
+alterF f !k m
+-- It doesn't seem sensible to worry about overflowing the queue
+-- if the word size is 61 or more. If I calculate it correctly,
+-- that would take a map with nearly a quadrillion entries.
+  | wordSize < 61 && size m >= alterFCutoff = alterFFallback f k m
+#endif
+alterF f !k m = case lookupTrace k m of
+  TraceResult mv q -> (<$> f mv) $ \ fres ->
+    case fres of
+      Nothing -> case mv of
+                   Nothing -> m
+                   Just old -> deleteAlong old q m
+      Just new -> case mv of
+                   Nothing -> insertAlong q k new m
+                   Just _ -> replaceAlong q new m
 
-    go k f (Bin sx kx x l r) = case compare k kx of
-               LT -> (\ m -> balance kx x m r) `fmap` go k f l
-               GT -> (\ m -> balance kx x l m) `fmap` go k f r
-               EQ -> (`fmap` f (Just x)) $ \ mx' -> case mx' of
-                       Just x' -> Bin sx kx x' l r
-                       Nothing -> glue l r
-#if __GLASGOW_HASKELL__ >= 700
-{-# INLINABLE at #-}
+#ifndef __GLASGOW_HASKELL__
+{-# INLINE alterF #-}
 #else
-{-# INLINE at #-}
+{-# INLINABLE [2] alterF #-}
+-- We can save precious time by recognizing the special case of
+-- `Control.Applicative.Const` and just doing a lookup.
+{-# RULES
+"alterF/Const" forall (f :: Maybe a -> Const b (Maybe a)) . alterF f = \k m -> Const . getConst . f $ lookup k m
+ #-}
+#endif
+
+#if DEFINE_ALTERF_FALLBACK
+alterFCutoff :: Int
+#if WORD_SIZE_IN_BITS == 32
+alterFCutoff = 55744454
+#else
+alterFCutoff = case wordSize of
+      30 -> 17637893
+      31 -> 31356255
+      32 -> 55744454
+      x -> (4^(x*2-2)) `quot` (3^(x*2-2))  -- Unlikely
+#endif
+#endif
+
+data TraceResult a = TraceResult (Maybe a) {-# UNPACK #-} !BitQueue
+
+-- Look up a key and return a result indicating whether it was found
+-- and what path was taken.
+lookupTrace :: Ord k => k -> Map k a -> TraceResult a
+lookupTrace = go emptyQB
+  where
+    go :: Ord k => BitQueueB -> k -> Map k a -> TraceResult a
+    go !q !_ Tip = TraceResult Nothing (buildQ q)
+    go q k (Bin _ kx x l r) = case compare k kx of
+      LT -> (go $! q `snocQB` False) k l
+      GT -> (go $! q `snocQB` True) k r
+      EQ -> TraceResult (Just x) (buildQ q)
+
+-- GHC 7.8 doesn't manage to unbox the queue properly
+-- unless we explicitly inline this function. This stuff
+-- is a bit touchy, unfortunately.
+#if __GLASGOW_HASKELL__ >= 710
+{-# INLINABLE lookupTrace #-}
+#else
+{-# INLINE lookupTrace #-}
+#endif
+
+-- Insert at a location (which will always be a leaf)
+-- described by the path passed in.
+insertAlong :: BitQueue -> k -> a -> Map k a -> Map k a
+insertAlong !_ kx x Tip = singleton kx x
+insertAlong q kx x (Bin sz ky y l r) =
+  case unconsQ q of
+        Just (False, tl) -> balanceL ky y (insertAlong tl kx x l) r
+        Just (True,tl) -> balanceR ky y l (insertAlong tl kx x r)
+        Nothing -> Bin sz kx x l r  -- Shouldn't happen
+
+-- Delete from a location (which will always be a node)
+-- described by the path passed in.
+--
+-- This is fairly horrifying! We don't actually have any
+-- use for the old value we're deleting. But if GHC sees
+-- that, then it will allocate a thunk representing the
+-- Map with the key deleted before we have any reason to
+-- believe we'll actually want that. This transformation
+-- enhances sharing, but we don't care enough about that.
+-- So deleteAlong needs to take the old value, and we need
+-- to convince GHC somehow that it actually uses it. We
+-- can't NOINLINE deleteAlong, because that would prevent
+-- the BitQueue from being unboxed. So instead we pass the
+-- old value to a NOINLINE constant function and then
+-- convince GHC that we use the result throughout the
+-- computation. Doing the obvious thing and just passing
+-- the value itself through the recursion costs 3-4% time,
+-- so instead we convert the value to a magical zero-width
+-- proxy that's ultimately erased.
+deleteAlong :: any -> BitQueue -> Map k a -> Map k a
+deleteAlong old !q0 !m = go (bogus old) q0 m where
+#if USE_MAGIC_PROXY
+  go :: Proxy# () -> BitQueue -> Map k a -> Map k a
+#else
+  go :: any -> BitQueue -> Map k a -> Map k a
+#endif
+  go !_ !_ Tip = Tip
+  go foom q (Bin _ ky y l r) =
+      case unconsQ q of
+        Just (False, tl) -> balanceR ky y (go foom tl l) r
+        Just (True, tl) -> balanceL ky y l (go foom tl r)
+        Nothing -> glue l r
+
+#if USE_MAGIC_PROXY
+{-# NOINLINE bogus #-}
+bogus :: a -> Proxy# ()
+bogus _ = proxy#
+#else
+-- No point hiding in this case.
+{-# INLINE bogus #-}
+bogus :: a -> a
+bogus a = a
+#endif
+
+-- Replace the value found in the node described
+-- by the given path with a new one.
+replaceAlong :: BitQueue -> a -> Map k a -> Map k a
+replaceAlong !_ _ Tip = Tip -- Should not happen
+replaceAlong q  x (Bin sz ky y l r) =
+      case unconsQ q of
+        Just (False, tl) -> Bin sz ky y (replaceAlong tl x l) r
+        Just (True,tl) -> Bin sz ky y l (replaceAlong tl x r)
+        Nothing -> Bin sz ky x l r
+
+#if DEFINE_ALTERF_FALLBACK
+-- When the map is too large to use a bit queue, we fall back to
+-- this much slower version which uses a more "natural" implementation
+-- improved with Yoneda to avoid repeated fmaps. This works okayish for
+-- some operations, but it's pretty lousy for lookups.
+alterFFallback :: (Functor f, Ord k)
+   => (Maybe a -> f (Maybe a)) -> k -> Map k a -> f (Map k a)
+alterFFallback f k t = alterFYoneda (\m q -> q <$> f m) k t id
+{-# NOINLINE alterFFallback #-}
+
+alterFYoneda :: Ord k =>
+      (Maybe a -> (Maybe a -> b) -> f b) -> k -> Map k a -> (Map k a -> b) -> f b
+alterFYoneda = go
+  where
+    go :: Ord k =>
+      (Maybe a -> (Maybe a -> b) -> f b) -> k -> Map k a -> (Map k a -> b) -> f b
+    go f !k Tip g = f Nothing $ \ mx -> case mx of
+      Nothing -> g Tip
+      Just x -> g (singleton k x)
+    go f k (Bin sx kx x l r) g = case compare k kx of
+               LT -> go f k l (\m -> g (balance kx x m r))
+               GT -> go f k r (\m -> g (balance kx x l m))
+               EQ -> f (Just x) $ \ mx' -> case mx' of
+                       Just x' -> g (Bin sx kx x' l r)
+                       Nothing -> g (glue l r)
+{-# INLINE alterFYoneda #-}
 #endif
 
 {--------------------------------------------------------------------

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -96,7 +96,7 @@ module Data.Map.Lazy (
     , updateWithKey
     , updateLookupWithKey
     , alter
-    , at
+    , alterF
 
     -- * Combine
 

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -96,6 +96,7 @@ module Data.Map.Lazy (
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , at
 
     -- * Combine
 

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -104,6 +104,7 @@ module Data.Map.Strict
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , at
 
     -- * Combine
 

--- a/Data/Utils/BitQueue.hs
+++ b/Data/Utils/BitQueue.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+
+#include "containers.h"
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Utils.BitQueue
+-- Copyright   :  (c) David Feuer 2016
+-- License     :  BSD-style
+-- Maintainer  :  libraries@haskell.org
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- An extremely light-weight, fast, and limited representation of a string of
+-- up to (2*WORDSIZE - 2) bits. In fact, there are two representations,
+-- misleadingly named bit queue builder and bit queue. The builder supports
+-- only `emptyQB`, creating an empty builder, and `snocQB`, enqueueing a bit.
+-- The bit queue builder is then turned into a bit queue using `buildQ`, after
+-- which bits can be removed one by one using `unconsQ`. If the size limit is
+-- exceeded, further operations will silently produce nonsense.
+-----------------------------------------------------------------------------
+
+module Data.Utils.BitQueue
+    ( BitQueue
+    , BitQueueB
+    , emptyQB
+    , snocQB
+    , buildQ
+    , unconsQ
+    , toListQ
+    ) where
+
+import Data.Word (Word)
+import Data.Utils.BitUtil (shiftLL, shiftRL, wordSize)
+import Data.Bits ((.|.), (.&.), testBit)
+#if MIN_VERSION_base(4,8,0)
+import Data.Bits (countTrailingZeros)
+#elif MIN_VERSION_base(4,5,0)
+import Data.Bits (popCount)
+#endif
+
+#if !MIN_VERSION_base(4,5,0)
+-- We could almost certainly improve this fall-back (copied straight from the
+-- default definition in Data.Bits), but it hardly seems worth the trouble
+-- to speed things up on GHC 7.4 and below.
+countTrailingZeros :: Word -> Int
+countTrailingZeros x = go 0
+      where
+        go i | i >= wordSize      = i
+             | testBit x i = i
+             | otherwise   = go (i+1)
+
+#elif !MIN_VERSION_base(4,8,0)
+countTrailingZeros :: Word -> Int
+countTrailingZeros x = popCount ((x .&. (-x)) - 1)
+{-# INLINE countTrailingZeros #-}
+#endif
+
+-- A bit queue builder. We represent a double word using two words
+-- because we don't currently have access to proper double words.
+data BitQueueB = BQB {-# UNPACK #-} !Word
+                     {-# UNPACK #-} !Word
+
+newtype BitQueue = BQ BitQueueB deriving Show
+
+-- Intended for debugging.
+instance Show BitQueueB where
+  show (BQB hi lo) = "BQ"++
+    show (map (testBit hi) [(wordSize - 1),(wordSize - 1)..0]
+            ++ map (testBit lo) [(wordSize - 1),(wordSize - 2)..0])
+
+-- | Create an empty bit queue builder. This is represented as a single guard
+-- bit in the most significant position.
+emptyQB :: BitQueueB
+emptyQB = BQB (1 `shiftLL` (wordSize - 1)) 0
+{-# INLINE emptyQB #-}
+
+-- Shift the double word to the right by one bit.
+shiftQBR1 :: BitQueueB -> BitQueueB
+shiftQBR1 (BQB hi lo) = BQB hi' lo' where
+  lo' = (lo `shiftRL` 1) .|. (hi `shiftLL` (wordSize - 1))
+  hi' = hi `shiftRL` 1
+{-# INLINE shiftQBR1 #-}
+
+-- | Enqueue a bit. This works by shifting the queue right one bit,
+-- then setting the most significant bit as requested.
+{-# INLINE snocQB #-}
+snocQB :: BitQueueB -> Bool -> BitQueueB
+snocQB bq b = case shiftQBR1 bq of
+  BQB hi lo -> BQB (hi .|. (fromIntegral (fromEnum b) `shiftLL` (wordSize - 1))) lo
+
+-- | Convert a bit queue builder to a bit queue. This shifts in a new
+-- guard bit on the left, and shifts right until the old guard bit falls
+-- off.
+{-# INLINE buildQ #-}
+buildQ :: BitQueueB -> BitQueue
+buildQ (BQB hi 0) = BQ (BQB 0 lo') where
+  zeros = countTrailingZeros hi
+  lo' = ((hi `shiftRL` 1) .|. (1 `shiftLL` (wordSize - 1))) `shiftRL` zeros
+buildQ (BQB hi lo) = BQ (BQB hi' lo') where
+  zeros = countTrailingZeros lo
+  lo1 = (lo `shiftRL` 1) .|. (hi `shiftLL` (wordSize - 1))
+  hi1 = (hi `shiftRL` 1) .|. (1 `shiftLL` (wordSize - 1))
+  lo' = (lo1 `shiftRL` zeros) .|. (hi1 `shiftLL` (wordSize - zeros))
+  hi' = hi1 `shiftRL` zeros
+
+-- Test if the queue is empty, which occurs when theres
+-- nothing left but a guard bit in the least significant
+-- place.
+nullQ :: BitQueue -> Bool
+nullQ (BQ (BQB 0 1)) = True
+nullQ _ = False
+{-# INLINE nullQ #-}
+
+-- | Dequeue an element, or discover the queue is empty.
+unconsQ :: BitQueue -> Maybe (Bool, BitQueue)
+unconsQ q | nullQ q = Nothing
+unconsQ (BQ bq@(BQB _ lo)) = Just (hd, BQ tl)
+  where
+    !hd = (lo .&. 1) /= 0
+    !tl = shiftQBR1 bq
+{-# INLINE unconsQ #-}
+
+-- | Convert a bit queue to a list of bits by unconsing.
+-- This is used to test that the queue functions properly.
+toListQ :: BitQueue -> [Bool]
+toListQ bq = case unconsQ bq of
+      Nothing -> []
+      Just (hd, tl) -> hd : toListQ tl

--- a/Data/Utils/BitUtil.hs
+++ b/Data/Utils/BitUtil.hs
@@ -23,9 +23,16 @@ module Data.Utils.BitUtil
     ( highestBitMask
     , shiftLL
     , shiftRL
+    , wordSize
     ) where
 
 import Data.Bits ((.|.), xor)
+#if MIN_VERSION_base(4,7,0)
+import Data.Bits (finiteBitSize)
+#else
+import Data.Bits (bitSize)
+#endif
+
 
 #if __GLASGOW_HASKELL__
 import GHC.Exts (Word(..), Int(..))
@@ -61,9 +68,19 @@ shiftRL, shiftLL :: Word -> Int -> Word
 --------------------------------------------------------------------}
 shiftRL (W# x) (I# i) = W# (uncheckedShiftRL# x i)
 shiftLL (W# x) (I# i) = W# (uncheckedShiftL#  x i)
+{-# INLINE CONLIKE shiftRL #-}
+{-# INLINE CONLIKE shiftLL #-}
 #else
 shiftRL x i   = shiftR x i
 shiftLL x i   = shiftL x i
-#endif
 {-# INLINE shiftRL #-}
 {-# INLINE shiftLL #-}
+#endif
+
+{-# INLINE wordSize #-}
+wordSize :: Int
+#if MIN_VERSION_base(4,7,0)
+wordSize = finiteBitSize (0 :: Word)
+#else
+wordSize = bitSize (0 :: Word)
+#endif

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -22,8 +22,14 @@ main = do
         , bench "lookup present" $ whnf (lookup evens) m_even
         , bench "at lookup absent" $ whnf (atLookup evens) m_odd
         , bench "at lookup present" $ whnf (atLookup evens) m_even
+        , bench "atLens lookup absent" $ whnf (atLensLookup evens) m_odd
+        , bench "atLens lookup present" $ whnf (atLensLookup evens) m_even
         , bench "insert absent" $ whnf (ins elems_even) m_odd
         , bench "insert present" $ whnf (ins elems_even) m_even
+        , bench "at insert absent" $ whnf (atIns elems_even) m_odd
+        , bench "at insert present" $ whnf (atIns elems_even) m_even
+        , bench "atLens insert absent" $ whnf (atLensIns elems_even) m_odd
+        , bench "atLens insert present" $ whnf (atLensIns elems_even) m_even
         , bench "insertWith absent" $ whnf (insWith elems_even) m_odd
         , bench "insertWith present" $ whnf (insWith elems_even) m_even
         , bench "insertWith' absent" $ whnf (insWith' elems_even) m_odd
@@ -57,6 +63,10 @@ main = do
         , bench "at alter insert" $ whnf (atAlt (const (Just 1)) evens) m_odd
         , bench "at alter update" $ whnf (atAlt id evens) m_even
         , bench "at alter delete" $ whnf (atAlt (const Nothing) evens) m
+        , bench "atLens alter absent" $ whnf (atLensAlt id evens) m_odd
+        , bench "atLens alter insert" $ whnf (atLensAlt (const (Just 1)) evens) m_odd
+        , bench "atLens alter update" $ whnf (atLensAlt id evens) m_even
+        , bench "atLens alter delete" $ whnf (atLensAlt (const Nothing) evens) m
         , bench "mapMaybe" $ whnf (M.mapMaybe maybeDel) m
         , bench "mapMaybeWithKey" $ whnf (M.mapMaybeWithKey (const maybeDel)) m
         , bench "lookupIndex" $ whnf (lookupIndex keys) m
@@ -91,11 +101,20 @@ lookup xs m = foldl' (\n k -> fromMaybe n (M.lookup k m)) 0 xs
 atLookup :: [Int] -> M.Map Int Int -> Int
 atLookup xs m = foldl' (\n k -> fromMaybe n (getConst (M.at k Const m))) 0 xs
 
+atLensLookup :: [Int] -> M.Map Int Int -> Int
+atLensLookup xs m = foldl' (\n k -> fromMaybe n (getConst (atLens k Const m))) 0 xs
+
 lookupIndex :: [Int] -> M.Map Int Int -> Int
 lookupIndex xs m = foldl' (\n k -> fromMaybe n (M.lookupIndex k m)) 0 xs
 
 ins :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
 ins xs m = foldl' (\m (k, v) -> M.insert k v m) m xs
+
+atIns :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
+atIns xs m = foldl' (\m (k, v) -> runIdentity (M.at k (\_ -> pure (Just v)) m)) m xs
+
+atLensIns :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
+atLensIns xs m = foldl' (\m (k, v) -> runIdentity (atLens k (\_ -> pure (Just v)) m)) m xs
 
 insWith :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
 insWith xs m = foldl' (\m (k, v) -> M.insertWith (+) k v m) m xs
@@ -137,6 +156,22 @@ alt f xs m = foldl' (\m k -> M.alter f k m) m xs
 
 atAlt :: (Maybe Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
 atAlt f xs m = foldl' (\m k -> runIdentity (M.at k (pure . f) m)) m xs
+
+atLensAlt :: (Maybe Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
+atLensAlt f xs m = foldl' (\m k -> runIdentity (atLens k (pure . f) m)) m xs
+
+-- implementation from Control.Lens.At for comparison
+atLens :: (Functor f, Ord k) =>
+          k -> (Maybe a -> f (Maybe a)) -> M.Map k a -> f (M.Map k a)
+atLens k f m = (`fmap` f mx) $ \ mx' ->
+  case mx' of
+    Just x' -> M.insert k x' m
+    Nothing ->
+      case mx of
+        Nothing -> m
+        Just x  -> M.delete k m
+  where mx = M.lookup k m
+{-# INLINE atLens #-}
 
 maybeDel :: Int -> Maybe Int
 maybeDel n | n `mod` 3 == 0 = Nothing

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -4,7 +4,7 @@ module Main where
 import Control.Applicative (Const(Const, getConst), pure)
 import Control.DeepSeq
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.IO.Class (liftIO)
 import Criterion.Main
 import Data.Functor.Identity (Identity(runIdentity))
 import Data.List (foldl')
@@ -30,6 +30,24 @@ main = do
         , bench "at insert present" $ whnf (atIns elems_even) m_even
         , bench "atLens insert absent" $ whnf (atLensIns elems_even) m_odd
         , bench "atLens insert present" $ whnf (atLensIns elems_even) m_even
+        , bench "delete absent" $ whnf (del evens) m_odd
+        , bench "delete present" $ whnf (del evens) m
+        , bench "at delete absent" $ whnf (atDel evens) m_odd
+        , bench "at delete present" $ whnf (atDel evens) m
+        , bench "atLens delete absent" $ whnf (atLensDel evens) m_odd
+        , bench "atLens delete present" $ whnf (atLensDel evens) m
+        , bench "alter absent"  $ whnf (alt id evens) m_odd
+        , bench "alter insert"  $ whnf (alt (const (Just 1)) evens) m_odd
+        , bench "alter update"  $ whnf (alt id evens) m_even
+        , bench "alter delete"  $ whnf (alt (const Nothing) evens) m
+        , bench "at alter absent" $ whnf (atAlt id evens) m_odd
+        , bench "at alter insert" $ whnf (atAlt (const (Just 1)) evens) m_odd
+        , bench "at alter update" $ whnf (atAlt id evens) m_even
+        , bench "at alter delete" $ whnf (atAlt (const Nothing) evens) m
+        , bench "atLens alter absent" $ whnf (atLensAlt id evens) m_odd
+        , bench "atLens alter insert" $ whnf (atLensAlt (const (Just 1)) evens) m_odd
+        , bench "atLens alter update" $ whnf (atLensAlt id evens) m_even
+        , bench "atLens alter delete" $ whnf (atLensAlt (const Nothing) evens) m
         , bench "insertWith absent" $ whnf (insWith elems_even) m_odd
         , bench "insertWith present" $ whnf (insWith elems_even) m_even
         , bench "insertWith' absent" $ whnf (insWith' elems_even) m_odd
@@ -47,26 +65,12 @@ main = do
         , bench "foldlWithKey" $ whnf (ins elems) m
 --         , bench "foldlWithKey'" $ whnf (M.foldlWithKey' sum 0) m
         , bench "foldrWithKey" $ whnf (M.foldrWithKey consPair []) m
-        , bench "delete absent" $ whnf (del evens) m_odd
-        , bench "delete present" $ whnf (del evens) m
         , bench "update absent" $ whnf (upd Just evens) m_odd
         , bench "update present" $ whnf (upd Just evens) m_even
         , bench "update delete" $ whnf (upd (const Nothing) evens) m
         , bench "updateLookupWithKey absent" $ whnf (upd' Just evens) m_odd
         , bench "updateLookupWithKey present" $ whnf (upd' Just evens) m_even
         , bench "updateLookupWithKey delete" $ whnf (upd' (const Nothing) evens) m
-        , bench "alter absent"  $ whnf (alt id evens) m_odd
-        , bench "alter insert"  $ whnf (alt (const (Just 1)) evens) m_odd
-        , bench "alter update"  $ whnf (alt id evens) m_even
-        , bench "alter delete"  $ whnf (alt (const Nothing) evens) m
-        , bench "at alter absent" $ whnf (atAlt id evens) m_odd
-        , bench "at alter insert" $ whnf (atAlt (const (Just 1)) evens) m_odd
-        , bench "at alter update" $ whnf (atAlt id evens) m_even
-        , bench "at alter delete" $ whnf (atAlt (const Nothing) evens) m
-        , bench "atLens alter absent" $ whnf (atLensAlt id evens) m_odd
-        , bench "atLens alter insert" $ whnf (atLensAlt (const (Just 1)) evens) m_odd
-        , bench "atLens alter update" $ whnf (atLensAlt id evens) m_even
-        , bench "atLens alter delete" $ whnf (atLensAlt (const Nothing) evens) m
         , bench "mapMaybe" $ whnf (M.mapMaybe maybeDel) m
         , bench "mapMaybeWithKey" $ whnf (M.mapMaybeWithKey (const maybeDel)) m
         , bench "lookupIndex" $ whnf (lookupIndex keys) m
@@ -91,6 +95,9 @@ main = do
     sum k v1 v2 = k + v1 + v2
     consPair k v xs = (k, v) : xs
 
+at :: (Functor f, Ord k) => k -> (Maybe a -> f (Maybe a)) -> M.Map k a -> f (M.Map k a)
+at = flip M.alterF
+
 add3 :: Int -> Int -> Int -> Int
 add3 x y z = x + y + z
 {-# INLINE add3 #-}
@@ -99,7 +106,7 @@ lookup :: [Int] -> M.Map Int Int -> Int
 lookup xs m = foldl' (\n k -> fromMaybe n (M.lookup k m)) 0 xs
 
 atLookup :: [Int] -> M.Map Int Int -> Int
-atLookup xs m = foldl' (\n k -> fromMaybe n (getConst (M.at k Const m))) 0 xs
+atLookup xs m = foldl' (\n k -> fromMaybe n (getConst (at k Const m))) 0 xs
 
 atLensLookup :: [Int] -> M.Map Int Int -> Int
 atLensLookup xs m = foldl' (\n k -> fromMaybe n (getConst (atLens k Const m))) 0 xs
@@ -111,7 +118,7 @@ ins :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
 ins xs m = foldl' (\m (k, v) -> M.insert k v m) m xs
 
 atIns :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
-atIns xs m = foldl' (\m (k, v) -> runIdentity (M.at k (\_ -> pure (Just v)) m)) m xs
+atIns xs m = foldl' (\m (k, v) -> runIdentity (at k (\_ -> pure (Just v)) m)) m xs
 
 atLensIns :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
 atLensIns xs m = foldl' (\m (k, v) -> runIdentity (atLens k (\_ -> pure (Just v)) m)) m xs
@@ -145,6 +152,12 @@ insLookupWithKey' xs m = let !(PS a b) = foldl' f (PS 0 m) xs in (a, b)
 del :: [Int] -> M.Map Int Int -> M.Map Int Int
 del xs m = foldl' (\m k -> M.delete k m) m xs
 
+atDel :: [Int] -> M.Map Int Int -> M.Map Int Int
+atDel xs m = foldl' (\m k -> runIdentity (at k (\_ -> pure Nothing) m)) m xs
+
+atLensDel :: [Int] -> M.Map Int Int -> M.Map Int Int
+atLensDel xs m = foldl' (\m k -> runIdentity (atLens k (\_ -> pure Nothing) m)) m xs
+
 upd :: (Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
 upd f xs m = foldl' (\m k -> M.update f k m) m xs
 
@@ -155,7 +168,7 @@ alt :: (Maybe Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
 alt f xs m = foldl' (\m k -> M.alter f k m) m xs
 
 atAlt :: (Maybe Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
-atAlt f xs m = foldl' (\m k -> runIdentity (M.at k (pure . f) m)) m xs
+atAlt f xs m = foldl' (\m k -> runIdentity (at k (pure . f) m)) m xs
 
 atLensAlt :: (Maybe Int -> Maybe Int) -> [Int] -> M.Map Int Int -> M.Map Int Int
 atLensAlt f xs m = foldl' (\m k -> runIdentity (atLens k (pure . f) m)) m xs

--- a/containers.cabal
+++ b/containers.cabal
@@ -55,6 +55,7 @@ Library
         Data.IntSet.Base
         Data.Map.Base
         Data.Set.Base
+        Data.Utils.BitQueue
         Data.Utils.BitUtil
         Data.Utils.StrictFold
         Data.Utils.StrictPair
@@ -103,6 +104,26 @@ Test-suite map-strict-properties
     ghc-options: -O2
     include-dirs: include
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
+
+    build-depends:
+        -- only needed for base < 4.8 to get Identity
+        transformers,
+        HUnit,
+        QuickCheck,
+        test-framework,
+        test-framework-hunit,
+        test-framework-quickcheck2
+
+Test-suite bitqueue-properties
+    hs-source-dirs: tests, .
+    main-is: bitqueue-properties.hs
+    type: exitcode-stdio-1.0
+    cpp-options: -DTESTING
+
+    build-depends: base >= 4.3 && < 5, array, ghc-prim
+    ghc-options: -O2
+    include-dirs: include
+--    extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
     build-depends:
         -- only needed for base < 4.8 to get Identity

--- a/containers.cabal
+++ b/containers.cabal
@@ -85,6 +85,8 @@ Test-suite map-lazy-properties
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
     build-depends:
+        -- only needed for base < 4.8 to get Identity
+        transformers,
         HUnit,
         QuickCheck,
         test-framework,
@@ -103,6 +105,8 @@ Test-suite map-strict-properties
     extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
     build-depends:
+        -- only needed for base < 4.8 to get Identity
+        transformers,
         HUnit,
         QuickCheck,
         test-framework,

--- a/tests/bitqueue-properties.hs
+++ b/tests/bitqueue-properties.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+
+import Control.Applicative (Const(Const, getConst), pure, (<$>))
+import qualified Data.List as List
+import Test.Framework
+import Test.Framework.Providers.HUnit
+import Test.Framework.Providers.QuickCheck2
+import Test.HUnit hiding (Test, Testable)
+import Test.QuickCheck
+import Test.QuickCheck.Gen
+import Text.Show.Functions ()
+import Data.Utils.BitQueue
+    ( BitQueue
+    , emptyQB
+    , snocQB
+    , buildQ
+    , unconsQ
+    , toListQ )
+
+default (Int)
+
+main :: IO ()
+main = defaultMain $ map testNum [0..126]
+
+testNum :: Int -> Test
+testNum n = testProperty ("Size "++show n) (prop_n n)
+
+prop_n :: Int -> Gen Bool
+prop_n n = checkList <$> vectorOf n (arbitrary :: Gen Bool)
+  where
+    checkList :: [Bool] -> Bool
+    checkList values = toListQ q == values
+      where
+        !q = buildQ $ List.foldl' snocQB emptyQB values

--- a/tests/map-properties.hs
+++ b/tests/map-properties.hs
@@ -6,6 +6,8 @@ import Data.Map.Strict as Data.Map
 import Data.Map.Lazy as Data.Map
 #endif
 
+import Control.Applicative (Const(Const, getConst), pure)
+import Data.Functor.Identity (Identity(runIdentity))
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
@@ -54,6 +56,7 @@ main = defaultMain
          , testCase "updateWithKey" test_updateWithKey
          , testCase "updateLookupWithKey" test_updateLookupWithKey
          , testCase "alter" test_alter
+         , testCase "at" test_at
          , testCase "union" test_union
          , testCase "mappend" test_mappend
          , testCase "unionWith" test_unionWith
@@ -404,6 +407,28 @@ test_alter = do
   where
     f _ = Nothing
     g _ = Just "c"
+
+test_at :: Assertion
+test_at = do
+    employeeCurrency "John" @?= Just "Euro"
+    employeeCurrency "Pete" @?= Nothing
+    atAlter f 7 (fromList [(5,"a"), (3,"b")]) @?= fromList [(3, "b"), (5, "a")]
+    atAlter f 5 (fromList [(5,"a"), (3,"b")]) @?= singleton 3 "b"
+    atAlter g 7 (fromList [(5,"a"), (3,"b")]) @?= fromList [(3, "b"), (5, "a"), (7, "c")]
+    atAlter g 5 (fromList [(5,"a"), (3,"b")]) @?= fromList [(3, "b"), (5, "c")]
+  where
+    atAlter f k m = runIdentity (at k (pure . f) m)
+    atLookup k m = getConst (at k Const m)
+    f _ = Nothing
+    g _ = Just "c"
+    employeeDept = fromList([("John","Sales"), ("Bob","IT")])
+    deptCountry = fromList([("IT","USA"), ("Sales","France")])
+    countryCurrency = fromList([("USA", "Dollar"), ("France", "Euro")])
+    employeeCurrency :: String -> Maybe String
+    employeeCurrency name = do
+        dept <- atLookup name employeeDept
+        country <- atLookup dept deptCountry
+        atLookup country countryCurrency
 
 ----------------------------------------------------------------
 -- Combine


### PR DESCRIPTION
Use a bit queue to implement `alterF`, a flipped version of `at`,
for `Data.Map`. This is fairly competitive with the simple implementation in
`Control.Lens.At` even with `Int` keys. For keys that are more expensive to compare,
it should be substantially better.

Unit tests and benchmarks were written by Phil Ruffwind, who proposed
adding `at` to begin with. The implementation is by David Feuer, as are
the QuickCheck properties.