### PR TITLE
Add restictKeys example via intersect, also withoutKeys

### DIFF
--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -1880,7 +1880,8 @@ difference t1 (Bin _ k _ l2 r2) = case split k t1 of
 -- | /O(m*log(n\/m + 1)), m <= n/. Remove all keys in a 'Set' from a 'Map'.
 --
 -- @
--- m `withoutKeys` s = 'filterWithKey' (\k _ -> k `'Set.notMember'` s) m
+-- m `'withoutKeys'` s = 'filterWithKey' (\k _ -> k `'Set.notMember'` s) m
+-- m `'withoutKeys'` s = m `'difference'` 'fromSet' (const ()) s
 -- @
 --
 -- @since 0.5.8
@@ -1961,7 +1962,8 @@ intersection t1@(Bin _ k x l1 r1) t2
 -- found in a 'Set'.
 --
 -- @
--- m `restrictKeys` s = 'filterWithKey' (\k _ -> k `'Set.member'` s) m
+-- m `'restrictKeys'` s = 'filterWithKey' (\k _ -> k `'Set.member'` s) m
+-- m `'restrictKeys'` s = m `'intersect' 'fromSet' (const ()) s
 -- @
 --
 -- @since 0.5.8


### PR DESCRIPTION
I think this examples would helped me to spot (I tried Ctrl+F with `intersect`).

EDIT: also fixed markup

---

For dual `(set, map) -> set` operations I'd use `union`, `intersection` and `difference` names with some prefix or suffix, as all three are possible. `unionWithMap` etc doesn't sound too bad, does it?

```haskell
unionWithMap        :: Set k -> Map k a -> Set k
intersectionWithMap :: Set k -> Map k a -> Set k
differenceWithMap   :: Set k -> Map k a -> Set k
```