### PR TITLE
Sequences: strictify adjust; reimplement update

### DIFF
--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -103,6 +103,7 @@ module Data.IntMap.Strict (
     , updateWithKey
     , updateLookupWithKey
     , alter
+    , alterF
 
     -- * Combine
 

--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -35,6 +35,16 @@ main = do
          , bench "100" $ nf (shuffle r100) s100
          , bench "1000" $ nf (shuffle r1000) s1000
          ]
+      , bgroup "update"
+         [ bench "10" $ nf (updatePoints r10 10) s10
+         , bench "100" $ nf (updatePoints r100 10) s100
+         , bench "1000" $ nf (updatePoints r1000 10) s1000
+         ]
+      , bgroup "adjust"
+         [ bench "10" $ nf (adjustPoints r10 (+10)) s10
+         , bench "100" $ nf (adjustPoints r100 (+10)) s100
+         , bench "1000" $ nf (adjustPoints r1000 (+10)) s1000
+         ]
       , bgroup "deleteAt"
          [ bench "10" $ nf (deleteAtPoints r10) s10
          , bench "100" $ nf (deleteAtPoints r100) s100
@@ -102,9 +112,25 @@ fakeInsertAt i x xs = case S.splitAt i xs of
   (before, after) -> before S.>< x S.<| after
 -}
 
+adjustPoints :: [Int] -> (a -> a) -> S.Seq a -> S.Seq a
+adjustPoints points f xs =
+  foldl' (\acc k -> S.adjust f k acc) xs points
+
 insertAtPoints :: [Int] -> a -> S.Seq a -> S.Seq a
 insertAtPoints points x xs =
   foldl' (\acc k -> S.insertAt k x acc) xs points
+
+updatePoints :: [Int] -> a -> S.Seq a -> S.Seq a
+updatePoints points x xs =
+  foldl' (\acc k -> S.update k x acc) xs points
+
+{-
+-- For comparison. Using the old implementation of update,
+-- which this simulates, can cause thunks to build up in the leaves.
+fakeupdatePoints :: [Int] -> a -> S.Seq a -> S.Seq a
+fakeupdatePoints points x xs =
+  foldl' (\acc k -> S.adjust (const x) k acc) xs points
+-}
 
 deleteAtPoints :: [Int] -> S.Seq a -> S.Seq a
 deleteAtPoints points xs =


### PR DESCRIPTION
Previously, `adjust` would place a thunk at the top of the tree.
Now, it pushes that thunk all the way down to the appropriate
leaf. This way, performing multiple adjustments to different
locations will not lead to a thunk clog at the top. The implementation
makes use of a new `MaybeForce` class, which allows `Node`s
(which can by forced safely) and `Elem`s (which generally aren't
allowed to be forced) to be handled in a uniform fashion. I'm
hopeful that `MaybeForce` will prove useful elsewhere in the module
as well.

Adjusting the *same* location many times, however, can lead to
a thunk clog at the leaf. This is generally unavoidable. `update`
used to be implemented as

```haskell
update i x = adjust (const x) i
```

which is subject to the thunk clog problem. By implementing the
`Elem` layer of `update` directly (duplicating code), we can
avoid subjecting `update` to this problem at all.

Also, bring all the insertion code together. It got separated
by mistake.

Finally, actually export `alterF` from `Data.IntMap.Strict`; it missed the boat somehow.