### PR TITLE
Add alterF for Data.IntMap

### DIFF
--- a/Data/IntMap/Base.hs
+++ b/Data/IntMap/Base.hs
@@ -90,6 +90,7 @@ module Data.IntMap.Base (
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , alterF
 
     -- * Combine
 
@@ -835,6 +836,42 @@ alter f k Nil     = case f Nothing of
                       Just x -> Tip k x
                       Nothing -> Nil
 
+-- | /O(log n)/. The expression (@'alterF' f k map@) alters the value @x@ at
+-- @k@, or absence thereof.  'alterF' can be used to inspect, insert, delete,
+-- or update a value in an 'IntMap'.  In short : @'lookup' k <$> 'alterF' f k m = f
+-- ('lookup' k m)@.
+--
+-- Example:
+--
+-- @
+-- interactiveAlter :: Int -> IntMap String -> IO (IntMap String)
+-- interactiveAlter k m = alterF f k m where
+--   f Nothing -> do
+--      putStrLn $ show k ++
+--          " was not found in the map. Would you like to add it?"
+--      getUserResponse1 :: IO (Maybe String)
+--   f (Just old) -> do
+--      putStrLn "The key is currently bound to " ++ show old ++
+--          ". Would you like to change or delete it?"
+--      getUserresponse2 :: IO (Maybe String)
+-- @
+--
+-- 'alterF' is the most general operation for working with an individual
+-- key that may or may not be in a given map.
+--
+-- Note: 'alterF' is a flipped version of the 'at' combinator from
+-- 'Control.Lens.At'.
+--
+-- @since 0.5.8
+
+alterF :: Functor f
+       => (Maybe a -> f (Maybe a)) -> Key -> IntMap a -> f (IntMap a)
+-- This implementation was stolen from 'Control.Lens.At'.
+alterF f k m = (<$> f mv) $ \fres ->
+  case fres of
+    Nothing -> maybe m (const (delete k m)) mv
+    Just v' -> insert k v' m
+  where mv = lookup k m
 
 {--------------------------------------------------------------------
   Union

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -96,6 +96,7 @@ module Data.IntMap.Lazy (
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , alterF
 
     -- * Combine
 

--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -1047,7 +1047,7 @@ replicateM n x
 -- @since 0.5.8
 cycleN :: Int -> Seq a -> Seq a
 cycleN n !_xs | n < 0 = error "cycleN takes a non-negative argument"
-cycleN n xs   | null xs = error "cycleN takes a non-empty sequence"
+cycleN _n xs  | null xs = error "cycleN takes a non-empty sequence"
 cycleN n xs = cycleNTimes reps xs >< take final xs
   where
     (reps, final) = n `quotRem` length xs

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@
   * Use `BangPatterns` throughout to reduce noise. This extension
     is now *required* to compile `containers`.
 
-  * Add `alterF` for `Data.Map`.
+  * Add `alterF` for `Data.Map` and `Data.IntMap`.
 
   * Make `Data.Map.Strict.traverseWithKey` force result values before
     installing them in the new map.


### PR DESCRIPTION
The implementation is just taken from `Control.Lens.At`, because
`IntMap` lookup is so fast there's no point in trying to be clever
about it.

Clear up unused-binding warning in `Data.Sequence`.