### PR TITLE
Make min and max views more eager

### DIFF
--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -64,7 +64,7 @@ module Data.IntMap.Lazy (
 #endif
 
     -- * Operators
-    , (!), (\\)
+    , (!?), (!), (\\)
 
     -- * Query
     , IM.null
@@ -188,6 +188,8 @@ module Data.IntMap.Lazy (
     , isProperSubmapOf, isProperSubmapOfBy
 
     -- * Min\/Max
+    , lookupMin
+    , lookupMax
     , findMin
     , findMax
     , deleteMin

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -71,7 +71,7 @@ module Data.IntMap.Strict (
 #endif
 
     -- * Operators
-    , (!), (\\)
+    , (!?), (!), (\\)
 
     -- * Query
     , null
@@ -195,6 +195,8 @@ module Data.IntMap.Strict (
     , isProperSubmapOf, isProperSubmapOfBy
 
     -- * Min\/Max
+    , lookupMin
+    , lookupMax
     , findMin
     , findMax
     , deleteMin

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -428,6 +428,8 @@ infixl 9 !,!?,\\ --
 --
 -- prop> fromList [(5, 'a'), (3, 'b')] !? 1 == Nothing
 -- prop> fromList [(5, 'a'), (3, 'b')] !? 5 == Just 'a'
+--
+-- @since 0.5.9
 
 (!?) :: Ord k => Map k a -> k -> Maybe a
 (!?) m k = lookup k m

--- a/changelog.md
+++ b/changelog.md
@@ -15,14 +15,19 @@
 * Plug space leaks in `Data.Map.Lazy.fromAscList` and
  `Data.Map.Lazy.fromDescList` by manually inlining constant functions.
 
-* Add `lookupMin` and `lookupMax` to `Data.Set` and `Data.Map` as total
-alternatives to `findMin` and `findMax`.
+* Add `lookupMin` and `lookupMax` to `Data.Set`, `Data.Map`, and `Data.IntMap`
+as total alternatives to `findMin` and `findMax`.
 
-* Add `!?` to `Data.Map` as a total alternative to `!`.
+* Add `!?` to `Data.Map` and `Data.IntMap` as a total alternative to `!`.
 
-* Avoid using `deleteFindMin` and `deleteFindMax` internally, preferring
-total functions instead. New implementations of said functions lead to slight
-performance improvements overall.
+* Set the fixity of `Data.IntMap.!` to match that of `Data.Map.!`.
+
+* Avoid using `deleteFindMin` and `deleteFindMax` internally in `Data.Map`,
+preferring total functions instead. New implementations of said functions lead
+to slight performance improvements overall.
+
+* Make more update functions total. Historically, many have thrown errors
+when given missing keys. Now, we prefer to return the structures unchanged.
 
 ## 0.5.8.1 *Aug 2016*
 

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -167,6 +167,8 @@ main = defaultMain
              , testProperty "foldl'"               prop_foldl'
              , testProperty "keysSet"              prop_keysSet
              , testProperty "fromSet"              prop_fromSet
+             , testProperty "minViewWithKey"       prop_minViewWithKey
+             , testProperty "maxViewWithKey"       prop_maxViewWithKey
              ]
 
 apply2 :: Fun (a, b) c -> a -> b -> c
@@ -755,6 +757,16 @@ prop_insertDelete k t = (lookup k t == Nothing) ==> (delete k (insert k () t) ==
 
 prop_deleteNonMember :: Int -> UMap -> Property
 prop_deleteNonMember k t = (lookup k t == Nothing) ==> (delete k t == t)
+
+prop_minViewWithKey :: IMap -> Property
+prop_minViewWithKey t = case minViewWithKey t of
+  Nothing -> null t === True
+  Just ((k,x), t') -> size t === size t' + 1 .&&. t === insert k x t' .&&. all ((>k) . fst) (toList t')
+
+prop_maxViewWithKey :: IMap -> Property
+prop_maxViewWithKey t = case maxViewWithKey t of
+  Nothing -> null t === True
+  Just ((k,x), t') -> size t === size t' + 1 .&&. t === insert k x t' .&&. all ((<k) . fst) (toList t')
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
- Make min and max views in `Data.IntMap` more
  eager, and structure them to reveal `Nothing` or `Just` as soon as
  possible. This lets GHC erase `Maybe` constructors and unbox tuples, at
  least when it's in a good mood.
- Add `lookupMin` and `lookupMax` to `Data.IntMap`
  as total alternatives to `findMin` and `findMax`.
- Add `!?` to `Data.IntMap` as a total alternative to `!`.
- Set the fixity of `Data.IntMap.!` to match that of `Data.Map.!`.
- Make more update functions total. Historically, many have thrown
  errors when given missing keys. Now, we prefer to return the structures
  unchanged.
