### PR TITLE
Use unsafeShift in BitUtil for base >= 4.8

### DIFF
--- a/Data/Utils/BitUtil.hs
+++ b/Data/Utils/BitUtil.hs
@@ -27,7 +27,13 @@ module Data.Utils.BitUtil
 
 import Data.Bits ((.|.), xor)
 
-#if __GLASGOW_HASKELL__
+#if !MIN_VERSION_base(4,8,0)
+import Data.Word (Word)
+#endif
+
+#if MIN_VERSION_base(4,5,0)
+import Data.Bits (unsafeShiftL, unsafeShiftR)
+#elif __GLASGOW_HASKELL__
 import GHC.Exts (Word(..), Int(..))
 import GHC.Prim (uncheckedShiftL#, uncheckedShiftRL#)
 #else
@@ -55,7 +61,10 @@ highestBitMask x1 = let x2 = x1 .|. x1 `shiftRL` 1
 
 -- Right and left logical shifts.
 shiftRL, shiftLL :: Word -> Int -> Word
-#if __GLASGOW_HASKELL__
+#if MIN_VERSION_base(4,5,0)
+shiftRL x i = unsafeShiftR x i
+shiftLL x i = unsafeShiftL x i
+#elif __GLASGOW_HASKELL__
 {--------------------------------------------------------------------
   GHC: use unboxing to get @shiftRL@ inlined.
 --------------------------------------------------------------------}

--- a/Data/Utils/BitUtil.hs
+++ b/Data/Utils/BitUtil.hs
@@ -2,7 +2,7 @@
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE MagicHash #-}
 #endif
-#if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
+#if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703 && !MIN_VERSION_base(4,8,0)
 {-# LANGUAGE Trustworthy #-}
 #endif
 


### PR DESCRIPTION
Use `unsafeShiftL/R` in `BitUtil` for base >= 4.8 instead of explicitly using GHC primitives, and also avoid the warning about `Trustworthy`.
