### PR TITLE
Add stack.yaml file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,6 @@ cabal test
 ### With [Stack](https://docs.haskellstack.org/en/stable/README/)
 
 ```
-stack init   # If you haven't previously initialized stack
 stack build
 stack test
 ```

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,11 @@
+flags: {}
+packages:
+- '.'
+
+### Uncoment the resolver you want to use and re-run `stack build/test/bench`.
+# resolver: lts-10.0
+resolver: lts-9.20
+
+### ChasingBottoms is only in Stackage snapshots lts-7.24 and below.
+extra-deps:
+- ChasingBottoms-1.3.1.3


### PR DESCRIPTION
Running `stack init` fails if you're using a resolver newer than lts-7.24 because ChasingBottoms has not been in Stackage LTS releases since then. Since Stack is a common workflow people use we should support the most recent Stackage LTS versions out of the box.

In the stack.yaml file we add ChasingBottoms-1.3.1.3 as an extra-dep and default the resolver to 9.20 because lts-10.0 uses GHC 8.2 which is not supported all of the tools yet; ghc-mod is lacking support, for example. Once all tooling supports lts-10.0 we'll change the default resolver.

This also updates CONTRIBUTING.md, removing the `stack init` step because it is no longer needed.

This resolves #458.