### PR TITLE
Add general merge functions for Data.Map

### DIFF
--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -117,7 +117,13 @@ module Data.Map.Lazy (
     , intersectionWith
     , intersectionWithKey
 
-    -- ** Universal combining function
+    -- ** General combining functions
+#ifdef __GLASGOW_HASKELL__
+    , MergeTactic (..)
+    , SimpleMergeTactic
+    , generalMerge
+    , generalMergeA
+#endif
     , mergeWithKey
 
     -- * Traversal

--- a/Data/Utils/PtrEquality.hs
+++ b/Data/Utils/PtrEquality.hs
@@ -7,7 +7,6 @@ module Data.Utils.PtrEquality (ptrEq) where
 
 #ifdef __GLASGOW_HASKELL__
 import GHC.Exts ( reallyUnsafePtrEquality# )
-import Unsafe.Coerce (unsafeCoerce)
 #if __GLASGOW_HASKELL__ < 707
 import GHC.Exts ( (==#) )
 #else

--- a/tests/map-properties.hs
+++ b/tests/map-properties.hs
@@ -25,7 +25,7 @@ import Test.Framework.Providers.QuickCheck2
 import Test.HUnit hiding (Test, Testable)
 import Test.QuickCheck
 import Test.QuickCheck.Function (Fun (..), apply)
-import Test.QuickCheck.Poly (A)
+import Test.QuickCheck.Poly (A,B)
 import Control.Arrow (first)
 
 default (Int)
@@ -138,6 +138,7 @@ main = defaultMain
          , testCase "minViewWithKey" test_minViewWithKey
          , testCase "maxViewWithKey" test_maxViewWithKey
          , testCase "valid" test_valid
+         , testProperty "differenceGenMerge"   prop_differenceGenMerge
          , testProperty "valid"                prop_valid
          , testProperty "insert to singleton"  prop_singleton
          , testProperty "insert"               prop_insert
@@ -168,6 +169,7 @@ main = defaultMain
          , testProperty "intersectionWithModel" prop_intersectionWithModel
          , testProperty "intersectionWithKey"  prop_intersectionWithKey
          , testProperty "intersectionWithKeyModel" prop_intersectionWithKeyModel
+         , testProperty "unionWithKeyGeneralMerge"   prop_unionWithKeyGeneralMerge
          , testProperty "mergeWithKey model"   prop_mergeWithKeyModel
          , testProperty "fromAscList"          prop_ordered
          , testProperty "fromDescList"         prop_rev_ordered
@@ -909,6 +911,18 @@ test_valid = do
 ----------------------------------------------------------------
 -- QuickCheck
 ----------------------------------------------------------------
+
+prop_differenceGenMerge :: Fun (Int, A, B) (Maybe A) -> Map Int A -> Map Int B -> Property
+prop_differenceGenMerge f m1 m2 =
+  differenceWithKey (apply3 f) m1 m2 === generalMerge Preserve Drop (apply3 f) m1 m2
+
+prop_unionWithKeyGeneralMerge :: Fun (Int, A, A) A -> Map Int A -> Map Int A -> Property
+prop_unionWithKeyGeneralMerge f m1 m2 =
+  unionWithKey (apply3 f) m1 m2 === unionWithKey' (apply3 f) m1 m2
+
+unionWithKey' :: Ord k => (k -> a -> a -> a) -> Map k a -> Map k a -> Map k a
+unionWithKey' f = generalMerge Preserve Preserve (\k a b -> Just (f k a b))
+
 
 prop_valid :: UMap -> Bool
 prop_valid t = valid t


### PR DESCRIPTION
Add `generalMerge` and `generalMergeA`. `generalMerge` is a
safe version of `mergeWithKey` that offers nearly as much useful
power but prevents users from accidentally violating internal
invariants and preserves the abstraction barrier. `generalMergeA`
is an `Applicative` version.