### PR TITLE
Fix up IntMap showTree deprecation story

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -3236,9 +3236,6 @@ splitRoot orig =
 {--------------------------------------------------------------------
   Debugging
 --------------------------------------------------------------------}
-{-# DEPRECATED showTree, showTreeWith
-    "These debugging functions will be moved to a separate module in future versions"
-    #-}
 
 -- | /O(n)/. Show the tree that implements the map. The tree is shown
 -- in a compressed, hanging format.

--- a/Data/IntMap/Internal/Debug.hs
+++ b/Data/IntMap/Internal/Debug.hs
@@ -1,0 +1,6 @@
+module Data.IntMap.Internal.Debug
+  ( showTree
+  , showTreeWith
+  ) where
+
+import Data.IntMap.Internal

--- a/Data/IntMap/Internal/DeprecatedDebug.hs
+++ b/Data/IntMap/Internal/DeprecatedDebug.hs
@@ -1,0 +1,20 @@
+module Data.IntMap.Internal.DeprecatedDebug where
+import qualified Data.IntMap.Internal as IM
+import Data.IntMap.Internal (IntMap)
+
+{-# DEPRECATED showTree, showTreeWith
+    "These debugging functions will be removed from this module. They are available from Data.IntMap.Internal.Debug."
+    #-}
+
+-- | /O(n)/. Show the tree that implements the map. The tree is shown
+-- in a compressed, hanging format.
+showTree :: Show a => IntMap a -> String
+showTree = IM.showTree
+
+{- | /O(n)/. The expression (@'showTreeWith' hang wide map@) shows
+ the tree that implements the map. If @hang@ is
+ 'True', a /hanging/ tree is shown otherwise a rotated tree is shown. If
+ @wide@ is 'True', an extra wide version is shown.
+-}
+showTreeWith :: Show a => Bool -> Bool -> IntMap a -> String
+showTreeWith = IM.showTreeWith

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -207,7 +207,8 @@ module Data.IntMap.Lazy (
     , showTreeWith
     ) where
 
-import Data.IntMap.Internal as IM
+import Data.IntMap.Internal as IM hiding (showTree, showTreeWith)
+import Data.IntMap.Internal.DeprecatedDebug
 
 -- $strictness
 --

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -284,8 +284,6 @@ import Data.IntMap.Internal
   , partition
   , partitionWithKey
   , restrictKeys
-  , showTree
-  , showTreeWith
   , size
   , split
   , splitLookup
@@ -295,8 +293,9 @@ import Data.IntMap.Internal
   , toList
   , union
   , unions
-  , withoutKeys)
-
+  , withoutKeys
+  )
+import Data.IntMap.Internal.DeprecatedDebug (showTree, showTreeWith)
 import qualified Data.IntSet.Internal as IntSet
 import Utils.Containers.Internal.BitUtil
 import Utils.Containers.Internal.StrictFold

--- a/containers.cabal
+++ b/containers.cabal
@@ -45,6 +45,7 @@ Library
         Data.IntMap.Lazy
         Data.IntMap.Strict
         Data.IntMap.Internal
+        Data.IntMap.Internal.Debug
         Data.IntMap.Merge.Lazy
         Data.IntMap.Merge.Strict
         Data.IntSet.Internal
@@ -74,6 +75,7 @@ Library
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality
         Data.Map.Internal.DeprecatedShowTree
+        Data.IntMap.Internal.DeprecatedDebug
 
     include-dirs: include
 

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE CPP #-}
 
 #ifdef STRICT
-import Data.IntMap.Strict as Data.IntMap
+import Data.IntMap.Strict as Data.IntMap hiding (showTree)
 #else
-import Data.IntMap.Lazy as Data.IntMap
+import Data.IntMap.Lazy as Data.IntMap hiding (showTree)
 #endif
+import Data.IntMap.Internal.Debug (showTree)
 
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)


### PR DESCRIPTION
Export deprecated copies from the places we don't want them,
and non-deprecated originals from internal places we do
want them. This allows the test suite to run without warnings,
and gives users a way to avoid them when using these functions.