### PR TITLE
Let Cabal know that we use CPP and BangPatterns

### DIFF
--- a/containers.cabal
+++ b/containers.cabal
@@ -38,6 +38,8 @@ Library
 
     ghc-options: -O2 -Wall
 
+    other-extensions: CPP, BangPatterns
+
     exposed-modules:
         Data.IntMap
         Data.IntMap.Lazy
@@ -77,6 +79,7 @@ Test-suite map-lazy-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -97,6 +100,7 @@ Test-suite map-strict-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -118,6 +122,7 @@ Test-suite bitqueue-properties
 
     build-depends: base >= 4.3 && < 5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -133,6 +138,7 @@ Test-suite set-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -150,6 +156,7 @@ Test-suite intmap-lazy-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -167,6 +174,7 @@ Test-suite intmap-strict-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -184,6 +192,7 @@ Test-suite intset-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -201,6 +210,7 @@ Test-suite deprecated-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -216,6 +226,7 @@ Test-suite seq-properties
 
     build-depends: base >= 4.3 && < 5, array, deepseq >= 1.2 && < 1.5, ghc-prim
     ghc-options: -O2
+    other-extensions: CPP, BangPatterns
     include-dirs: include
 
     build-depends:
@@ -240,12 +251,14 @@ test-suite map-strictness-properties
     test-framework-quickcheck2 >= 0.2.9
 
   ghc-options: -Wall
+  other-extensions: CPP, BangPatterns
   include-dirs: include
 
 test-suite intmap-strictness-properties
   hs-source-dirs: tests, .
   main-is: intmap-strictness.hs
   type: exitcode-stdio-1.0
+  other-extensions: CPP, BangPatterns
 
   build-depends:
     array,
@@ -264,6 +277,7 @@ test-suite intset-strictness-properties
   hs-source-dirs: tests, .
   main-is: intset-strictness.hs
   type: exitcode-stdio-1.0
+  other-extensions: CPP, BangPatterns
 
   build-depends:
     array,


### PR DESCRIPTION
Use `other-extensions` to indicate this. I'm not convinced it's
worth the trouble to try to get real specific about what
extensions we use for each GHC version.