### PR TITLE
Make Data.Sequence.fromList more eager

### DIFF
--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -35,6 +35,12 @@ main = do
          , bench "100" $ nf (shuffle r100) s100
          , bench "1000" $ nf (shuffle r1000) s1000
          ]
+      , bgroup "fromList"
+         [ bench "10" $ nf S.fromList [(0 :: Int)..9]
+         , bench "100" $ nf S.fromList [(0 :: Int)..99]
+         , bench "1000" $ nf S.fromList [(0 :: Int)..999]
+         , bench "10000" $ nf S.fromList [(0 :: Int)..9999]
+         ]
       , bgroup "partition"
          [ bench "10" $ nf (S.partition even) s10
          , bench "100" $ nf (S.partition even) s100

--- a/changelog.md
+++ b/changelog.md
@@ -32,15 +32,23 @@
 
   * Derive `Generic` and `Generic1` for `Data.Tree`.
 
-  * Add `foldTree` for `Data.Tree`.
+  * Add `foldTree` for `Data.Tree`. (Thanks, Daniel Wagner!)
+
+  * Make `drawTree` handle newlines better. (Thanks, recursion-ninja!)
 
   * Slightly optimize `replicateA` and `traverse` for `Data.Sequence`.
   
-  * Substantially speed up `splitAt` and (consequently) `zipWith` for
-    `Data.Sequence` by building the result sequences eagerly and rearranging
-    code to avoid allocating unnecessary intermediate structures. The
-    improvements are greatest for small sequences, but large even for long
-    ones. Reimplement `take` and `drop` to avoid building trees only to discard them.
+  * Substantially speed up `splitAt`, `zipWith`, `take`, `drop`,
+    `fromList`, and `partition` in `Data.Sequence`.
+
+  * Most operations in `Data.Sequence` advertised as taking logarithmic
+    time (including `><` and `adjust`) now use their full allotted time
+    to avoid potentially building up chains of thunks in the tree. In general,
+    the only remaining operations that avoid doing more than they
+    really need are bulk creation and transformation functions that
+    really benefit from the extra laziness. There are some situations
+    where this change may slow programs down, but I think having more
+    predictable and usually better performance more than makes up for that.
 
   * Roughly double the speeds of `foldl'` and `foldr'` for `Data.Sequence`
     by writing custom definitions instead of using the defaults.


### PR DESCRIPTION
`fromList` previously suspended most of its work,
storing the structure in thunks rather than trees.
Now it builds everything.

Old:

benchmarking fromList/10
time                 175.2 ns   (174.7 ns .. 175.7 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 175.2 ns   (174.8 ns .. 175.6 ns)
std dev              1.383 ns   (1.124 ns .. 1.775 ns)

benchmarking fromList/100
time                 2.712 μs   (2.707 μs .. 2.720 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.732 μs   (2.717 μs .. 2.779 μs)
std dev              76.64 ns   (40.38 ns .. 147.1 ns)
variance introduced by outliers: 35% (moderately inflated)

benchmarking fromList/1000
time                 32.24 μs   (32.18 μs .. 32.33 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 32.26 μs   (32.22 μs .. 32.35 μs)
std dev              194.7 ns   (100.0 ns .. 371.4 ns)

benchmarking fromList/10000
time                 510.3 μs   (508.2 μs .. 511.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 508.1 μs   (506.2 μs .. 509.8 μs)
std dev              5.787 μs   (4.788 μs .. 7.175 μs)

New:

benchmarking fromList/10
time                 139.8 ns   (139.5 ns .. 140.2 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 139.8 ns   (139.6 ns .. 140.3 ns)
std dev              1.023 ns   (547.5 ps .. 1.573 ns)

benchmarking fromList/100
time                 1.520 μs   (1.517 μs .. 1.525 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.522 μs   (1.518 μs .. 1.529 μs)
std dev              16.53 ns   (10.57 ns .. 24.26 ns)

benchmarking fromList/1000
time                 16.00 μs   (15.97 μs .. 16.05 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.99 μs   (15.97 μs .. 16.04 μs)
std dev              89.39 ns   (39.63 ns .. 151.2 ns)

benchmarking fromList/10000
time                 262.8 μs   (262.3 μs .. 263.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 262.8 μs   (262.4 μs .. 264.7 μs)
std dev              2.559 μs   (757.4 ns .. 5.482 μs)