### PR TITLE
Fix lots of strictness bugs

### DIFF
--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -403,6 +403,7 @@ import Control.Applicative (Const (..), liftA3)
 import Control.Applicative (Applicative (..), (<$>))
 #endif
 import qualified Data.Set.Internal as Set
+import qualified Data.Map.Internal as L
 import Utils.Containers.Internal.StrictFold
 import Utils.Containers.Internal.StrictPair
 
@@ -1336,13 +1337,8 @@ map f = go
 #ifdef __GLASGOW_HASKELL__
 {-# NOINLINE [1] map #-}
 {-# RULES
-"map/map" forall f g xs . map f (map g xs) = map (f . g) xs
- #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 709
--- Safe coercions were introduced in 7.8, but did not work well with RULES yet.
-{-# RULES
-"mapSeq/coerce" map coerce = coerce
+"map/map" forall f g xs . map f (map g xs) = map (\x -> f $! g x) xs
+"map/mapL" forall f g xs . map f (L.map g xs) = map (\x -> f (g x)) xs
  #-}
 #endif
 
@@ -1361,10 +1357,16 @@ mapWithKey f (Bin sx kx x l r) =
 {-# NOINLINE [1] mapWithKey #-}
 {-# RULES
 "mapWithKey/mapWithKey" forall f g xs . mapWithKey f (mapWithKey g xs) =
+  mapWithKey (\k a -> f k $! g k a) xs
+"mapWithKey/mapWithKeyL" forall f g xs . mapWithKey f (L.mapWithKey g xs) =
   mapWithKey (\k a -> f k (g k a)) xs
 "mapWithKey/map" forall f g xs . mapWithKey f (map g xs) =
+  mapWithKey (\k a -> f k $! g a) xs
+"mapWithKey/mapL" forall f g xs . mapWithKey f (L.map g xs) =
   mapWithKey (\k a -> f k (g a)) xs
 "map/mapWithKey" forall f g xs . map f (mapWithKey g xs) =
+  mapWithKey (\k a -> f $! g k a) xs
+"map/mapWithKeyL" forall f g xs . map f (L.mapWithKey g xs) =
   mapWithKey (\k a -> f (g k a)) xs
  #-}
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,20 @@
 
 * Planned for GHC 8.2.
 
-* Optimize `Data.IntMap.restrictKeys` (the semantic fix in 0.5.10.1 left it
-  rather slow in certain cases). Partially optimize `Data.IntMap.withoutKeys`.
+* Make `Data.IntMap.Strict.traverseWithKey` force the values before
+  installing them in the result. Previously, this function could be used to
+  produce an `IntMap` containing undefined values.
+
+* Fix strictness bugs in various rewrite rules for `Data.Map.Strict` and
+  `Data.IntMap.Strict`. Previously, rules could unintentionally reduce
+  strictness. The most important change in this regard is the elimination
+  of rules rewriting `*.Strict.map coerce` to `coerce`. To map a coercion
+  over a structure for free, be sure to use the lazy `map` or `fmap`.
+  It is possible to write rules that do a somewhat better job of this, but
+  it turns out to be a bit messy.
+
+* Optimize `Data.IntMap.restrictKeys` and `Data.IntMap.withoutKeys`. The
+  semantic fix in 0.5.10.1 left them rather slow in certain cases.
 
 * Define a custom `liftA2` in `Applicative` instances for base 4.10, and use
   `liftA2` rather than `<*>` whenever it may be beneficial.


### PR DESCRIPTION
* `Data.IntMap.Strict` previously re-exported the lazy `traverseWithKey`.
  Implement a strict one.

* `Data.IntMap.Strict` and `Data.Map.Strict` previously had a number of
  rewrite rules with strictness bugs. Remove `map/coerce` rules from
  each and fix the other rules.