### PR TITLE
Improve error message for `index`

### DIFF
--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -1883,7 +1883,7 @@ index (Seq xs) i
   -- See note on unsigned arithmetic in splitAt
   | fromIntegral i < (fromIntegral (size xs) :: Word) = case lookupTree i xs of
                 Place _ (Elem x) -> x
-  | otherwise   = error "index out of bounds"
+  | otherwise   = error $ "index out of bounds in call to: index " ++ show i
 
 -- | /O(log(min(i,n-i)))/. The element at the specified position,
 -- counting from 0. If the specified position is negative or at

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -1883,7 +1883,8 @@ index (Seq xs) i
   -- See note on unsigned arithmetic in splitAt
   | fromIntegral i < (fromIntegral (size xs) :: Word) = case lookupTree i xs of
                 Place _ (Elem x) -> x
-  | otherwise   = error $ "index out of bounds in call to: index " ++ show i
+  | otherwise   = 
+      error $ "index out of bounds in call to: Data.Sequence.index " ++ show i
 
 -- | /O(log(min(i,n-i)))/. The element at the specified position,
 -- counting from 0. If the specified position is negative or at


### PR DESCRIPTION
When the index is out of bounds mention which function is causing the error. We include the index `i` in the error message because it may be useful in debugging (-1 vs large number could narrow down where to look).

This was originally mentioned in https://github.com/haskell/containers/issues/347.