### PR TITLE
Integrate benchmarks with `cabal`.  Fixes #188

### DIFF
--- a/benchmarks/IntMap.hs
+++ b/benchmarks/IntMap.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.IntMap as M
 import Data.Maybe (fromMaybe)

--- a/benchmarks/IntSet.hs
+++ b/benchmarks/IntSet.hs
@@ -2,10 +2,9 @@
 
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.IntSet as S
 

--- a/benchmarks/LookupGE/IntMap.hs
+++ b/benchmarks/LookupGE/IntMap.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Config
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, nf)
 import Data.List (foldl')
 import qualified Data.IntMap as M
 import qualified LookupGE_IntMap as M
@@ -14,10 +12,8 @@ import Prelude hiding (lookup)
 
 main :: IO ()
 main = do
-    defaultMainWith
-        defaultConfig
-        (liftIO . evaluate $ rnf [m_even, m_odd, m_large])
-        [b f | b <- benches, f <- funs1]
+    evaluate $ rnf [m_even, m_odd, m_large]
+    defaultMain [b f | b <- benches, f <- funs1]
   where
     m_even = M.fromAscList elems_even :: M.IntMap Int
     m_odd  = M.fromAscList elems_odd :: M.IntMap Int

--- a/benchmarks/LookupGE/LookupGE_IntMap.hs
+++ b/benchmarks/LookupGE/LookupGE_IntMap.hs
@@ -3,9 +3,6 @@ module LookupGE_IntMap where
 
 import Prelude hiding (null)
 import Data.IntMap.Base
-#ifdef TESTING
-import Test.QuickCheck
-#endif
 
 lookupGE1 :: Key -> IntMap a -> Maybe (Key,a)
 lookupGE1 k m =

--- a/benchmarks/LookupGE/LookupGE_Map.hs
+++ b/benchmarks/LookupGE/LookupGE_Map.hs
@@ -2,9 +2,6 @@
 module LookupGE_Map where
 
 import Data.Map.Base
-#ifdef TESTING
-import Test.QuickCheck
-#endif
 
 lookupGE1 :: Ord k => k -> Map k a -> Maybe (k,a)
 lookupGE1 k m =

--- a/benchmarks/LookupGE/Map.hs
+++ b/benchmarks/LookupGE/Map.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Config
-import Criterion.Main
+import Criterion.Main (defaultMain, bench, nf)
 import Data.List (foldl')
 import qualified Data.Map as M
 import qualified LookupGE_Map as M
@@ -14,10 +12,8 @@ import Prelude hiding (lookup)
 
 main :: IO ()
 main = do
-    defaultMainWith
-        defaultConfig
-        (liftIO . evaluate $ rnf [m_even, m_odd, m_large])
-        [b f | b <- benches, f <- funs1]
+    evaluate $ rnf [m_even, m_odd, m_large]
+    defaultMain [b f | b <- benches, f <- funs1]
   where
     m_even = M.fromAscList elems_even :: M.Map Int Int
     m_odd  = M.fromAscList elems_odd :: M.Map Int Int

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)

--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -1,14 +1,13 @@
--- > ghc -DTESTING --make -O2 -fforce-recomp -i.. Sequence.hs
 module Main where
 
 import Control.Applicative
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main
+import Criterion.Main (bench, bgroup, defaultMain, nf)
 import Data.List (foldl')
 import qualified Data.Sequence as S
 import qualified Data.Foldable
-import System.Random
+import System.Random (mkStdGen, randoms)
 
 main = do
     let s10 = S.fromList [1..10] :: S.Seq Int

--- a/benchmarks/Set.hs
+++ b/benchmarks/Set.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 
--- > ghc -DTESTING --make -O2 -fforce-recomp -i.. Set.hs
 module Main where
 
-import Control.DeepSeq
+import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Control.Monad.Trans (liftIO)
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.Set as S
 

--- a/benchmarks/SetOperations/SetOperations.hs
+++ b/benchmarks/SetOperations/SetOperations.hs
@@ -2,7 +2,7 @@
 
 module SetOperations (benchmark) where
 
-import Criterion.Main
+import Criterion.Main (bench, defaultMain, whnf)
 import Data.List (partition)
 
 benchmark :: ([Int] -> container) -> Bool -> [(String, container -> container -> container)] -> IO ()

--- a/containers.cabal
+++ b/containers.cabal
@@ -66,6 +66,136 @@ Library
     if impl(ghc<7.0)
         extensions: MagicHash, DeriveDataTypeable, StandaloneDeriving, Rank2Types
 
+-----------------------------
+-- B E N C H M A R K I N G --
+-----------------------------
+
+benchmark intmap-benchmarks
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: IntMap.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5
+
+benchmark intset-benchmarks
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: IntSet.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5
+
+benchmark map-benchmarks
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: Map.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5
+
+benchmark sequence-benchmarks
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: Sequence.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5,
+    random < 1.2
+
+benchmark set-benchmarks
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: Set.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5
+
+benchmark set-operations-intmap
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/SetOperations
+  main-is: SetOperations-IntMap.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2
+
+benchmark set-operations-intset
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/SetOperations
+  main-is: SetOperations-IntSet.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2
+
+benchmark set-operations-map
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/SetOperations
+  main-is: SetOperations-Map.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2
+
+benchmark set-operations-set
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/SetOperations
+  main-is: SetOperations-Set.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2
+
+benchmark lookupge-intmap
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/LookupGE, .
+  main-is: IntMap.hs
+  ghc-options: -O2
+  cpp-options: -DTESTING
+  other-modules:
+    Data.IntMap.Base
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5,
+    ghc-prim
+
+benchmark lookupge-map
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks/LookupGE, .
+  main-is: Map.hs
+  ghc-options: -O2
+  cpp-options: -DTESTING
+  other-modules:
+    Data.Map.Base
+  build-depends:
+    base >= 4.2 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.2,
+    deepseq >= 1.1.0.0 && < 1.5,
+    ghc-prim
+
 -------------------
 -- T E S T I N G --
 -------------------


### PR DESCRIPTION
Some comments about the changes that might seem unrelated:

* I changed to more explicit imports so that it was easier to figure out what the correct bounds should be for each benchmark's dependencies
* Several benchmarks were (unnecessarily) using an old version of `defaultMainWith` that only worked before `criterion-1.0.0.0`.  I replaced this with just evaluating the values in the top-level `main` function