### PR TITLE
Use pointer equality to enhance sharing for Sets

### DIFF
--- a/Data/Utils/PtrEquality.hs
+++ b/Data/Utils/PtrEquality.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE MagicHash #-}
+#endif
+
+module Data.Utils.PtrEquality (ptrEq) where
+
+#ifdef __GLASGOW_HASKELL__
+import GHC.Exts ( reallyUnsafePtrEquality# )
+
+-- | Checks if two pointers are equal. Yes means yes;
+-- no means maybe. The values should be forced to at least
+-- WHNF before comparison to get moderately reliable results.
+ptrEq :: a -> a -> Bool
+ptrEq x y = case reallyUnsafePtrEquality# x y of
+              1# -> True
+              _ -> False
+
+#else
+ptrEq :: a -> a -> Bool
+ptrEq _ _ = False
+#endif
+
+{-# INLINE ptrEq #-}
+
+infix 4 `ptrEq`

--- a/containers.cabal
+++ b/containers.cabal
@@ -62,6 +62,7 @@ Library
         Data.Utils.StrictFold
         Data.Utils.StrictPair
         Data.Utils.StrictMaybe
+        Data.Utils.PtrEquality
 
     include-dirs: include
 


### PR DESCRIPTION
Use pointer equality to avoid allocating new copies of existing
structures. This helps a number of benchmarks a *lot*. Unfortunately,
it hurts some others a little.