### PR TITLE
Update CONTRIBUTING.md with benchmark instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,27 +4,34 @@ As mentioned in the [README](https://github.com/haskell/containers/blob/master/R
 
 For proposing API changes/enhancements, please follow the [guidelines outlined on the Haskell Wiki](https://wiki.haskell.org/Library_submissions#Guide_to_proposers). Especially note that all API changes/enhancements should be discussed on libraries@haskell.org mailing list.
 
-## Building and testing
+## Building, testing, and benchmarking
 
-Building and testing the containers package can be done using either `cabal-install` or `stack`.
+Building, testing, and benchmarking the containers package can be done using either `cabal-install` or `stack`.
 
 ### With cabal-install
+
+Minimum cabal version: 1.24
 
 ```
 cabal sandbox init
 cabal install --only-dependencies
-cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit'
-cabal configure -v2 --enable-tests
+cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
+cabal configure -v2 --enable-tests --enable-benchmarks
 cabal build
 cabal test
-```
+cabal bench
+``` 
+
 
 ### With [Stack](https://docs.haskellstack.org/en/stable/README/)
+
+Minimum stack version: 1.6.1
 
 ```
 stack init   # If you haven't previously initialized stack
 stack build
 stack test
+stack bench
 ```
 
 ## Troubleshooting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ _Note: The procedure here is a little weird because cabal configure is unable to
 ```
 cabal sandbox init
 cabal install --only-dependencies
-cabal install 'test-framework' 'test-framework-quickcheck2' 'QuickCheck' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
+cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
 cabal configure -v2 --enable-tests --enable-benchmarks
 cabal build
 cabal test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,12 @@ Building, testing, and benchmarking the containers package can be done using eit
 
 Minimum cabal version: 1.24
 
+_Note: The procedure here is a little weird because cabal configure is unable to solve for the constraints. We're looking into why that is ([#462](https://github.com/haskell/containers/issues/462))._
+
 ```
 cabal sandbox init
 cabal install --only-dependencies
-cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
+cabal install 'test-framework' 'test-framework-quickcheck2' 'QuickCheck' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
 cabal configure -v2 --enable-tests --enable-benchmarks
 cabal build
 cabal test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,11 @@ _Note: The procedure here is a little weird because cabal configure is unable to
 ```
 cabal sandbox init
 cabal install --only-dependencies
-cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit' 'criterion'
+# Install test dependencies
+cabal install 'test-framework >= 0.3.3' 'test-framework-quickcheck2 >= 0.2.9' 'QuickCheck >= 2.4.0.1' 'ChasingBottoms' 'HUnit' 'test-framework-hunit'
+# Install benchmark dependencies
+cabal install 'criterion'
+# If you only need tests or benchmarks, you can omit the other --enable-xyz flag.
 cabal configure -v2 --enable-tests --enable-benchmarks
 cabal build
 cabal test


### PR DESCRIPTION
This includes instructions for building and running benchmarks with both cabal-install and stack.

This addresses #354 and #371.