### PR TITLE
Add powerSet to Data.Set

### DIFF
--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -80,6 +80,7 @@ module Data.Set (
             , singleton
             , insert
             , delete
+            , powerSet
 
             -- * Combine
             , union

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -145,6 +145,7 @@ module Data.Set.Internal (
             , singleton
             , insert
             , delete
+            , powerSet
 
             -- * Combine
             , union
@@ -246,7 +247,8 @@ import GHC.Exts ( build, lazy )
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
 #endif
-import Text.Read
+import Text.Read ( readPrec, Read (..), Lexeme (..), parens, prec
+                 , lexP, readListPrecDefault )
 import Data.Data
 #endif
 
@@ -1660,6 +1662,17 @@ splitRoot orig =
     Bin _ v l r -> [l, singleton v, r]
 {-# INLINE splitRoot #-}
 
+
+-- | Calculate the power set of a set: the set of all its subsets.
+--
+-- @
+-- t `member` powerSet s == t `isSubsetOf` s
+-- @
+--
+-- @since 0.5.11
+powerSet :: Set a -> Set (Set a)
+powerSet xs0 = insertMin empty (foldr' step Tip xs0) where
+  step x pxs = insertMin (singleton x) (insertMin x `mapMonotonic` pxs) `glue` pxs
 
 {--------------------------------------------------------------------
   Debugging

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
 
 * Add a `MonadFix` instance for `Data.Tree`.
 
+* Add `powerSet` for `Data.Set` (Thanks, Edward Kmett!)
+
 * Make `>>=` for `Data.Tree` strict in the result of its second argument;
   being too lazy here is almost useless, and violates one of the monad identity
   laws. Specifically, `return () >>= \_ -> undefined` should always be

--- a/tests/set-properties.hs
+++ b/tests/set-properties.hs
@@ -93,6 +93,7 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testProperty "take"                 prop_take
                    , testProperty "drop"                 prop_drop
                    , testProperty "splitAt"              prop_splitAt
+                   , testProperty "powerSet"             prop_powerSet
                    ]
 
 -- A type with a peculiar Eq instance designed to make sure keys
@@ -602,6 +603,17 @@ prop_spanAntitone xs' = valid tw .&&. valid dw
   where
     xs = fromList xs'
     (tw, dw) = spanAntitone isLeft xs
+
+prop_powerSet :: Set Int -> Property
+prop_powerSet xs = valid ps .&&. ps === ps'
+  where
+    xs' = take 10 xs
+
+    ps = powerSet xs'
+    ps' = fromList . fmap fromList $ lps (toList xs')
+
+    lps [] = [[]]
+    lps (y : ys) = fmap (y:) (lps ys) ++ lps ys
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True


### PR DESCRIPTION
This should be somewhat more efficient than what can be written
using the public API because it can glue trees together without
needing to perform a full divide-and-conquer union

Addresses #442