### PR TITLE
Quit using deleteFindMin and deleteFindMax

### DIFF
--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -66,7 +66,7 @@ module Data.Map.Lazy (
     Map              -- instance Eq,Show,Read
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , null
@@ -212,6 +212,8 @@ module Data.Map.Lazy (
     , splitAt
 
     -- * Min\/Max
+    , lookupMin
+    , lookupMax
     , findMin
     , findMax
     , deleteMin

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -74,7 +74,7 @@ module Data.Map.Strict
     Map              -- instance Eq,Show,Read
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , null
@@ -221,6 +221,8 @@ module Data.Map.Strict
     , splitAt
 
     -- * Min\/Max
+    , lookupMin
+    , lookupMax
     , findMin
     , findMax
     , deleteMin

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -88,7 +88,7 @@ module Data.Map.Strict.Internal
     Map(..)          -- instance Eq,Show,Read
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , null
@@ -273,6 +273,8 @@ module Data.Map.Strict.Internal
     , splitAt
 
     -- * Min\/Max
+    , lookupMin
+    , lookupMax
     , findMin
     , findMax
     , deleteMin
@@ -312,6 +314,7 @@ import Data.Map.Internal
   , merge
   , mergeA
   , (!)
+  , (!?)
   , (\\)
   , assocs
   , atKeyImpl
@@ -363,6 +366,8 @@ import Data.Map.Internal
   , lookupIndex
   , lookupLE
   , lookupLT
+  , lookupMin
+  , lookupMax
   , mapKeys
   , mapKeysMonotonic
   , maxView

--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -121,6 +121,8 @@ module Data.Set (
             , fold
 
             -- * Min\/Max
+            , lookupMin
+            , lookupMax
             , findMin
             , findMax
             , deleteMin

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,15 @@
 * Plug space leaks in `Data.Map.Lazy.fromAscList` and
  `Data.Map.Lazy.fromDescList` by manually inlining constant functions.
 
+* Add `lookupMin` and `lookupMax` to `Data.Set` and `Data.Map` as total
+alternatives to `findMin` and `findMax`.
+
+* Add `!?` to `Data.Map` as a total alternative to `!`.
+
+* Avoid using `deleteFindMin` and `deleteFindMax` internally, preferring
+total functions instead. New implementations of said functions lead to slight
+performance improvements overall.
+
 ## 0.5.8.1 *Aug 2016*
 
 ### General package changes

--- a/tests/map-properties.hs
+++ b/tests/map-properties.hs
@@ -222,6 +222,8 @@ main = defaultMain
          , testProperty "take"                 prop_take
          , testProperty "drop"                 prop_drop
          , testProperty "splitAt"              prop_splitAt
+         , testProperty "lookupMin"            prop_lookupMin
+         , testProperty "lookupMax"            prop_lookupMax
          ]
 
 {--------------------------------------------------------------------
@@ -960,6 +962,12 @@ prop_deleteMin t = valid $ deleteMin $ deleteMin t
 
 prop_deleteMax :: UMap -> Bool
 prop_deleteMax t = valid $ deleteMax $ deleteMax t
+
+prop_lookupMin :: IMap -> Property
+prop_lookupMin m = lookupMin m === (fst <$> minViewWithKey m)
+
+prop_lookupMax :: IMap -> Property
+prop_lookupMax m = lookupMax m === (fst <$> maxViewWithKey m)
 
 ----------------------------------------------------------------
 

--- a/tests/set-properties.hs
+++ b/tests/set-properties.hs
@@ -67,6 +67,8 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testProperty "prop_isSubsetOf" prop_isSubsetOf
                    , testProperty "prop_isSubsetOf2" prop_isSubsetOf2
                    , testProperty "prop_size" prop_size
+                   , testProperty "prop_lookupMax" prop_lookupMax
+                   , testProperty "prop_lookupMin" prop_lookupMin
                    , testProperty "prop_findMax" prop_findMax
                    , testProperty "prop_findMin" prop_findMin
                    , testProperty "prop_ord" prop_ord
@@ -492,6 +494,12 @@ prop_findMax s = not (null s) ==> findMax s == maximum (toList s)
 
 prop_findMin :: Set Int -> Property
 prop_findMin s = not (null s) ==> findMin s == minimum (toList s)
+
+prop_lookupMin :: Set Int -> Property
+prop_lookupMin m = lookupMin m === (fst <$> minView m)
+
+prop_lookupMax :: Set Int -> Property
+prop_lookupMax m = lookupMax m === (fst <$> maxView m)
 
 prop_ord :: TwoSets -> Bool
 prop_ord (TwoSets s1 s2) = s1 `compare` s2 == toList s1 `compare` toList s2


### PR DESCRIPTION
* The `deleteFindMin` and `deleteFindMax` functions are partial,
and also rather ugly. Reimplement `minView`, `minViewWithKey`,
`glue`, etc., using total functions. This produces pretty
core as well.

* Add `lookupMin` and `lookupMax`, total versions of `findMin`
and `findMax`.