### PR TITLE
Add function to check if two `IntSet`s are `disjoint`.

### DIFF
--- a/Data/IntSet.hs
+++ b/Data/IntSet.hs
@@ -74,6 +74,7 @@ module Data.IntSet (
             , lookupGE
             , isSubsetOf
             , isProperSubsetOf
+            , disjoint
 
             -- * Construction
             , empty

--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -118,6 +118,7 @@ module Data.IntSet.Internal (
     , lookupGE
     , isSubsetOf
     , isProperSubsetOf
+    , disjoint
 
     -- * Construction
     , empty
@@ -657,6 +658,54 @@ isSubsetOf t1@(Tip kx _) (Bin p m l r)
   | otherwise      = isSubsetOf t1 r
 isSubsetOf (Tip _ _) Nil = False
 isSubsetOf Nil _         = True
+
+
+{--------------------------------------------------------------------
+  Disjoint
+--------------------------------------------------------------------}
+-- | /O(n+m)/. Check whether two sets are disjoint (i.e. their intersection
+--   is empty).
+--
+-- > disjoint (fromList [2,4,6])   (fromList [1,3])     == True
+-- > disjoint (fromList [2,4,6,8]) (fromList [2,3,5,7]) == False
+-- > disjoint (fromList [1,2])     (fromList [1,2,3,4]) == False
+-- > disjoint (fromList [])        (fromList [])        == True
+--
+-- @since 0.5.11
+disjoint :: IntSet -> IntSet -> Bool
+disjoint t1@(Bin p1 m1 l1 r1) t2@(Bin p2 m2 l2 r2)
+  | shorter m1 m2  = disjoint1
+  | shorter m2 m1  = disjoint2
+  | p1 == p2       = disjoint l1 l2 && disjoint r1 r2
+  | otherwise      = True
+  where
+    disjoint1 | nomatch p2 p1 m1  = True
+              | zero p2 m1        = disjoint l1 t2
+              | otherwise         = disjoint r1 t2
+
+    disjoint2 | nomatch p1 p2 m2  = True
+              | zero p1 m2        = disjoint t1 l2
+              | otherwise         = disjoint t1 r2
+
+disjoint t1@(Bin _ _ _ _) (Tip kx2 bm2) = disjointBM t1
+  where disjointBM (Bin p1 m1 l1 r1) | nomatch kx2 p1 m1 = True
+                                     | zero kx2 m1       = disjointBM l1
+                                     | otherwise         = disjointBM r1
+        disjointBM (Tip kx1 bm1) | kx1 == kx2 = (bm1 .&. bm2) == 0
+                                 | otherwise = True
+        disjointBM Nil = True
+
+disjoint (Bin _ _ _ _) Nil = True
+
+disjoint (Tip kx1 bm1) t2 = disjointBM t2
+  where disjointBM (Bin p2 m2 l2 r2) | nomatch kx1 p2 m2 = True
+                                     | zero kx1 m2       = disjointBM l2
+                                     | otherwise         = disjointBM r2
+        disjointBM (Tip kx2 bm2) | kx1 == kx2 = (bm1 .&. bm2) == 0
+                                 | otherwise = True
+        disjointBM Nil = True
+
+disjoint Nil _ = True
 
 
 {--------------------------------------------------------------------

--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -74,6 +74,7 @@ module Data.Set (
             , lookupGE
             , isSubsetOf
             , isProperSubsetOf
+            , disjoint
 
             -- * Construction
             , empty

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -141,6 +141,7 @@ module Data.Set.Internal (
             , lookupGE
             , isSubsetOf
             , isProperSubsetOf
+            , disjoint
 
             -- * Construction
             , empty
@@ -622,6 +623,27 @@ isSubsetOfX (Bin _ x l r) t
 {-# INLINABLE isSubsetOfX #-}
 #endif
 
+{--------------------------------------------------------------------
+  Disjoint
+--------------------------------------------------------------------}
+-- | /O(n+m)/. Check whether two sets are disjoint (i.e. their intersection
+--   is empty).
+--
+-- > disjoint (fromList [2,4,6])   (fromList [1,3])     == True
+-- > disjoint (fromList [2,4,6,8]) (fromList [2,3,5,7]) == False
+-- > disjoint (fromList [1,2])     (fromList [1,2,3,4]) == False
+-- > disjoint (fromList [])        (fromList [])        == True
+--
+-- @since 0.5.11
+
+disjoint :: Ord a => Set a -> Set a -> Bool
+disjoint Tip _ = True
+disjoint _ Tip = True
+disjoint (Bin _ x l r) t
+  -- Analogous implementation to `subsetOfX`
+  = not found && disjoint l lt && disjoint r gt
+  where
+    (lt,found,gt) = splitMember x t
 
 {--------------------------------------------------------------------
   Minimal, Maximal

--- a/benchmarks/IntSet.hs
+++ b/benchmarks/IntSet.hs
@@ -32,6 +32,10 @@ main = do
         , bench "fromList" $ whnf S.fromList elems
         , bench "fromAscList" $ whnf S.fromAscList elems
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
+        , bench "disjoint:false" $ whnf (S.disjoint s) s_even
+        , bench "disjoint:true" $ whnf (S.disjoint s_odd) s_even
+        , bench "null.intersection:false" $ whnf (S.null. S.intersection s) s_even
+        , bench "null.intersection:true" $ whnf (S.null. S.intersection s_odd) s_even
         ]
   where
     elems = [1..2^12]

--- a/benchmarks/Set.hs
+++ b/benchmarks/Set.hs
@@ -33,6 +33,10 @@ main = do
         , bench "fromList-desc" $ whnf S.fromList (reverse elems)
         , bench "fromAscList" $ whnf S.fromAscList elems
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
+        , bench "disjoint:false" $ whnf (S.disjoint s) s_even
+        , bench "disjoint:true" $ whnf (S.disjoint s_odd) s_even
+        , bench "null.intersection:false" $ whnf (S.null. S.intersection s) s_even
+        , bench "null.intersection:true" $ whnf (S.null. S.intersection s_odd) s_even
         ]
   where
     elems = [1..2^12]

--- a/tests/intset-properties.hs
+++ b/tests/intset-properties.hs
@@ -54,6 +54,7 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testProperty "prop_isProperSubsetOf2" prop_isProperSubsetOf2
                    , testProperty "prop_isSubsetOf" prop_isSubsetOf
                    , testProperty "prop_isSubsetOf2" prop_isSubsetOf2
+                   , testProperty "prop_disjoint" prop_disjoint
                    , testProperty "prop_size" prop_size
                    , testProperty "prop_findMax" prop_findMax
                    , testProperty "prop_findMin" prop_findMin
@@ -202,7 +203,7 @@ prop_MemberFromList xs
         t = fromList abs_xs
 
 {--------------------------------------------------------------------
-  Union
+  Union, Difference and Intersection
 --------------------------------------------------------------------}
 prop_UnionInsert :: Int -> IntSet -> Property
 prop_UnionInsert x t =
@@ -232,6 +233,9 @@ prop_Int xs ys =
     t ->
       valid t .&&.
       toAscList t === List.sort (nub ((List.intersect) (xs)  (ys)))
+
+prop_disjoint :: IntSet -> IntSet -> Bool
+prop_disjoint a b = a `disjoint` b == null (a `intersection` b)
 
 {--------------------------------------------------------------------
   Lists
@@ -402,3 +406,4 @@ prop_bitcount a w = bitcount_orig a w == bitcount_new a w
             go a x = go (a + 1) (x .&. (x-1))
     bitcount_new a x = a + popCount x
 #endif
+

--- a/tests/set-properties.hs
+++ b/tests/set-properties.hs
@@ -67,6 +67,7 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testProperty "prop_isProperSubsetOf2" prop_isProperSubsetOf2
                    , testProperty "prop_isSubsetOf" prop_isSubsetOf
                    , testProperty "prop_isSubsetOf2" prop_isSubsetOf2
+                   , testProperty "prop_disjoint" prop_disjoint
                    , testProperty "prop_size" prop_size
                    , testProperty "prop_lookupMax" prop_lookupMax
                    , testProperty "prop_lookupMin" prop_lookupMin
@@ -425,6 +426,9 @@ prop_IntValid = forValidUnitTree $ \t1 ->
 prop_Int :: [Int] -> [Int] -> Bool
 prop_Int xs ys = toAscList (intersection (fromList xs) (fromList ys))
                  == List.sort (nub ((List.intersect) (xs)  (ys)))
+
+prop_disjoint :: Set Int -> Set Int -> Bool
+prop_disjoint a b = a `disjoint` b == null (a `intersection` b)
 
 {--------------------------------------------------------------------
   Lists


### PR DESCRIPTION
This function is equivalent to computing the intersection and checking
if it is empty. However, it is more efficient because the intersection
set does not need to be built in memory, and the computation can
be short-circuited as soon as two non-disjoint `Tip`s are found.