### PR TITLE
Stop using hedge algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cabal.sandbox.config
 /benchmarks/bench-IntSet
 /benchmarks/bench-IntMap
 /benchmarks/bench-Sequence
+/benchmarks/SetOperations/bench-*

--- a/Data/IntMap/Base.hs
+++ b/Data/IntMap/Base.hs
@@ -250,7 +250,9 @@ import Data.Utils.StrictPair
 import Data.Data (Data(..), Constr, mkConstr, constrIndex, Fixity(Prefix),
                   DataType, mkDataType)
 import GHC.Exts (build)
+#if !MIN_VERSION_base(4,8,0)
 import Data.Functor ((<$))
+#endif
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
 #endif

--- a/Data/Utils/StrictMaybe.hs
+++ b/Data/Utils/StrictMaybe.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE CPP #-}
+
+#include "containers.h"
+
 module Data.Utils.StrictMaybe (MaybeS (..), maybeS, toMaybe, toMaybeS) where
+
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable (..))
 import Data.Monoid (Monoid (..))
+#endif
 
 data MaybeS a = NothingS | JustS !a
 

--- a/changelog.md
+++ b/changelog.md
@@ -73,6 +73,11 @@
 
   * Add rewrite rules to fuse `fmap` with `reverse` for `Data.Sequence`.
 
+  * Switch from *hedge* algorithms to *divide-and-conquer* algorithms
+    for union, intersection, difference, and merge in both `Data.Map`
+    and `Data.Set`. These algorithms are simpler, are known to be
+    asymptotically optimal, and are faster according to our benchmarks.
+
   * Speed up `adjust` for `Data.Map`. Allow `map` to inline, and
     define a custom `(<$)`. This considerably improves mapping with
     a constant function.


### PR DESCRIPTION
Replace hedge algorithms with divide and conquer algorithms for unions,
intersections, differences, and merges in `Data.Set` and `Data.Map`. The
divide and conquer algorithms

* are much simpler,

* have recently been proven asymptotically optimal, and

* are faster on most benchmarks, sometimes much faster, and never
  much slower.