### PR TITLE
Expose Size (and other Int aliases) from *.Internal modules

### DIFF
--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -98,6 +98,7 @@
 module Data.IntSet.Internal (
     -- * Set type
       IntSet(..), Key -- instance Eq,Show
+    , Prefix, Mask, BitMap
 
     -- * Operators
     , (\\)

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -129,6 +129,7 @@
 module Data.Map.Internal (
     -- * Map type
       Map(..)          -- instance Eq,Show,Read
+    , Size
 
     -- * Operators
     , (!), (!?), (\\)

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -85,6 +85,7 @@ module Data.Map.Strict.Internal
 
     -- * Map type
     Map(..)          -- instance Eq,Show,Read
+    , L.Size
 
     -- * Operators
     , (!), (!?), (\\)

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -121,6 +121,7 @@
 module Data.Set.Internal (
             -- * Set type
               Set(..)       -- instance Eq,Ord,Show,Read,Data,Typeable
+            , Size
 
             -- * Operators
             , (\\)


### PR DESCRIPTION
Currently, these aliases are referenced in the Haddocks for the `*.Internal` modules, but because they're not exported, you can't easily see what they represent without digging into the source code. At the very least, we can also export them from the `*.Internal` modules as well.