### PR TITLE
Use isTrue# for pointer equality

### DIFF
--- a/Data/Utils/PtrEquality.hs
+++ b/Data/Utils/PtrEquality.hs
@@ -7,14 +7,21 @@ module Data.Utils.PtrEquality (ptrEq) where
 
 #ifdef __GLASGOW_HASKELL__
 import GHC.Exts ( reallyUnsafePtrEquality# )
+#if __GLASGOW_HASKELL__ < 707
+import GHC.Exts ( (==#) )
+#else
+import GHC.Exts ( isTrue# )
+#endif
 
 -- | Checks if two pointers are equal. Yes means yes;
 -- no means maybe. The values should be forced to at least
 -- WHNF before comparison to get moderately reliable results.
 ptrEq :: a -> a -> Bool
-ptrEq x y = case reallyUnsafePtrEquality# x y of
-              1# -> True
-              _ -> False
+#if __GLASGOW_HASKELL__ < 707
+ptrEq x y = reallyUnsafePtrEquality# x y ==# 1#
+#else
+ptrEq x y = isTrue# (reallyUnsafePtrEquality# x y)
+#endif
 
 #else
 ptrEq :: a -> a -> Bool


### PR DESCRIPTION
Edward Kmett says it's better to do that and take the load off
core-to-core. Currently, that gets shifted to codegen, I think.