### PR TITLE
Use countTrailingZeros for indexOfTheOnlyBit

### DIFF
--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1418,6 +1418,11 @@ indexOfTheOnlyBit :: Nat -> Int
 {-# INLINE indexOfTheOnlyBit #-}
 #if MIN_VERSION_base(4,8,0) && (WORD_SIZE_IN_BITS==64)
 indexOfTheOnlyBit bitmask = countTrailingZeros bitmask
+
+lowestBitSet x = countTrailingZeros x
+
+highestBitSet x = WORD_SIZE_IN_BITS - 1 - countLeadingZeros x
+
 #else
 {----------------------------------------------------------------------
   For lowestBitSet we use wordsize-dependant implementation based on
@@ -1451,6 +1456,10 @@ indexOfTheOnlyBit bitmask =
 -- is 48B on 32-bit and 56B on 64-bit architectures -- so the 32B and 64B array
 -- is actually improvement on 32-bit and only a 8B size increase on 64-bit.
 
+lowestBitSet x = indexOfTheOnlyBit (lowestBitMask x)
+
+highestBitSet x = indexOfTheOnlyBit (highestBitMask x)
+
 #endif
 
 lowestBitMask :: Nat -> Nat
@@ -1473,10 +1482,6 @@ revNat x1 = case ((x1 `shiftRL` 1) .&. 0x5555555555555555) .|. ((x1 .&. 0x555555
                      x5 -> case ((x5 `shiftRL` 16) .&. 0x0000FFFF0000FFFF) .|. ((x5 .&. 0x0000FFFF0000FFFF) `shiftLL` 16) of
                        x6 -> ( x6 `shiftRL` 32             ) .|. ( x6               `shiftLL` 32);
 #endif
-
-lowestBitSet x = indexOfTheOnlyBit (lowestBitMask x)
-
-highestBitSet x = indexOfTheOnlyBit (highestBitMask x)
 
 foldlBits prefix f z bitmap = go bitmap z
   where go 0 acc = acc

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1414,6 +1414,11 @@ foldr'Bits :: Int -> (Int -> a -> a) -> a -> Nat -> a
 {-# INLINE foldr'Bits #-}
 
 #if defined(__GLASGOW_HASKELL__) && (WORD_SIZE_IN_BITS==32 || WORD_SIZE_IN_BITS==64)
+indexOfTheOnlyBit :: Nat -> Int
+{-# INLINE indexOfTheOnlyBit #-}
+#if MIN_VERSION_base(4,8,0) && (WORD_SIZE_IN_BITS==64)
+indexOfTheOnlyBit bitmask = countTrailingZeros bitmask
+#else
 {----------------------------------------------------------------------
   For lowestBitSet we use wordsize-dependant implementation based on
   multiplication and DeBrujn indeces, which was proposed by Edward Kmett
@@ -1427,8 +1432,6 @@ foldr'Bits :: Int -> (Int -> a -> a) -> a -> Nat -> a
   before changing this code.
 ----------------------------------------------------------------------}
 
-indexOfTheOnlyBit :: Nat -> Int
-{-# INLINE indexOfTheOnlyBit #-}
 indexOfTheOnlyBit bitmask =
   I# (lsbArray `indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
   where unboxInt (I# i) = i
@@ -1447,6 +1450,8 @@ indexOfTheOnlyBit bitmask =
 -- as NOINLINE. But the code size of calling it and processing the result
 -- is 48B on 32-bit and 56B on 64-bit architectures -- so the 32B and 64B array
 -- is actually improvement on 32-bit and only a 8B size increase on 64-bit.
+
+#endif
 
 lowestBitMask :: Nat -> Nat
 lowestBitMask x = x .&. negate x


### PR DESCRIPTION
This is an experiment for `indexOfTheOnlyBit`. I haven't benchmarked yet. But will do so tonight. 