### PR TITLE
Fuse fmap with reverse for Data.Sequence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,8 @@
     are greatest for small sequences, but meaningful even for long ones.
     Reimplement `take` and `drop` to avoid building and then discarding trees.
 
+  * Add rewrite rules to fuse `fmap` with `reverse` for `Data.Sequence`.
+
   * Speed up `adjust` for `Data.Map`.
 
   * Remove non-essential laziness in `Data.Map.Lazy` implementation.


### PR DESCRIPTION
Add rules fusing `fmap f . reverse` and `reverse . fmap f`
for `Data.Sequence`. These make mapping over a sequence and
reversing it simultaneously as cheap as just mapping over it.

Closes #238.