### PR TITLE
Use QuickCheck function support

### DIFF
--- a/tests/deprecated-properties.hs
+++ b/tests/deprecated-properties.hs
@@ -12,7 +12,7 @@ import qualified Data.IntMap.Strict as SIM
 
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2
-import Text.Show.Functions ()
+import Test.QuickCheck.Function (Fun(..), apply)
 
 default (Int)
 
@@ -32,11 +32,16 @@ main = defaultMain
 
 
 ---------- Map properties ----------
+apply2 :: Fun (a, b) c -> a -> b -> c
+apply2 f a b = apply f (a, b)
 
-prop_mapInsertWith'Strict :: [(Int, Int)] -> (Int -> Int -> Int) -> [(Int, Int)] -> Bool
+apply3 :: Fun (a, b, c) d -> a -> b -> c -> d
+apply3 f a b c = apply f (a, b, c)
+
+prop_mapInsertWith'Strict :: [(Int, Int)] -> Fun (Int, Int) Int -> [(Int, Int)] -> Bool
 prop_mapInsertWith'Strict xs f kxxs =
   let m = M.fromList xs
-      insertList ins = foldr (\(kx, x) -> ins f kx x) m kxxs
+      insertList ins = foldr (\(kx, x) -> ins (apply2 f) kx x) m kxxs
   in insertList M.insertWith' == insertList SM.insertWith
 
 prop_mapInsertWith'Undefined :: [(Int, Int)] -> Bool
@@ -46,10 +51,10 @@ prop_mapInsertWith'Undefined xs =
       insertList ins = foldr (\(kx, _) -> ins f kx undefined) m xs
   in insertList M.insertWith' == insertList M.insertWith
 
-prop_mapInsertWithKey'Strict :: [(Int, Int)] -> (Int -> Int -> Int -> Int) -> [(Int, Int)] -> Bool
+prop_mapInsertWithKey'Strict :: [(Int, Int)] -> Fun (Int, Int, Int) Int -> [(Int, Int)] -> Bool
 prop_mapInsertWithKey'Strict xs f kxxs =
   let m = M.fromList xs
-      insertList ins = foldr (\(kx, x) -> ins f kx x) m kxxs
+      insertList ins = foldr (\(kx, x) -> ins (apply3 f) kx x) m kxxs
   in insertList M.insertWithKey' == insertList SM.insertWithKey
 
 prop_mapInsertWithKey'Undefined :: [(Int, Int)] -> Bool
@@ -59,10 +64,10 @@ prop_mapInsertWithKey'Undefined xs =
       insertList ins = foldr (\(kx, _) -> ins f kx undefined) m xs
   in insertList M.insertWithKey' == insertList M.insertWithKey
 
-prop_mapInsertLookupWithKey'Strict :: [(Int, Int)] -> (Int -> Int -> Int -> Int) -> [(Int, Int)] -> Bool
+prop_mapInsertLookupWithKey'Strict :: [(Int, Int)] -> Fun (Int, Int, Int) Int -> [(Int, Int)] -> Bool
 prop_mapInsertLookupWithKey'Strict xs f kxxs =
   let m = M.fromList xs
-      insertLookupList insLkp = scanr (\(kx, x) (_, mp) -> insLkp f kx x mp) (Nothing, m) kxxs
+      insertLookupList insLkp = scanr (\(kx, x) (_, mp) -> insLkp (apply3 f) kx x mp) (Nothing, m) kxxs
   in insertLookupList M.insertLookupWithKey' == insertLookupList SM.insertLookupWithKey
 
 prop_mapInsertLookupWithKey'Undefined :: [(Int, Int)] -> Bool
@@ -75,10 +80,10 @@ prop_mapInsertLookupWithKey'Undefined xs =
 
 ---------- IntMap properties ----------
 
-prop_intmapInsertWith'Strict :: [(Int, Int)] -> (Int -> Int -> Int) -> [(Int, Int)] -> Bool
+prop_intmapInsertWith'Strict :: [(Int, Int)] -> Fun (Int, Int) Int -> [(Int, Int)] -> Bool
 prop_intmapInsertWith'Strict xs f kxxs =
   let m = IM.fromList xs
-      insertList ins = foldr (\(kx, x) -> ins f kx x) m kxxs
+      insertList ins = foldr (\(kx, x) -> ins (apply2 f) kx x) m kxxs
   in insertList IM.insertWith' == insertList SIM.insertWith
 
 prop_intmapInsertWith'Undefined :: [(Int, Int)] -> Bool
