### PR TITLE
Point to docs.

### DIFF
--- a/Data/Map.hs
+++ b/Data/Map.hs
@@ -21,6 +21,8 @@
 -- * The stored values don't represent large virtual data structures
 -- to be lazily computed.
 --
+-- "Data.Map.Strict" also contains applicable documentation.
+--
 -- An efficient implementation of ordered maps from keys to values
 -- (dictionaries).
 --


### PR DESCRIPTION
I'm not sure if the following is the correct solution, but here is the problem I ran into.

I see code where folks are importing `Data.Map`. Therefore, I lookup `Data.Map`'s documentations, not realizing that what I really should be looking at is `Data.Map.Strict`. 

(I'd even go as far as to add that `Data.Map.Strict` should be the first "port of call" if this is your first time using the `Map` structure, but I wanted to propose the simplest possible fix first).

This small change might avoid a bit of confusing for newcomers. 