### PR TITLE
Corrected drawTree & drawForest to render multiline String values in a palatable manner!

### DIFF
--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -134,7 +134,7 @@ drawForest :: Forest String -> String
 drawForest  = unlines . map drawTree
 
 draw :: Tree String -> [String]
-draw (Node x ts0) = x : drawSubTrees ts0
+draw (Node x ts0) = lines x ++ drawSubTrees ts0
   where
     drawSubTrees [] = []
     drawSubTrees [t] =


### PR DESCRIPTION
The old version assumed that all `String` values in the `Tree` would not contain newlines. The presence of newlines in a `String` value would cause the rendering to break indentation and make even medium sized trees indecipherable.

This minor change allows a `Tree` containing `String`s with newlines to be rendered with the hierarchical indentation preserved. 

Consider the example type `T`:
```
    data T = T
    instance Show T where
      show _ = "Top line\nBottom line"
```

Consider also the following `Tree T` construction and rendering: 

    putStr . drawTree $
      show <$> Node T [Node T [Node T [], Node T [Node T []], Node T []], Node T [Node T []]]


```
Top line
Bottom line
|
+- Top line
Bottom line
|  |
|  +- Top line
Bottom line
|  |
|  +- Top line
Bottom line
|  |  |
|  |  `- Top line
Bottom line
|  |
|  `- Top line
Bottom line
|
`- Top line
Bottom line
   |
   `- Top line
```

One would expect the rendering to look like this:

```
Top line
Bottom line
|
+- Top line
|  Bottom line
|  |
|  +- Top line
|  |  Bottom line
|  |
|  +- Top line
|  |  Bottom line
|  |  |
|  |  `- Top line
|  |     Bottom line
|  |
|  `- Top line
|     Bottom line
|
`- Top line
   Bottom line
   |
   `- Top line
      Bottom line
```