@@ -88,10 +93,10 @@ prop_intmapInsertWith'Undefined xs =
       insertList ins = foldr (\(kx, _) -> ins f kx undefined) m xs
   in insertList IM.insertWith' == insertList IM.insertWith
 
-prop_intmapInsertWithKey'Strict :: [(Int, Int)] -> (Int -> Int -> Int -> Int) -> [(Int, Int)] -> Bool
+prop_intmapInsertWithKey'Strict :: [(Int, Int)] -> Fun (Int, Int, Int) Int -> [(Int, Int)] -> Bool
 prop_intmapInsertWithKey'Strict xs f kxxs =
   let m = IM.fromList xs
-      insertList ins = foldr (\(kx, x) -> ins f kx x) m kxxs
+      insertList ins = foldr (\(kx, x) -> ins (apply3 f) kx x) m kxxs
   in insertList IM.insertWithKey' == insertList SIM.insertWithKey
 
 prop_intmapInsertWithKey'Undefined :: [(Int, Int)] -> Bool

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -22,7 +22,7 @@ import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2
 import Test.HUnit hiding (Test, Testable)
 import Test.QuickCheck
-import Text.Show.Functions ()
+import Test.QuickCheck.Function (Fun(..), apply)
 
 default (Int)
 
@@ -168,6 +168,13 @@ main = defaultMain
              , testProperty "keysSet"              prop_keysSet
              , testProperty "fromSet"              prop_fromSet
              ]
+
+apply2 :: Fun (a, b) c -> a -> b -> c
+apply2 f a b = apply f (a, b)
+
+apply3 :: Fun (a, b, c) d -> a -> b -> c -> d
+apply3 f a b c = apply f (a, b, c)
+
 
 {--------------------------------------------------------------------
   Arbitrary, reasonably balanced trees
@@ -958,35 +965,35 @@ prop_deleteMaxModel ys = length ys > 0 ==>
       m  = fromList xs
   in  toAscList (deleteMax m) == init (sort xs)
 
-prop_filter :: (Int -> Bool) -> [(Int, Int)] -> Property
+prop_filter :: Fun Int Bool -> [(Int, Int)] -> Property
 prop_filter p ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  filter p m == fromList (List.filter (p . snd) xs)
+  in  filter (apply p) m == fromList (List.filter (apply p . snd) xs)
 
-prop_partition :: (Int -> Bool) -> [(Int, Int)] -> Property
+prop_partition :: Fun Int Bool -> [(Int, Int)] -> Property
 prop_partition p ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  partition p m == let (a,b) = (List.partition (p . snd) xs) in (fromList a, fromList b)
+  in  partition (apply p) m == let (a,b) = (List.partition (apply p . snd) xs) in (fromList a, fromList b)
 
-prop_map :: (Int -> Int) -> [(Int, Int)] -> Property
+prop_map :: Fun Int Int -> [(Int, Int)] -> Property
 prop_map f ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  map f m == fromList [ (a, f b) | (a,b) <- xs ]
+  in  map (apply f) m == fromList [ (a, apply f b) | (a,b) <- xs ]
 
-prop_fmap :: (Int -> Int) -> [(Int, Int)] -> Property
+prop_fmap :: Fun Int Int -> [(Int, Int)] -> Property
 prop_fmap f ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  fmap f m == fromList [ (a, f b) | (a,b) <- xs ]
+  in  fmap (apply f) m == fromList [ (a, apply f b) | (a,b) <- xs ]
 
-prop_mapkeys :: (Int -> Int) -> [(Int, Int)] -> Property
+prop_mapkeys :: Fun Int Int -> [(Int, Int)] -> Property
 prop_mapkeys f ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  mapKeys f m == (fromList $ List.nubBy ((==) `on` fst) $ reverse [ (f a, b) | (a,b) <- sort xs])
+  in  mapKeys (apply f) m == (fromList $ List.nubBy ((==) `on` fst) $ reverse [ (apply f a, b) | (a,b) <- sort xs])
 
 prop_splitModel :: Int -> [(Int, Int)] -> Property
 prop_splitModel n ys = length ys > 0 ==>


### PR DESCRIPTION
Previously, a number of tests used functions directly as
arguments to QuickCheck properties. As a result, they needed
to include the horrifying `Text.Show.Functions`.

Now the properties requiring functions use
`Test.QuickCheck.Function.Fun`, which has both a meaningful
`Show` instance and proper shrinks.