### PR TITLE
Remove a bunch of unnecessary laziness from Data.Map

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@
 
   * Speed up `adjust` for `Data.Map`.
 
+  * Remove non-essential laziness in `Data.Map.Lazy` implementation.
+
   * Speed up deletion and alteration functions for `Data.IntMap`.
 
 ## 0.5.7.1  *Dec 2015*


### PR DESCRIPTION
Lots of functions in `Data.Map.Base` used lazy pairs and such for no obviously good
reason. As a result, they sometimes did strange things like
building up chains of suspensions to rebuild trees.