### PR TITLE
Write custom strict folds

### DIFF
--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -5,7 +5,7 @@ import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Control.Monad.Trans.State.Strict
 import Criterion.Main (bench, bgroup, defaultMain, nf)
-import Data.List (foldl')
+import Data.Foldable (foldl', foldr')
 import qualified Data.Sequence as S
 import qualified Data.Foldable
 import Data.Traversable (traverse)
@@ -34,6 +34,18 @@ main = do
          [ bench "10" $ nf (shuffle r10) s10
          , bench "100" $ nf (shuffle r100) s100
          , bench "1000" $ nf (shuffle r1000) s1000
+         ]
+      , bgroup "foldl'"
+         [ bench "10" $ nf (foldl' (+) 0) s10
+         , bench "100" $ nf (foldl' (+) 0) s100
+         , bench "1000" $ nf (foldl' (+) 0) s1000
+         , bench "10000" $ nf (foldl' (+) 0) s10000
+         ]
+      , bgroup "foldr'"
+         [ bench "10" $ nf (foldr' (+) 0) s10
+         , bench "100" $ nf (foldr' (+) 0) s100
+         , bench "1000" $ nf (foldr' (+) 0) s1000
+         , bench "10000" $ nf (foldr' (+) 0) s10000
          ]
       , bgroup "update"
          [ bench "10" $ nf (updatePoints r10 10) s10

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,8 @@
   * Make `splitAt` in `Data.Sequence` strict in its arguments. Previously,
     it returned a lazy pair.
 
+  * Fix completely erroneous definition of `length` for `ViewR`.
+
   * Derive `Generic` and `Generic1` for `Data.Tree`.
 
   * Add `foldTree` for `Data.Tree`.
@@ -39,6 +41,9 @@
     code to avoid allocating unnecessary intermediate structures. The
     improvements are greatest for small sequences, but large even for long
     ones. Reimplement `take` and `drop` to avoid building trees only to discard them.
+
+  * Roughly double the speeds of `foldl'` and `foldr'` for `Data.Sequence`
+    by writing custom definitions instead of using the defaults.
 
   * Add rewrite rules to fuse `fmap` with `reverse` for `Data.Sequence`.
 

--- a/tests/seq-properties.hs
+++ b/tests/seq-properties.hs
@@ -4,7 +4,7 @@ import Control.Applicative (Applicative(..))
 import Control.Arrow ((***))
 import Control.Monad.Trans.State.Strict
 import Data.Array (listArray)
-import Data.Foldable (Foldable(foldl, foldl1, foldr, foldr1, foldMap, fold), toList, all, sum)
+import Data.Foldable (Foldable(foldl, foldl1, foldr, foldr1, foldMap, fold), toList, all, sum, foldl', foldr')
 import Data.Functor ((<$>), (<$))
 import Data.Maybe
 import Data.Monoid (Monoid(..), All(..), Endo(..), Dual(..))
@@ -28,8 +28,10 @@ main = defaultMain
        [ testProperty "fmap" prop_fmap
        , testProperty "(<$)" prop_constmap
        , testProperty "foldr" prop_foldr
+       , testProperty "foldr'" prop_foldr'
        , testProperty "foldr1" prop_foldr1
        , testProperty "foldl" prop_foldl
+       , testProperty "foldl'" prop_foldl'
        , testProperty "foldl1" prop_foldl1
        , testProperty "(==)" prop_equals
        , testProperty "compare" prop_compare
@@ -233,9 +235,16 @@ prop_constmap :: A -> Seq A -> Bool
 prop_constmap x xs =
     toList' (x <$ xs) ~= map (const x) (toList xs)
 
-prop_foldr :: Seq A -> Bool
+prop_foldr :: Seq A -> Property
 prop_foldr xs =
-    foldr f z xs == Prelude.foldr f z (toList xs)
+    foldr f z xs === Prelude.foldr f z (toList xs)
+  where
+    f = (:)
+    z = []
+
+prop_foldr' :: Seq A -> Property
+prop_foldr' xs =
+    foldr' f z xs === foldr' f z (toList xs)
   where
     f = (:)
     z = []
@@ -245,9 +254,16 @@ prop_foldr1 xs =
     not (null xs) ==> foldr1 f xs == Data.List.foldr1 f (toList xs)
   where f = (-)
 
-prop_foldl :: Seq A -> Bool
+prop_foldl :: Seq A -> Property
 prop_foldl xs =
-    foldl f z xs == Prelude.foldl f z (toList xs)
+    foldl f z xs === Prelude.foldl f z (toList xs)
+  where
+    f = flip (:)
+    z = []
+
+prop_foldl' :: Seq A -> Property
+prop_foldl' xs =
+    foldl' f z xs === foldl' f z (toList xs)
   where
     f = flip (:)
     z = []


### PR DESCRIPTION
Writing `foldl'` and `foldr'` for sequences by hand, instead of using the
default definitions, makes them about twice as fast.