### PR TITLE
Retarget Haddocks to point to new merge modules

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -1574,7 +1574,7 @@ dropMissing = WhenMissing
 --
 -- > preserveMissing :: SimpleWhenMissing x x
 --
--- prop> preserveMissing = Lazy.Merge.mapMaybeMissing (\_ x -> Just x)
+-- prop> preserveMissing = Merge.Lazy.mapMaybeMissing (\_ x -> Just x)
 --
 -- but @preserveMissing@ is much faster.
 preserveMissing :: Applicative f => WhenMissing f x x
@@ -1620,7 +1620,7 @@ mapMaybeMissing f = WhenMissing
 --
 -- > filterMissing :: (k -> x -> Bool) -> SimpleWhenMissing x x
 --
--- prop> filterMissing f = Lazy.Merge.mapMaybeMissing $ \k x -> guard (f k x) *> Just x
+-- prop> filterMissing f = Merge.Lazy.mapMaybeMissing $ \k x -> guard (f k x) *> Just x
 --
 -- but this should be a little faster.
 filterMissing
@@ -1634,7 +1634,7 @@ filterMissing f = WhenMissing
 -- | Filter the entries whose keys are missing from the other map
 -- using some 'Applicative' action.
 --
--- > filterAMissing f = Lazy.Merge.traverseMaybeMissing $
+-- > filterAMissing f = Merge.Lazy.traverseMaybeMissing $
 -- >   \k x -> (\b -> guard b *> Just x) <$> f k x
 --
 -- but this should be a little faster.

--- a/Data/IntMap/Merge/Lazy.hs
+++ b/Data/IntMap/Merge/Lazy.hs
@@ -33,9 +33,9 @@
 --
 -- The 'merge' and 'mergeA' functions are shared by
 -- the lazy and strict modules. Only the choice of merge tactics
--- determines strictness. If you use 'Data.Map.Strict.Merge.mapMissing'
--- from "Data.Map.Strict.Merge" then the results will be forced before
--- they are inserted. If you use 'Data.Map.Lazy.Merge.mapMissing' from
+-- determines strictness. If you use 'Data.Map.Merge.Strict.mapMissing'
+-- from "Data.Map.Merge.Strict" then the results will be forced before
+-- they are inserted. If you use 'Data.Map.Merge.Lazy.mapMissing' from
 -- this module then they will not.
 --
 -- == Efficiency note

--- a/Data/IntMap/Merge/Strict.hs
+++ b/Data/IntMap/Merge/Strict.hs
@@ -33,10 +33,10 @@
 --
 -- The 'merge' and 'mergeA' functions are shared by
 -- the lazy and strict modules. Only the choice of merge tactics
--- determines strictness. If you use 'Data.Map.Strict.Merge.mapMissing'
+-- determines strictness. If you use 'Data.Map.Merge.Strict.mapMissing'
 -- from this module then the results will be forced before they are
