### PR TITLE
Add Data.Sequence.adjust'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@
 
   * Add `Empty`, `:<|`, and `:|>` pattern synonyms for `Data.Sequence`.
 
-  * Add `(!?)`, `lookup`, `chunksOf`, `cycleTaking`, `insertAt`, `deleteAt`, `intersperse`,
+  * Add `adjust'`, `(!?)`, `lookup`, `chunksOf`, `cycleTaking`, `insertAt`, `deleteAt`, `intersperse`,
     `foldMapWithIndex`, and `traverseWithIndex` for `Data.Sequence`.
 
   * Derive `Generic` and `Generic1` for `Data.Tree.Tree`, `Data.Sequence.ViewL`,


### PR DESCRIPTION
* Add `adjust'`, which forces the new value before installing it
in the sequence.

* Improve the documentation for `lookup`.

* Cut out some unnecessary code from `traverse`.