### PR TITLE
Remove unnecessary extensions from tests

### DIFF
--- a/tests/bitqueue-properties.hs
+++ b/tests/bitqueue-properties.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
-{-# OPTIONS_GHC -Wall #-}
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))

--- a/tests/intmap-strictness.hs
+++ b/tests/intmap-strictness.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
@@ -8,20 +7,13 @@ import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck (Arbitrary(arbitrary))
 
+import Text.Show.Functions ()
+
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as M
 
 instance Arbitrary v => Arbitrary (IntMap v) where
     arbitrary = M.fromList `fmap` arbitrary
-
-instance Show (Int -> Int) where
-    show _ = "<function>"
-
-instance Show (Int -> Int -> Int) where
-    show _ = "<function>"
-
-instance Show (Int -> Int -> Int -> Int) where
-    show _ = "<function>"
 
 ------------------------------------------------------------------------
 -- * Properties

--- a/tests/intset-strictness.hs
+++ b/tests/intset-strictness.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Main (main) where
 
 import Prelude hiding (foldl)

--- a/tests/map-strictness.hs
+++ b/tests/map-strictness.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
@@ -8,21 +7,14 @@ import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck (Arbitrary(arbitrary))
 
+import Text.Show.Functions ()
+
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 
 instance (Arbitrary k, Arbitrary v, Ord k) =>
          Arbitrary (Map k v) where
     arbitrary = M.fromList `fmap` arbitrary
-
-instance Show (Int -> Int) where
-    show _ = "<function>"
-
-instance Show (Int -> Int -> Int) where
-    show _ = "<function>"
-
-instance Show (Int -> Int -> Int -> Int) where
-    show _ = "<function>"
 
 ------------------------------------------------------------------------
 -- * Properties


### PR DESCRIPTION
Use `Text.Show.Functions` (blech!) to avoid declaring our own,
similar instances and using `FlexibleInstances` to do so (double
blech!). Remove unused invocation of `GeneralizedNewtypeDeriving`.

I had planned to add the necessary extensions to the Cabal file, but they weren't necessary!