--- inserted. If you use 'Data.Map.Lazy.Merge.mapMissing' from
--- "Data.Map.Lazy.Merge" then they will not.
+-- inserted. If you use 'Data.Map.Merge.Lazy.mapMissing' from
+-- "Data.Map.Merge.Lazy" then they will not.
 --
 -- == Efficiency note
 --

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -348,7 +348,7 @@ module Data.Map.Internal (
     , MaybeS(..)
     , Identity(..)
 
-    -- Used by Map.Lazy.Merge
+    -- Used by Map.Merge.Lazy
     , mapWhenMissing
     , mapWhenMatched
     , lmapWhenMissing
@@ -2257,7 +2257,7 @@ dropMissing = WhenMissing
 -- preserveMissing :: SimpleWhenMissing k x x
 -- @
 --
--- prop> preserveMissing = Lazy.Merge.mapMaybeMissing (\_ x -> Just x)
+-- prop> preserveMissing = Merge.Lazy.mapMaybeMissing (\_ x -> Just x)
 --
 -- but @preserveMissing@ is much faster.
 preserveMissing :: Applicative f => WhenMissing f k x x
@@ -2304,7 +2304,7 @@ mapMaybeMissing f = WhenMissing
 -- filterMissing :: (k -> x -> Bool) -> SimpleWhenMissing k x x
 -- @
 --
--- prop> filterMissing f = Lazy.Merge.mapMaybeMissing $ \k x -> guard (f k x) *> Just x
+-- prop> filterMissing f = Merge.Lazy.mapMaybeMissing $ \k x -> guard (f k x) *> Just x
 --
 -- but this should be a little faster.
 filterMissing :: Applicative f
@@ -2318,7 +2318,7 @@ filterMissing f = WhenMissing
 -- using some 'Applicative' action.
 --
 -- @
--- filterAMissing f = Lazy.Merge.traverseMaybeMissing $
+-- filterAMissing f = Merge.Lazy.traverseMaybeMissing $
 --   \k x -> (\b -> guard b *> Just x) <$> f k x
 -- @
 --

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -120,7 +120,7 @@ module Data.Map.Lazy (
     , intersectionWithKey
 
     -- ** General combining functions
-    -- | See "Data.Map.Lazy.Merge"
+    -- | See "Data.Map.Merge.Lazy"
 
     -- ** Unsafe general combining function
 

--- a/Data/Map/Merge/Lazy.hs
+++ b/Data/Map/Merge/Lazy.hs
@@ -33,9 +33,9 @@
 --
 -- The 'merge' and 'mergeA' functions are shared by
 -- the lazy and strict modules. Only the choice of merge tactics
--- determines strictness. If you use 'Data.Map.Strict.Merge.mapMissing'
--- from "Data.Map.Strict.Merge" then the results will be forced before
--- they are inserted. If you use 'Data.Map.Lazy.Merge.mapMissing' from
+-- determines strictness. If you use 'Data.Map.Merge.Strict.mapMissing'
+-- from "Data.Map.Merge.Strict" then the results will be forced before
+-- they are inserted. If you use 'Data.Map.Merge.Lazy.mapMissing' from
 -- this module then they will not.
 --
 -- == Efficiency note

--- a/Data/Map/Merge/Strict.hs
+++ b/Data/Map/Merge/Strict.hs
@@ -33,10 +33,10 @@
 --
 -- The 'merge' and 'mergeA' functions are shared by
 -- the lazy and strict modules. Only the choice of merge tactics
--- determines strictness. If you use 'Data.Map.Strict.Merge.mapMissing'
+-- determines strictness. If you use 'Data.Map.Merge.Strict.mapMissing'
 -- from this module then the results will be forced before they are
--- inserted. If you use 'Data.Map.Lazy.Merge.mapMissing' from
--- "Data.Map.Lazy.Merge" then they will not.
+-- inserted. If you use 'Data.Map.Merge.Lazy.mapMissing' from
+-- "Data.Map.Merge.Lazy" then they will not.
 --
 -- == Efficiency note
 --

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -128,7 +128,7 @@ module Data.Map.Strict
     , intersectionWithKey
 
     -- ** General combining functions
-    -- | See "Data.Map.Strict.Merge"
+    -- | See "Data.Map.Merge.Strict"
 
     -- ** Deprecated general combining function
 

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -1193,8 +1193,8 @@ forceMaybe m@(Just !_) = m
 --
 -- WARNING: This function can produce corrupt maps and its results
 -- may depend on the internal structures of its inputs. Users should
--- prefer 'Data.Map.Strict.Merge.merge' or
--- 'Data.Map.Strict.Merge.mergeA'.
+-- prefer 'Data.Map.Merge.Strict.merge' or
+-- 'Data.Map.Merge.Strict.mergeA'.
 --
 -- When 'mergeWithKey' is given three arguments, it is inlined to the call
 -- site. You should therefore use 'mergeWithKey' only to define custom


### PR DESCRIPTION
We had a bunch of stale links to `Strict.Merge` and `Lazy.Merge`.
Fix them all, hopefully.