### PR TITLE
Add operator IntMap.!?.

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -388,7 +388,7 @@ bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)
 -- > fromList [(5,'a'), (3,'b')] !? 1 == Nothing
 -- > fromList [(5,'a'), (3,'b')] !? 5 == Just 'a'
 --
--- TODO(mrenaud): Add @since annotation.
+-- @since 0.5.11
 
 (!?) :: IntMap a -> Key -> Maybe a
 (!?) m k = lookup k m

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -75,7 +75,7 @@ module Data.IntMap.Internal (
       IntMap(..), Key          -- instance Eq,Show
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , null
@@ -382,11 +382,22 @@ bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)
 (!) :: IntMap a -> Key -> a
 (!) m k = find k m
 
+-- | /O(min(n,W))/. Find the value at a key.
+-- Returns 'Nothing' when the element can not be found.
+--
+-- > fromList [(5,'a'), (3,'b')] !? 1 == Nothing
+-- > fromList [(5,'a'), (3,'b')] !? 5 == Just 'a'
+--
+-- TODO(mrenaud): Add @since annotation.
+
+(!?) :: IntMap a -> Key -> Maybe a
+(!?) m k = lookup k m
+
 -- | Same as 'difference'.
 (\\) :: IntMap a -> IntMap b -> IntMap a
 m1 \\ m2 = difference m1 m2
 
-infixl 9 \\{-This comment teaches CPP correct behaviour -}
+infixl 9 !?,\\{-This comment teaches CPP correct behaviour -}
 
 {--------------------------------------------------------------------
   Types
@@ -2170,7 +2181,7 @@ findMin :: IntMap a -> (Key, a)
 findMin t
   | Just r <- lookupMin t = r
   | otherwise = error "findMin: empty map has no minimal element"
-  
+
 -- | /O(min(n,W))/. The maximal key of the map. Returns 'Nothing' if the map is empty.
 lookupMax :: IntMap a -> Maybe (Key, a)
 lookupMax Nil = Nothing
@@ -2186,7 +2197,7 @@ lookupMax (Bin _ m l r)
 findMax :: IntMap a -> (Key, a)
 findMax t
   | Just r <- lookupMax t = r
-  | otherwise = error "findMax: empty map has no maximal element"          
+  | otherwise = error "findMax: empty map has no maximal element"
 
 -- | /O(min(n,W))/. Delete the minimal key. Returns an empty map if the map is empty.
 --

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -63,7 +63,7 @@ module Data.IntMap.Lazy (
 #endif
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , IM.null

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -239,6 +239,7 @@ import Data.IntMap.Internal
 
   , (\\)
   , (!)
+  , (!?)
   , empty
   , assocs
   , filter

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -70,7 +70,7 @@ module Data.IntMap.Strict (
 #endif
 
     -- * Operators
-    , (!), (\\)
+    , (!), (!?), (\\)
 
     -- * Query
     , null

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -31,6 +31,7 @@ main :: IO ()
 main = defaultMain
          [
                testCase "index"      test_index
+             , testCase "index_lookup" test_index_lookup
              , testCase "size"       test_size
              , testCase "size2"      test_size2
              , testCase "member"     test_member
@@ -143,6 +144,7 @@ main = defaultMain
              , testProperty "fromList"             prop_fromList
              , testProperty "alter"                prop_alter
              , testProperty "index"                prop_index
+             , testProperty "index_lookup"         prop_index_lookup
              , testProperty "null"                 prop_null
              , testProperty "size"                 prop_size
              , testProperty "member"               prop_member

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -933,7 +933,7 @@ prop_index xs = length xs > 0 ==>
 prop_index_lookup :: [Int] -> Property
 prop_index_lookup xs = length xs > 0 ==>
   let m  = fromList (zip xs xs)
-  in  (Just <$> xs) == [ m !? i | i <- xs ]
+  in  (Prelude.map Just xs) == [ m !? i | i <- xs ]
 
 prop_null :: IMap -> Bool
 prop_null m = null m == (size m == 0)

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -933,7 +933,7 @@ prop_index xs = length xs > 0 ==>
 prop_index_lookup :: [Int] -> Property
 prop_index_lookup xs = length xs > 0 ==>
   let m  = fromList (zip xs xs)
-  in  Just <$> xs == [ m !? i | i <- xs ]
+  in  (Just <$> xs) == [ m !? i | i <- xs ]
 
 prop_null :: IMap -> Bool
 prop_null m = null m == (size m == 0)

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -226,6 +226,11 @@ tests = [ testGroup "Test Case" [
 test_index :: Assertion
 test_index = fromList [(5,'a'), (3,'b')] ! 5 @?= 'a'
 
+test_index_lookup :: Assertion
+test_index_lookup = do
+    fromList [(5,'a'), (3,'b')] !? 1 @?= Nothing
+    fromList [(5,'a'), (3,'b')] !? 5 @?= Just 'a'
+
 ----------------------------------------------------------------
 -- Query
 
@@ -922,6 +927,11 @@ prop_index :: [Int] -> Property
 prop_index xs = length xs > 0 ==>
   let m  = fromList (zip xs xs)
   in  xs == [ m ! i | i <- xs ]
+
+prop_index_lookup :: [Int] -> Property
+prop_index_lookup xs = length xs > 0 ==>
+  let m  = fromList (zip xs xs)
+  in  Just <$> xs == [ m !? i | i <- xs ]
 
 prop_null :: IMap -> Bool
 prop_null m = null m == (size m == 0)

--- a/tests/intmap-strictness.hs
+++ b/tests/intmap-strictness.hs
@@ -91,6 +91,7 @@ tests =
       , testProperty "findWithDefault is key-strict" pFindWithDefaultKeyStrict
       , testProperty "findWithDefault is value-strict" pFindWithDefaultValueStrict
       , testProperty "! is key-strict" $ keyStrict (flip (M.!))
+      , testProperty "!? is key-strict" $ keyStrict (flip (M.!?))
       , testProperty "delete is key-strict" $ keyStrict M.delete
       , testProperty "adjust is key-strict" pAdjustKeyStrict
       , testProperty "adjust is value-strict" pAdjustValueStrict


### PR DESCRIPTION
This operator was added to Data.Map but was accidentally left out of the IntMap
API.

```
(!?) :: IntMap a -> Key -> Maybe a
```

See https://github.com/haskell/containers/issues/453 for more information.