### PR TITLE
Improve inference for IsString instance for Seq

### DIFF
--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -6,15 +6,13 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 #endif
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE DeriveGeneric #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE TypeFamilies #-}
 #endif
 #ifdef DEFINE_PATTERN_SYNONYMS
 {-# LANGUAGE PatternSynonyms #-}
@@ -3928,7 +3926,7 @@ instance GHC.Exts.IsList (Seq a) where
 
 #ifdef __GLASGOW_HASKELL__
 -- | @since 0.5.7
-instance IsString (Seq Char) where
+instance a ~ Char => IsString (Seq a) where
     fromString = fromList
 #endif
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,7 @@
 
 ## 0.5.11
 
-* Speed up unstable sorting for `Data.Sequence` (Thanks, Donnacha
-  Oisín Kidney!)
+### New functions and classes
 
 * Add a `MonadFix` instance for `Data.Sequence`.
 
@@ -11,22 +10,34 @@
 
 * Add `powerSet` for `Data.Set` (Thanks, Edward Kmett!)
 
+* Add `lookupMin` and `lookupMax` to `Data.IntMap` (Thanks, bwroga!)
+
+### Changes to existing functions and features
+
+* Rewrite the `IsString` instance head for sequences, improving compatibility
+  with the list instance and also improving type inference.
+
 * Make `>>=` for `Data.Tree` strict in the result of its second argument;
   being too lazy here is almost useless, and violates one of the monad identity
   laws. Specifically, `return () >>= \_ -> undefined` should always be
   `undefined`, but this was not the case.
 
-* Add `lookupMin` and `lookupMax` to `Data.IntMap` (Thanks, bwroga!)
+### Performance improvement
+
+* Speed up unstable sorting for `Data.Sequence` (Thanks, Donnacha
+  Oisín Kidney!)
+
+### Other changes
 
 * Update for recent and upcoming GHC and Cabal versions (Thanks, Herbert
   Valerio Reidel, Simon Jakobi, and Ryan Scott!)
 
 * Improve documentation (Thanks, Oleg Grenrus and Benjamin Hodgson!)
 
-* Add a (very incomplete) test suite for `Data.Tree`.
-
 * Add Haddock `@since` annotations for changes made since version
   0.5.4 (Thanks, Simon Jakobi!)
+
+* Add a (very incomplete) test suite for `Data.Tree`.
 
 ## 0.5.10.2
 


### PR DESCRIPTION
When I originally added an `IsString` instance for `Seq`, we
conservatively used

```haskell
instance IsString (Seq Char)
```

to allow for the possibility that we might eventually want to write
additional instances. But the result is very bad inference and
a discrepency with the instance for lists. So let's not do that.