### PR TITLE
Speed up Data.Sequence.splitAt and zipWith

### DIFF
--- a/Data/Utils/BitQueue.hs
+++ b/Data/Utils/BitQueue.hs
@@ -31,7 +31,9 @@ module Data.Utils.BitQueue
     , toListQ
     ) where
 
+#if !MIN_VERSION_base(4,8,0)
 import Data.Word (Word)
+#endif
 import Data.Utils.BitUtil (shiftLL, shiftRL, wordSize)
 import Data.Bits ((.|.), (.&.), testBit)
 #if MIN_VERSION_base(4,8,0)

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@
 
   * Add `intersperse` and `traverseWithIndex` for `Data.Sequence`.
 
+  * Make `splitAt` in `Data.Sequence` strict in its arguments. Previously,
+    it returned a lazy pair.
+
   * Derive `Generic` and `Generic1` for `Data.Tree`.
 
   * Add `foldTree` for `Data.Tree`.

--- a/tests/bitqueue-properties.hs
+++ b/tests/bitqueue-properties.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -Wall #-}
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
+#endif
 import qualified Data.List as List
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2


### PR DESCRIPTION
Previously, `splitAt` returned a lazy pair, and was pretty much
lazy throughout. Now it's about as strict as it's allowed to be.

Avoid allocating anything extra when splitting at or before the
beginning of a sequence.

Fix misplaced bang annotation (my fault).

Hand-inline and reduce the splitting of the top of the tree. This
avoids a separate cons step at the end, saving some time when
splitting small sequences. This is particularly helpful for
zip performance.

Note: `zip` performance is, for some reason, rather sensitive to
how the inliner handles `sdeepL`. I don't know why. I also don't
really know how to fix it. Splitting in general is rather complicated
and hard to follow. It would be nice to fix that.