### PR TITLE
faster {IntMap,IntSet} size functions

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -512,9 +512,11 @@ null _   = False
 -- > size (singleton 1 'a')                       == 1
 -- > size (fromList([(1,'a'), (2,'c'), (3,'b')])) == 3
 size :: IntMap a -> Int
-size (Bin _ _ l r) = size l + size r
-size (Tip _ _) = 1
-size Nil = 0
+size = go 0
+  where
+    go !acc (Bin _ _ l r) = go (go acc l) r
+    go acc (Tip _ _) = 1 + acc
+    go acc Nil = acc
 
 -- | /O(min(n,W))/. Is the key a member of the map?
 --

--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -311,9 +311,11 @@ null _   = False
 
 -- | /O(n)/. Cardinality of the set.
 size :: IntSet -> Int
-size (Bin _ _ l r) = size l + size r
-size (Tip _ bm) = bitcount 0 bm
-size Nil = 0
+size = go 0
+  where
+    go !acc (Bin _ _ l r) = go (go acc l) r
+    go acc (Tip _ bm) = acc + bitcount 0 bm
+    go acc Nil = acc
 
 -- | /O(min(n,W))/. Is the value a member of the set?
 

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -142,6 +142,7 @@ main = defaultMain
              , testProperty "alter"                prop_alter
              , testProperty "index"                prop_index
              , testProperty "null"                 prop_null
+             , testProperty "size"                 prop_size
              , testProperty "member"               prop_member
              , testProperty "notmember"            prop_notmember
              , testProperty "lookup"               prop_lookup
@@ -905,6 +906,11 @@ prop_index xs = length xs > 0 ==>
 
 prop_null :: IMap -> Bool
 prop_null m = null m == (size m == 0)
+
+prop_size :: UMap -> Property
+prop_size im = sz === foldl' (\i _ -> i + 1) (0 :: Int) im .&&.
+               sz === List.length (toList im)
+  where sz = size im
 
 prop_member :: [Int] -> Int -> Bool
 prop_member xs n =

--- a/tests/intset-properties.hs
+++ b/tests/intset-properties.hs
@@ -261,8 +261,10 @@ prop_isSubsetOf a b = isSubsetOf a b == Set.isSubsetOf (toSet a) (toSet b)
 prop_isSubsetOf2 :: IntSet -> IntSet -> Bool
 prop_isSubsetOf2 a b = isSubsetOf a (union a b)
 
-prop_size :: IntSet -> Bool
-prop_size s = size s == List.length (toList s)
+prop_size :: IntSet -> Property
+prop_size s = sz === foldl' (\i _ -> i + 1) (0 :: Int) s .&&.
+              sz === List.length (toList s)
+  where sz = size s
 
 prop_findMax :: IntSet -> Property
 prop_findMax s = not (null s) ==> findMax s == maximum (toList s)


### PR DESCRIPTION
fixes #414 

informal benchmark:
```haskell
{-# LANGUAGE BangPatterns #-}
{-# LANGUAGE CPP          #-}
import           Criterion.Main
import           Data.Bits
import qualified Data.IntMap.Internal as II
import qualified Data.IntMap.Strict   as I
import qualified Data.IntSet          as IS
import qualified Data.IntSet.Internal as ISI

bitcount :: Int -> Word -> Int
#if MIN_VERSION_base(4,5,0)
bitcount a x = a + popCount x
#else
bitcount a0 x0 = go a0 x0
  where go a 0 = a
        go a x = go (a + 1) (x .&. (x-1))
#endif

datum :: I.IntMap Int
datum = I.fromList (zip [1..10000] [0..])

datum_is :: IS.IntSet
datum_is = IS.fromList [0,3..1000000]

size_tailish :: I.IntMap a -> Int
size_tailish = go 0
  where
    go !acc (II.Bin _ _ l r) = go (go acc l) r
    go acc (II.Tip _ _) = 1 + acc
    go acc II.Nil = acc

size_tailish_is :: IS.IntSet -> Int
size_tailish_is = go 0
  where
    go !acc (ISI.Bin _ _ l r) = go (go acc l) r
    go acc (ISI.Tip _ bm) = bitcount 0 bm + acc
    go acc ISI.Nil = acc

main :: IO ()
main = defaultMain
  [ bgroup "intmap"
    [ bench "size (default)" (whnf I.size datum)
    , bench "size (foldl')"  (whnf (I.foldl' (\i _ -> (i :: Int) + 1) 0) datum)
    , bench "size (tailish)" (whnf size_tailish datum)
    ]
  , bgroup "intset"
    [ bench "size (default)" (whnf IS.size datum_is)
    , bench "size (foldl')"  (whnf (IS.foldl' (\i _ -> (i :: Int) + 1) 0) datum_is)
    , bench "size (tailish)" (whnf size_tailish_is datum_is)
    ]
  ]
```

```
mike@neato ~/Code> ./benchisize
benchmarking intmap/size (default)
time                 65.07 μs   (64.65 μs .. 65.45 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 64.94 μs   (64.64 μs .. 65.22 μs)
std dev              999.7 ns   (883.3 ns .. 1.157 μs)

benchmarking intmap/size (foldl')
time                 43.12 μs   (42.95 μs .. 43.29 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 43.21 μs   (43.05 μs .. 43.31 μs)
std dev              397.7 ns   (265.3 ns .. 643.2 ns)

benchmarking intmap/size (tailish)
time                 40.54 μs   (40.35 μs .. 40.71 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 40.57 μs   (40.43 μs .. 40.68 μs)
std dev              429.3 ns   (319.5 ns .. 618.1 ns)

benchmarking intset/size (default)
time                 141.0 μs   (140.8 μs .. 141.2 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 141.0 μs   (140.9 μs .. 141.1 μs)
std dev              444.7 ns   (372.3 ns .. 547.7 ns)

benchmarking intset/size (foldl')
time                 439.0 μs   (436.2 μs .. 442.2 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 438.3 μs   (436.5 μs .. 439.6 μs)
std dev              5.209 μs   (3.907 μs .. 7.267 μs)

benchmarking intset/size (tailish)
time                 96.82 μs   (96.46 μs .. 97.15 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 96.75 μs   (96.38 μs .. 96.99 μs)
std dev              979.5 ns   (665.1 ns .. 1.402 μs)

```