### PR TITLE
Mark Internal modules not-home

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE TypeFamilies #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 #include "containers.h"
 
 -----------------------------------------------------------------------------

--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE TypeFamilies #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 #include "containers.h"
 
 -----------------------------------------------------------------------------

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -17,6 +17,8 @@
 {-# LANGUAGE MagicHash #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 #include "containers.h"
 
 #if !(WORD_SIZE_IN_BITS >= 61)

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -3,6 +3,7 @@
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
+{-# OPTIONS_HADDOCK not-home #-}
 
 #include "containers.h"
 

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -21,6 +21,8 @@
 {-# LANGUAGE ViewPatterns #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Sequence.Internal

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE TypeFamilies #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 #include "containers.h"
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Let Haddock know that it shouldn't consider the `Internal` modules
home for any identifiers. This should've been done when I exposed
those internal modules. Whoops.