### PR TITLE
Update replicateM post-AMP

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -62,7 +62,7 @@ module Data.Sequence (
     -- ** Repetition
     replicate,      -- :: Int -> a -> Seq a
     replicateA,     -- :: Applicative f => Int -> f a -> f (Seq a)
-    replicateM,     -- :: Monad m => Int -> m a -> m (Seq a)
+    replicateM,     -- :: Applicative m => Int -> m a -> m (Seq a)
     cycleTaking,    -- :: Int -> Seq a -> Seq a
     -- ** Iterative construction
     iterateN,       -- :: Int -> (a -> a) -> a -> Seq a

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
 * Add `powerSet` for `Data.Set` (Thanks, Edward Kmett!)
 
+* Make `Data.Sequence.replicateM` a synonym for `replicateA`
+  for post-AMP `base`.
+
 * Make `>>=` for `Data.Tree` strict in the result of its second argument;
   being too lazy here is almost useless, and violates one of the monad identity
   laws. Specifically, `return () >>= \_ -> undefined` should always be


### PR DESCRIPTION
Make `replicateM` a synonym for `replicateA` for `base >= 4.8.0`.