### PR TITLE
Optimize IntMap's withoutKeys

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -1153,13 +1153,19 @@ lookupPrefix _ Nil = Nil
 
 
 restrictBM :: IntSetBitMap -> IntMap a -> IntMap a
+{-
+-- See note below about 'bitmapForBin'.
 restrictBM 0 _ = Nil
+-}
 restrictBM bm (Bin p m l r) =
-    -- Assuming 'bitmapForBin' actually works correctly...
+    {-
+    -- Assuming 'bitmapForBin' actually worked correctly, this would let us short-circuit by hitting the 0 case above.
     let m'  = intFromNat (natFromInt m `shiftRL` 1)
         bmL = bitmapForBin p m'
         bmR = bitmapForBin (p .|. m) m'
     in bin p m (restrictBM bmL l) (restrictBM bmR r)
+    -}
+    bin p m (restrictBM bm l) (restrictBM bm r)
 restrictBM bm t@(Tip k _)
     -- TODO(wrengr): need we manually inline 'IntSet.Member' here?
     | k `IntSet.member` IntSet.Tip (k .&. IntSet.prefixBitMask) bm = t
@@ -1167,6 +1173,7 @@ restrictBM bm t@(Tip k _)
 restrictBM _ Nil = Nil
 
 
+{-
 -- TODO(wrengr): this is buggy somehow.
 -- | Return an `IntSet`-bitmap for all keys that could possibly be
 -- contained in an `IntMap`-`Bin` with the given prefix and switching
@@ -1192,6 +1199,7 @@ bitmapForBin p m =
     bitmapOf i = shiftLL 1 (i .&. IntSet.suffixBitMask)
     {-# INLINE bitmapOf #-}
 {-# INLINE bitmapForBin #-}
+-}
 
 
 -- | /O(n+m)/. The intersection with a combining function.

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -353,6 +353,16 @@ data IntMap a = Bin {-# UNPACK #-} !Prefix
 type Prefix = Int
 type Mask   = Int
 
+
+-- Some stuff from "Data.IntSet.Internal", for 'restrictKeys' and
+-- 'withoutKeys' to use.
+type IntSetPrefix = Int
+type IntSetBitMap = Word
+
+bitmapOf :: Int -> IntSetBitMap
+bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)
+{-# INLINE bitmapOf #-}
+
 {--------------------------------------------------------------------
   Operators
 --------------------------------------------------------------------}
@@ -1035,7 +1045,9 @@ differenceWithKey :: (Key -> a -> b -> Maybe a) -> IntMap a -> IntMap b -> IntMa
 differenceWithKey f m1 m2
   = mergeWithKey f id (const Nil) m1 m2
 
--- | Remove all the keys in a given set from a map.
+
+-- TODO(wrengr): re-verify that asymptotic bound
+-- | /O(n+m)/. Remove all the keys in a given set from a map.
 --
 -- @
 -- m `withoutKeys` s = 'filterWithKey' (\k _ -> k `'IntSet.notMember'` s) m
@@ -1057,8 +1069,14 @@ withoutKeys t1@(Bin p1 m1 l1 r1) t2@(IntSet.Bin p2 m2 l2 r2)
         | nomatch p1 p2 m2  = t1
         | zero p1 m2        = withoutKeys t1 l2
         | otherwise         = withoutKeys t1 r2
-withoutKeys t1@(Bin _ _ _ _) (IntSet.Tip p2 bm2) =
-    withoutBM t1 p2 bm2 (IntSet.suffixBitMask + 1)
+withoutKeys t1@(Bin p1 m1 _ _) (IntSet.Tip p2 bm2) =
+    let minbit = bitmapOf p1
+        lt_minbit = minbit - 1
+        maxbit = bitmapOf (p1 .|. (m1 .|. (m1 - 1)))
+        gt_maxbit = maxbit `xor` complement (maxbit - 1)
+    -- TODO(wrengr): should we manually inline/unroll 'updatePrefix'
+    -- and 'withoutBM' here, in order to avoid redundant case analyses?
+    in updatePrefix p2 t1 $ withoutBM (bm2 .|. lt_minbit .|. gt_maxbit)
 withoutKeys t1@(Bin _ _ _ _) IntSet.Nil = t1
 withoutKeys t1@(Tip k1 _) t2
     | k1 `IntSet.member` t2 = Nil
@@ -1066,30 +1084,33 @@ withoutKeys t1@(Tip k1 _) t2
 withoutKeys Nil _ = Nil
 
 
--- TODO(wrengr): Right now this is still pretty naive. It essentially
--- unpacks the 'IntSetBitMap' into a tree-representation, and then
--- calls 'delete' on each element of the set; thus, it is
--- /O(min(m,W) * min(n,W)/. While technically that degenerates to
--- /O(1)/ for a fixed /W/, it's morally equivalent to /O(m * log n)/.
--- Really, we should be able to get this down to /O(n+m)/ just like
--- 'difference' is. One way to do this would be to restrict @t@
--- on the recursive calls, so that the 'lookup's are cheaper. But
--- we should be able to do even better by avoiding the call to
--- 'lookup' entirely.
-withoutBM :: IntMap a -> IntSetPrefix -> IntSetBitMap -> Key -> IntMap a
-withoutBM t !prefix !_ 0 = delete prefix t
-withoutBM t prefix bmask bits =
-    case intFromNat (natFromInt bits `shiftRL` 1) of
-    bits2
-      | bmask .&. (shiftLL 1 bits2 - 1) == 0 ->
-          withoutBM t (prefix + bits2) (shiftRL bmask bits2) bits2
-      | shiftRL bmask bits2 .&. (shiftLL 1 bits2 - 1) == 0 ->
-          withoutBM t prefix bmask bits2
-      | otherwise ->
-          -- withoutKeys t (bin prefix bits2 _ _)
-          withoutBM
-            (withoutBM t (prefix + bits2) (shiftRL bmask bits2) bits2)
-            prefix bmask bits2
+updatePrefix
+    :: IntSetPrefix -> IntMap a -> (IntMap a -> IntMap a) -> IntMap a
+updatePrefix !kp t@(Bin p m l r) f
+    | m .&. IntSet.suffixBitMask /= 0 =
+        if p .&. IntSet.prefixBitMask == kp then f t else t
+    | nomatch kp p m = t
+    | zero kp m      = binCheckLeft p m (updatePrefix kp l f) r
+    | otherwise      = binCheckRight p m l (updatePrefix kp r f)
+updatePrefix kp t@(Tip kx _) f
+    | kx .&. IntSet.prefixBitMask == kp = f t
+    | otherwise = t
+updatePrefix _ Nil _ = Nil
+
+
+withoutBM :: IntSetBitMap -> IntMap a -> IntMap a
+withoutBM 0 t = t
+withoutBM bm (Bin p m l r) =
+    let leftBits = bitmapOf (p .|. m) - 1
+        bmL = bm .&. leftBits
+        bmR = bm `xor` bmL -- = (bm .&. complement leftBits)
+    in  bin p m (withoutBM bmL l) (withoutBM bmR r)
+withoutBM bm t@(Tip k _)
+    -- TODO(wrengr): need we manually inline 'IntSet.Member' here?
+    | k `IntSet.member` IntSet.Tip (k .&. IntSet.prefixBitMask) bm = Nil
+    | otherwise = t
+withoutBM _ Nil = Nil
+
 
 {--------------------------------------------------------------------
   Intersection
@@ -1102,6 +1123,8 @@ intersection :: IntMap a -> IntMap b -> IntMap a
 intersection m1 m2
   = mergeWithKey' bin const (const Nil) (const Nil) m1 m2
 
+
+-- TODO(wrengr): re-verify that asymptotic bound
 -- | /O(n+m)/. The restriction of a map to the keys in a set.
 --
 -- @
@@ -1139,10 +1162,8 @@ restrictKeys t1@(Tip k1 _) t2
 restrictKeys Nil _ = Nil
 
 
-type IntSetPrefix = Int
-type IntSetBitMap = Word
-
--- | Find the sub-tree of @t@ which matches the prefix @kp@.
+-- | /O(min(n,W))/. Restrict to the sub-map with all keys matching
+-- a key prefix.
 lookupPrefix :: IntSetPrefix -> IntMap a -> IntMap a
 lookupPrefix !kp t@(Bin p m l r)
     | m .&. IntSet.suffixBitMask /= 0 =
@@ -1168,11 +1189,6 @@ restrictBM bm t@(Tip k _)
     | k `IntSet.member` IntSet.Tip (k .&. IntSet.prefixBitMask) bm = t
     | otherwise = Nil
 restrictBM _ Nil = Nil
-
-
-bitmapOf :: Int -> IntSetBitMap
-bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)
-{-# INLINE bitmapOf #-}
 
 
 -- | /O(n+m)/. The intersection with a combining function.

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -1057,18 +1057,23 @@ withoutKeys t1@(Bin p1 m1 l1 r1) t2@(IntSet.Bin p2 m2 l2 r2)
         | nomatch p1 p2 m2  = t1
         | zero p1 m2        = withoutKeys t1 l2
         | otherwise         = withoutKeys t1 r2
--- TODO(wrengr): should we inline the top-level 'withoutBM' here?
-withoutKeys t1@(Bin _ _ _ _) (IntSet.Tip kx' bm') = withoutBM kx' bm' t1
+withoutKeys t1@(Bin _ _ _ _) (IntSet.Tip kx' bm') =
+    withoutBM t1 kx' bm' (IntSet.suffixBitMask + 1)
     where
-    withoutBM !kx !bm t@(Bin p m l r)
-        | nomatch kx p m = t
-        | zero kx m      = binCheckLeft p m (withoutBM kx bm l) r
-        | otherwise      = binCheckRight p m l (withoutBM kx bm r)
-    withoutBM kx bm t@(Tip ky _)
-        -- TODO(wrengr): should we inline 'IntSet.member' here?
-        | ky `IntSet.member` IntSet.Tip kx bm = Nil
-        | otherwise = t
-    withoutBM _ _ Nil = Nil
+    -- TODO(wrengr): this is still pretty naive. It could be improved by restricting @t@ on the recursive calls, so that the 'delete' in the basis case is faster. As is, this is linear in the size of the IntSet (as opposed to the previous version which was linear in the size of the IntMap; we want /O(n+m)/ at worst, just like for 'intersection').
+    withoutBM t !prefix !_ 0 = delete prefix t
+    withoutBM t prefix bmask bits =
+        case intFromNat (natFromInt bits `shiftRL` 1) of
+        bits2
+          | bmask .&. (shiftLL 1 bits2 - 1) == 0 ->
+              withoutBM t (prefix + bits2) (shiftRL bmask bits2) bits2
+          | shiftRL bmask bits2 .&. (shiftLL 1 bits2 - 1) == 0 ->
+              withoutBM t prefix bmask bits2
+          | otherwise ->
+              -- withoutKeys t (bin prefix bits2 _ _)
+              withoutBM
+                (withoutBM t (prefix + bits2) (shiftRL bmask bits2) bits2)
+                prefix bmask bits2
 withoutKeys t1@(Bin _ _ _ _) IntSet.Nil = t1
 withoutKeys t1@(Tip k1 _) t2
     | k1 `IntSet.member` t2 = Nil
@@ -1109,18 +1114,25 @@ restrictKeys t1@(Bin p1 m1 l1 r1) t2@(IntSet.Bin p2 m2 l2 r2)
         | nomatch p1 p2 m2  = Nil
         | zero p1 m2        = restrictKeys t1 l2
         | otherwise         = restrictKeys t1 r2
--- TODO(wrengr): should we inline the top-level 'restrictBM' here?
-restrictKeys t1@(Bin _ _ _ _) (IntSet.Tip kx' bm') = restrictBM kx' bm' t1
+restrictKeys t1@(Bin _ _ _ _) (IntSet.Tip kx' bm') =
+    restrictBM t1 kx' bm' (IntSet.suffixBitMask + 1)
     where
-    restrictBM !kx !bm (Bin p1 m1 l1 r1)
-        | nomatch kx p1 m1 = Nil
-        | zero kx m1       = restrictBM kx bm l1
-        | otherwise        = restrictBM kx bm r1
-    restrictBM kx bm t@(Tip ky _)
-        -- TODO(wrengr): should we inline 'IntSet.member' here?
-        | ky `IntSet.member` IntSet.Tip kx bm = t
-        | otherwise = Nil
-    restrictBM _ _ Nil = Nil
+    -- TODO(wrengr): this is still pretty naive. It could be improved by restricting @t@ on the recursive calls, so that the 'lookup' in the basis case is faster. As is, this is linear in the size of the IntSet (as opposed to the previous version which was linear in the size of the IntMap; we want /O(n+m)/ at worst, just like for 'intersection').
+    restrictBM t !prefix !_ 0 =
+        case lookup prefix t of
+        Nothing -> Nil
+        Just x -> Tip prefix x
+    restrictBM t prefix bmask bits =
+        case intFromNat (natFromInt bits `shiftRL` 1) of
+        bits2
+          | bmask .&. (shiftLL 1 bits2 - 1) == 0 ->
+              restrictBM t (prefix + bits2) (shiftRL bmask bits2) bits2
+          | shiftRL bmask bits2 .&. (shiftLL 1 bits2 - 1) == 0 ->
+              restrictBM t prefix bmask bits2
+          | otherwise ->
+              bin prefix bits2
+                (restrictBM t prefix bmask bits2)
+                (restrictBM t (prefix + bits2) (shiftRL bmask bits2) bits2)
 restrictKeys (Bin _ _ _ _) IntSet.Nil = Nil
 restrictKeys t1@(Tip k1 _) t2
     | k1 `IntSet.member` t2 = t1

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -1132,11 +1132,19 @@ restrictKeys t1@(Bin _ _ _ _) (IntSet.Tip p2 bm2) =
         -- @t1'@, so we generate a mask for all the bitmaps of keys
         -- greater than or equal to this smallest-possible-key and
         -- only look at that subset of @bm2@.
-        let p1_bit = shiftLL 1 (p1 .&. IntSet.suffixBitMask)
-            bitsLT = p1_bit - 1
-            bitsGE = complement bitsLT
-            bm2' = bm2 .&. bitsGE
-        in restrictBM t1' p2 bm2' (IntSet.suffixBitMask + 1)
+        let s1 :: IntSetPrefix
+            s1 = p1 .&. IntSet.suffixBitMask
+            s1_bitmap :: IntSetBitMap
+            s1_bitmap = shiftLL 1 s1
+            bitsLT_s1 :: IntSetBitMap
+            bitsLT_s1 = s1_bitmap - 1
+            bitsGE_s1 :: IntSetBitMap
+            bitsGE_s1 = complement bitsLT_s1
+
+            -- TODO(wrengr): in principle this should be sound to use in place of @bm2@. But why isn't it working?
+            bm2' :: IntSetBitMap
+            bm2' = bm2 .&. bitsGE_s1
+        in restrictBM t1' p2 bm2 (IntSet.suffixBitMask + 1)
     t1' -> t1'
 restrictKeys (Bin _ _ _ _) IntSet.Nil = Nil
 restrictKeys t1@(Tip k1 _) t2

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -805,17 +805,21 @@ prop_intersectionWithKeyModel xs ys
           ys' = List.nubBy ((==) `on` fst) ys
           f k l r = k + 2 * l + 3 * r
 
+-- TODO: the second argument should be simply an 'IntSet', but that
+-- runs afoul of our orphan instance.
 prop_restrictKeys :: IMap -> IMap -> Property
-prop_restrictKeys m s0 = m `restrictKeys` s === filterWithKey (\k _ -> k `IntSet.member` s) m
+prop_restrictKeys m s0 =
+    m `restrictKeys` s === filterWithKey (\k _ -> k `IntSet.member` s) m
   where
     s = keysSet s0
-    restricted = restrictKeys m s
 
+-- TODO: the second argument should be simply an 'IntSet', but that
+-- runs afoul of our orphan instance.
 prop_withoutKeys :: IMap -> IMap -> Property
-prop_withoutKeys m s0 = m `withoutKeys` s === filterWithKey (\k _ -> k `IntSet.notMember` s) m
+prop_withoutKeys m s0 =
+    m `withoutKeys` s === filterWithKey (\k _ -> k `IntSet.notMember` s) m
   where
     s = keysSet s0
-    reduced = withoutKeys m s
 
 prop_mergeWithKeyModel :: [(Int,Int)] -> [(Int,Int)] -> Bool
 prop_mergeWithKeyModel xs ys


### PR DESCRIPTION
The previous PR #400 only optimized `IntMap`'s `restrictKeys` by the time it got pulled in. This PR handles `withoutKeys` using the same algorithm.

Fixes #394