### PR TITLE
Make Data.Map.Strict.traverseWithKey strict enough

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@
 
   * Add `alterF` for `Data.Map`.
 
+  * Make `Data.Map.Strict.traverseWithKey` force result values before
+    installing them in the new map.
+
   * Add `Empty`, `:<|`, and `:|>` pattern synonyms for `Data.Sequence`.
 
   * Add `intersperse` and `traverseWithIndex` for `Data.Sequence`.


### PR DESCRIPTION
Previously, `Data.Map.Strict` re-exported `traverseWithKey`
from `Data.Map.Base`. That function could produce a map containing
bottoms.