### PR TITLE
Add RULES for Data.IntMap.alterF

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -986,20 +986,18 @@ alterF f k m = (<$> f mv) $ \fres ->
 -- TODO(m-renaud): Figure out if this should be marked INLINE or NOINLINE.
 -- It needs to be one or the other or else the specialization rule may not fire.
 {-# NOINLINE [1] alterF #-}
+#if MIN_VERSION_base(4,8,0)
 {-# RULES
 "Identity specialize alterF" forall (f :: Maybe a -> Identity (Maybe a)) k m.
-  alterF f k m =
-    Identity $ alter (runIdentity . f) k m
+  alterF f k m = Identity $ alter (runIdentity . f) k m
   #-}
+#endif
 
 #if MIN_VERSION_base(4,9,0)
--- TODO(m-renaud): Figure out where to import Const from from pre-base-4.9 or
--- how to conditionally include pragrams (the #if around this doesn't work :/).
--- {-# RULES
--- "Const specialize alterF" forall (f :: Maybe a -> Const x (Maybe a)) k m.
---   alterF f k m =
---     Const $ alter (getConst . f) k m
---   #-}
+{-# RULES
+"Const specialize alterF" forall (f :: Maybe a -> Const x (Maybe a)) k m.
+  alterF f k m = Const $ alter (getConst . f) k m
+  #-}
 #endif
 
 {--------------------------------------------------------------------

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -286,12 +286,13 @@ module Data.IntMap.Internal (
 
 #if MIN_VERSION_base(4,8,0)
 import Data.Functor.Identity (Identity (..))
-import Control.Applicative (liftA2)
+import Control.Applicative (liftA2
+#if MIN_VERSION_base(4,9,0)
+                           , Const(..)
+#endif
+                           )
 #else
 import Control.Applicative (Applicative(pure, (<*>)), (<$>), liftA2)
-#if MIN_VERSION_base(4,9,0)
-import Control.Applicative (Const(..))
-#endif
 import Data.Monoid (Monoid(..))
 import Data.Traversable (Traversable(traverse))
 import Data.Word (Word)
@@ -996,7 +997,7 @@ alterF f k m = (<$> f mv) $ \fres ->
 #if MIN_VERSION_base(4,9,0)
 {-# RULES
 "Const specialize alterF" forall (f :: Maybe a -> Const x (Maybe a)) k m.
-  alterF f k m = Const $ alter (getConst . f) k m
+  alterF f k m = Const . getConst . f $ lookup k m
   #-}
 #endif
 

--- a/benchmarks/IntMap.hs
+++ b/benchmarks/IntMap.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 module Main where
 
+#if MIN_VERSION_base(4,9,0)
+import Control.Applicative (Const(..))
+#endif
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Criterion.Main (bench, defaultMain, whnf)
+#if MIN_VERSION_base(4,8,0)
+import Data.Functor.Identity (Identity (..))
+#endif
 import Data.List (foldl')
 import qualified Data.IntMap as M
 import qualified Data.IntMap.Strict as MS
@@ -35,6 +42,13 @@ main = do
         , bench "update" $ whnf (upd keys) m
         , bench "updateLookupWithKey" $ whnf (upd' keys) m
         , bench "alter"  $ whnf (alt keys) m
+        , bench "alterF" $ whnf (altFList keys) m
+#if MIN_VERSION_base(4,8,0)
+        , bench "alterFIdentity" $ whnf (altFIdentity keys) m
+#endif
+#if MIN_VERSION_base(4,9,0)
+        , bench "alterFConst" $ whnf (altFConst keys) m
+#endif
         , bench "mapMaybe" $ whnf (M.mapMaybe maybeDel) m
         , bench "mapMaybeWithKey" $ whnf (M.mapMaybeWithKey (const maybeDel)) m
         , bench "fromList" $ whnf M.fromList elems
@@ -89,6 +103,22 @@ upd' xs m = foldl' (\m k -> snd $ M.updateLookupWithKey (\_ a -> Just a) k m) m 
 
 alt :: [Int] -> M.IntMap Int -> M.IntMap Int
 alt xs m = foldl' (\m k -> M.alter id k m) m xs
+
+altFList :: [Int] -> M.IntMap Int -> M.IntMap Int
+altFList xs m = foldl' (\m k -> head $ M.alterF (pure . id) k m) m xs
+
+#if MIN_VERSION_base(4,8,0)
+altFIdentity :: [Int] -> M.IntMap Int -> M.IntMap Int
+altFIdentity xs m = foldl' (\m k -> runIdentity $ M.alterF (pure . id) k m) m xs
+#endif
+
+#if MIN_VERSION_base(4,9,0)
+altFConst :: [Int] -> M.IntMap Int -> M.IntMap Int
+altFConst xs m =
+    foldl' (\m k -> getConst $ M.alterF (const (Const m) . id) k m) m xs
+#endif
+
+
 
 maybeDel :: Int -> Maybe Int
 maybeDel n | n `mod` 3 == 0 = Nothing


### PR DESCRIPTION
Adds afterF rewrite RULES for the `Identity` and `Const` functor.

## Testing

- Adds unit tests for alterF for list, identity, and const
- Property test comparing the rewritten versions to versions operating on isomorphic structures

## Benchmark

```
benchmarking alter
time                 698.5 μs   (676.3 μs .. 726.1 μs)
                     0.994 R²   (0.991 R² .. 0.999 R²)
mean                 674.8 μs   (668.6 μs .. 686.6 μs)
std dev              28.63 μs   (14.53 μs .. 45.31 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking alterF
time                 969.5 μs   (962.1 μs .. 977.3 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 956.7 μs   (952.8 μs .. 961.1 μs)
std dev              13.98 μs   (11.21 μs .. 17.72 μs)

benchmarking alterFIdentity
time                 660.7 μs   (654.5 μs .. 673.4 μs)
                     0.994 R²   (0.990 R² .. 0.997 R²)
mean                 674.1 μs   (660.4 μs .. 691.3 μs)
std dev              49.44 μs   (38.40 μs .. 57.64 μs)
variance introduced by outliers: 61% (severely inflated)

benchmarking alterFConst
time                 14.98 μs   (13.94 μs .. 16.02 μs)
                     0.976 R²   (0.972 R² .. 0.990 R²)
mean                 15.12 μs   (14.57 μs .. 15.84 μs)
std dev              2.104 μs   (1.813 μs .. 2.236 μs)
variance introduced by outliers: 92% (severely inflated)
```

This addresses #325.