### PR TITLE
Add more indexed and unsafe functions for Data.Map

### DIFF
--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && __GLASGOW_HASKELL__ >= 703
+#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Safe #-}
 #endif
 
@@ -63,11 +63,7 @@ module Data.Map.Lazy (
     -- $strictness
 
     -- * Map type
-#if !defined(TESTING)
     Map              -- instance Eq,Show,Read
-#else
-    Map(..)          -- instance Eq,Show,Read
-#endif
 
     -- * Operators
     , (!), (\\)
@@ -126,7 +122,7 @@ module Data.Map.Lazy (
     -- ** General combining functions
     -- | See "Data.Map.Lazy.Merge"
 
-    -- ** Deprecated general combining function
+    -- ** Unsafe general combining function
 
     , mergeWithKey
 
@@ -188,6 +184,9 @@ module Data.Map.Lazy (
     , withoutKeys
     , partition
     , partitionWithKey
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
 
     , mapMaybe
     , mapMaybeWithKey
@@ -208,6 +207,9 @@ module Data.Map.Lazy (
     , elemAt
     , updateAt
     , deleteAt
+    , take
+    , drop
+    , splitAt
 
     -- * Min\/Max
     , findMin
@@ -229,18 +231,10 @@ module Data.Map.Lazy (
     , showTree
     , showTreeWith
     , valid
-
-#if defined(TESTING)
-    -- * Internals
-    , bin
-    , balanced
-    , link
-    , link2
-#endif
-
     ) where
 
 import Data.Map.Base as M
+import Prelude ()
 
 -- $strictness
 --

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -193,6 +193,10 @@ module Data.Map.Strict
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -212,6 +216,9 @@ module Data.Map.Strict
     , elemAt
     , updateAt
     , deleteAt
+    , take
+    , drop
+    , splitAt
 
     -- * Min\/Max
     , findMin

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -247,6 +247,9 @@ module Data.Map.Strict.Internal
     , withoutKeys
     , partition
     , partitionWithKey
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
 
     , mapMaybe
     , mapMaybeWithKey
@@ -267,6 +270,9 @@ module Data.Map.Strict.Internal
     , elemAt
     , updateAt
     , deleteAt
+    , take
+    , drop
+    , splitAt
 
     -- * Min\/Max
     , findMin
@@ -295,7 +301,7 @@ module Data.Map.Strict.Internal
     , link2
     ) where
 
-import Prelude hiding (lookup,map,filter,foldr,foldl,null)
+import Prelude hiding (lookup,map,filter,foldr,foldl,null,take,drop,splitAt)
 
 import Data.Map.Base
   ( Map (..)
@@ -332,6 +338,8 @@ import Data.Map.Base
   , deleteMin
   , deleteMax
   , difference
+  , drop
+  , dropWhileAntitone
   , filter
   , filterWithKey
   , findIndex
@@ -378,9 +386,13 @@ import Data.Map.Base
   , showTree
   , showTreeWith
   , size
+  , spanAntitone
   , split
+  , splitAt
   , splitLookup
   , splitRoot
+  , take
+  , takeWhileAntitone
   , toList
   , toAscList
   , toDescList


### PR DESCRIPTION
* Offer `take`, `drop`, and `splitAt` by index.

* Offer 'takeWhileAntitone`, `dropWhileAntitone`, and `spanAntitone`.