### PR TITLE
Added HasCallStack to partial functions

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -331,6 +331,8 @@ import qualified Control.Category as Category
 import Data.Coerce
 #endif
 
+import GHC.Stack (HasCallStack)
+
 
 -- A "Nat" is a natural machine word (an unsigned Int)
 type Nat = Word
@@ -390,7 +392,7 @@ bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)
 -- > fromList [(5,'a'), (3,'b')] ! 1    Error: element not in the map
 -- > fromList [(5,'a'), (3,'b')] ! 5 == 'a'
 
-(!) :: IntMap a -> Key -> a
+(!) :: HasCallStack => IntMap a -> Key -> a
 (!) m k = find k m
 
 -- | /O(min(n,W))/. Find the value at a key.
@@ -2169,11 +2171,11 @@ minView :: IntMap a -> Maybe (a, IntMap a)
 minView t = liftM (first snd) (minViewWithKey t)
 
 -- | /O(min(n,W))/. Delete and find the maximal element.
-deleteFindMax :: IntMap a -> ((Key, a), IntMap a)
+deleteFindMax :: HasCallStack => IntMap a -> ((Key, a), IntMap a)
 deleteFindMax = fromMaybe (error "deleteFindMax: empty map has no maximal element") . maxViewWithKey
 
 -- | /O(min(n,W))/. Delete and find the minimal element.
-deleteFindMin :: IntMap a -> ((Key, a), IntMap a)
+deleteFindMin :: HasCallStack => IntMap a -> ((Key, a), IntMap a)
 deleteFindMin = fromMaybe (error "deleteFindMin: empty map has no minimal element") . minViewWithKey
 
 -- | /O(min(n,W))/. The minimal key of the map. Returns 'Nothing' if the map is empty.
@@ -2188,7 +2190,7 @@ lookupMin (Bin _ m l r)
           go Nil            = Nothing
 
 -- | /O(min(n,W))/. The minimal key of the map. Calls 'error' if the map is empty.
-findMin :: IntMap a -> (Key, a)
+findMin :: HasCallStack => IntMap a -> (Key, a)
 findMin t
   | Just r <- lookupMin t = r
   | otherwise = error "findMin: empty map has no minimal element"
@@ -2205,7 +2207,7 @@ lookupMax (Bin _ m l r)
           go Nil            = Nothing
 
 -- | /O(min(n,W))/. The maximal key of the map. Calls 'error' if the map is empty.
-findMax :: IntMap a -> (Key, a)
+findMax :: HasCallStack => IntMap a -> (Key, a)
 findMax t
   | Just r <- lookupMax t = r
   | otherwise = error "findMax: empty map has no maximal element"

--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -216,6 +216,7 @@ import qualified GHC.Exts as GHCExts
 import GHC.Prim (indexInt8OffAddr#)
 #endif
 
+import GHC.Stack (HasCallStack)
 
 infixl 9 \\{-This comment teaches CPP correct behaviour -}
 
@@ -793,18 +794,18 @@ minView t =
 -- | /O(min(n,W))/. Delete and find the minimal element.
 --
 -- > deleteFindMin set = (findMin set, deleteMin set)
-deleteFindMin :: IntSet -> (Key, IntSet)
+deleteFindMin :: HasCallStack => IntSet -> (Key, IntSet)
 deleteFindMin = fromMaybe (error "deleteFindMin: empty set has no minimal element") . minView
 
 -- | /O(min(n,W))/. Delete and find the maximal element.
 --
 -- > deleteFindMax set = (findMax set, deleteMax set)
-deleteFindMax :: IntSet -> (Key, IntSet)
+deleteFindMax :: HasCallStack => IntSet -> (Key, IntSet)
 deleteFindMax = fromMaybe (error "deleteFindMax: empty set has no maximal element") . maxView
 
 
 -- | /O(min(n,W))/. The minimal element of the set.
-findMin :: IntSet -> Key
+findMin :: HasCallStack => IntSet -> Key
 findMin Nil = error "findMin: empty set has no minimal element"
 findMin (Tip kx bm) = kx + lowestBitSet bm
 findMin (Bin _ m l r)
@@ -815,7 +816,7 @@ findMin (Bin _ m l r)
           find Nil            = error "findMin Nil"
 
 -- | /O(min(n,W))/. The maximal element of a set.
-findMax :: IntSet -> Key
+findMax :: HasCallStack => IntSet -> Key
 findMax Nil = error "findMax: empty set has no maximal element"
 findMax (Tip kx bm) = kx + highestBitSet bm
 findMax (Bin _ m l r)

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -411,6 +411,7 @@ import qualified Control.Category as Category
 import Data.Coerce
 #endif
 
+import GHC.Stack (HasCallStack)
 
 {--------------------------------------------------------------------
   Operators
@@ -423,7 +424,7 @@ infixl 9 !,!?,\\ --
 -- > fromList [(5,'a'), (3,'b')] ! 1    Error: element not in the map
 -- > fromList [(5,'a'), (3,'b')] ! 5 == 'a'
 
-(!) :: Ord k => Map k a -> k -> a
+(!) :: (HasCallStack, Ord k) => Map k a -> k -> a
 (!) m k = find k m
 #if __GLASGOW_HASKELL__
 {-# INLINE (!) #-}
@@ -1433,7 +1434,7 @@ alterFYoneda = go
 -- > findIndex 6 (fromList [(5,"a"), (3,"b")])    Error: element is not in the map
 
 -- See Note: Type of local 'go' function
-findIndex :: Ord k => k -> Map k a -> Int
+findIndex :: (HasCallStack, Ord k) => k -> Map k a -> Int
 findIndex = go 0
   where
     go :: Ord k => Int -> k -> Map k a -> Int
@@ -1477,7 +1478,7 @@ lookupIndex = go 0
 -- > elemAt 1 (fromList [(5,"a"), (3,"b")]) == (5, "a")
 -- > elemAt 2 (fromList [(5,"a"), (3,"b")])    Error: index out of range
 
-elemAt :: Int -> Map k a -> (k,a)
+elemAt :: HasCallStack => Int -> Map k a -> (k,a)
 elemAt !_ Tip = error "Map.elemAt: index out of range"
 elemAt i (Bin _ kx x l r)
   = case compare i sizeL of
@@ -1566,7 +1567,7 @@ splitAt i0 m0
 -- > updateAt (\_ _  -> Nothing)  2    (fromList [(5,"a"), (3,"b")])    Error: index out of range
 -- > updateAt (\_ _  -> Nothing)  (-1) (fromList [(5,"a"), (3,"b")])    Error: index out of range
 
-updateAt :: (k -> a -> Maybe a) -> Int -> Map k a -> Map k a
+updateAt :: HasCallStack => (k -> a -> Maybe a) -> Int -> Map k a -> Map k a
 updateAt f !i t =
   case t of
     Tip -> error "Map.updateAt: index out of range"
@@ -1588,7 +1589,7 @@ updateAt f !i t =
 -- > deleteAt 2 (fromList [(5,"a"), (3,"b")])     Error: index out of range
 -- > deleteAt (-1) (fromList [(5,"a"), (3,"b")])  Error: index out of range
 
-deleteAt :: Int -> Map k a -> Map k a
+deleteAt :: HasCallStack => Int -> Map k a -> Map k a
 deleteAt !i t =
   case t of
     Tip -> error "Map.deleteAt: index out of range"
@@ -1624,7 +1625,7 @@ lookupMin (Bin _ k x l _) = Just $! lookupMinSure k x l
 -- > findMin (fromList [(5,"a"), (3,"b")]) == (3,"b")
 -- > findMin empty                            Error: empty map has no minimal element
 
-findMin :: Map k a -> (k,a)
+findMin :: HasCallStack => Map k a -> (k,a)
 findMin t
   | Just r <- lookupMin t = r
   | otherwise = error "Map.findMin: empty map has no minimal element"
@@ -1649,7 +1650,7 @@ lookupMax :: Map k a -> Maybe (k, a)
 lookupMax Tip = Nothing
 lookupMax (Bin _ k x _ r) = Just $! lookupMaxSure k x r
 
-findMax :: Map k a -> (k,a)
+findMax :: HasCallStack => Map k a -> (k,a)
 findMax t
   | Just r <- lookupMax t = r
   | otherwise = error "Map.findMax: empty map has no maximal element"
@@ -2661,7 +2662,7 @@ mergeA
 -- @only2@ are 'id' and @'const' 'empty'@, but for example @'map' f@,
 -- @'filterWithKey' f@, or @'mapMaybeWithKey' f@ could be used for any @f@.
 
-mergeWithKey :: Ord k
+mergeWithKey :: (HasCallStack, Ord k)
              => (k -> a -> b -> Maybe c)
              -> (Map k a -> Map k c)
              -> (Map k b -> Map k c)
@@ -3866,7 +3867,7 @@ maxViewSure = go
 -- > deleteFindMin (fromList [(5,"a"), (3,"b"), (10,"c")]) == ((3,"b"), fromList[(5,"a"), (10,"c")])
 -- > deleteFindMin                                            Error: can not return the minimal element of an empty map
 
-deleteFindMin :: Map k a -> ((k,a),Map k a)
+deleteFindMin :: HasCallStack => Map k a -> ((k,a),Map k a)
 deleteFindMin t = case minViewWithKey t of
   Nothing -> (error "Map.deleteFindMin: can not return the minimal element of an empty map", Tip)
   Just res -> res
@@ -3876,7 +3877,7 @@ deleteFindMin t = case minViewWithKey t of
 -- > deleteFindMax (fromList [(5,"a"), (3,"b"), (10,"c")]) == ((10,"c"), fromList [(3,"b"), (5,"a")])
 -- > deleteFindMax empty                                      Error: can not return the maximal element of an empty map
 
-deleteFindMax :: Map k a -> ((k,a),Map k a)
+deleteFindMax :: HasCallStack => Map k a -> ((k,a),Map k a)
 deleteFindMax t = case maxViewWithKey t of
   Nothing -> (error "Map.deleteFindMax: can not return the maximal element of an empty map", Tip)
   Just res -> res

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -418,6 +418,8 @@ import Data.Coerce
 import Data.Functor.Identity (Identity (..))
 #endif
 
+import GHC.Stack (HasCallStack)
+
 
 -- $strictness
 --
@@ -881,7 +883,7 @@ atKeyIdentity k f t = Identity $ atKeyPlain Strict k (coerce f) t
 -- > updateAt (\_ _  -> Nothing)  2    (fromList [(5,"a"), (3,"b")])    Error: index out of range
 -- > updateAt (\_ _  -> Nothing)  (-1) (fromList [(5,"a"), (3,"b")])    Error: index out of range
 
-updateAt :: (k -> a -> Maybe a) -> Int -> Map k a -> Map k a
+updateAt :: HasCallStack => (k -> a -> Maybe a) -> Int -> Map k a -> Map k a
 updateAt f i t = i `seq`
   case t of
     Tip -> error "Map.updateAt: index out of range"

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -259,6 +259,8 @@ import Text.Read ( readPrec, Read (..), Lexeme (..), parens, prec
 import Data.Data
 #endif
 
+import GHC.Stack (HasCallStack)
+
 
 {--------------------------------------------------------------------
   Operators
@@ -644,7 +646,7 @@ lookupMin Tip = Nothing
 lookupMin (Bin _ x l _) = Just $! lookupMinSure x l
 
 -- | /O(log n)/. The minimal element of a set.
-findMin :: Set a -> a
+findMin :: HasCallStack => Set a -> a
 findMin t
   | Just r <- lookupMin t = r
   | otherwise = error "Set.findMin: empty set has no minimal element"
@@ -662,7 +664,7 @@ lookupMax Tip = Nothing
 lookupMax (Bin _ x _ r) = Just $! lookupMaxSure x r
 
 -- | /O(log n)/. The maximal element of a set.
-findMax :: Set a -> a
+findMax :: HasCallStack => Set a -> a
 findMax t
   | Just r <- lookupMax t = r
   | otherwise = error "Set.findMax: empty set has no maximal element"
@@ -1188,7 +1190,7 @@ splitMember x (Bin _ y l r)
 -- @since 0.5.4
 
 -- See Note: Type of local 'go' function
-findIndex :: Ord a => a -> Set a -> Int
+findIndex :: (HasCallStack, Ord a) => a -> Set a -> Int
 findIndex = go 0
   where
     go :: Ord a => Int -> a -> Set a -> Int
@@ -1236,7 +1238,7 @@ lookupIndex = go 0
 --
 -- @since 0.5.4
 
-elemAt :: Int -> Set a -> a
+elemAt :: HasCallStack => Int -> Set a -> a
 elemAt !_ Tip = error "Set.elemAt: index out of range"
 elemAt i (Bin _ x l r)
   = case compare i sizeL of
@@ -1257,7 +1259,7 @@ elemAt i (Bin _ x l r)
 --
 -- @since 0.5.4
 
-deleteAt :: Int -> Set a -> Set a
+deleteAt :: HasCallStack => Int -> Set a -> Set a
 deleteAt !i t =
   case t of
     Tip -> error "Set.deleteAt: index out of range"
@@ -1464,7 +1466,7 @@ glue l@(Bin sl xl ll lr) r@(Bin sr xr rl rr)
 --
 -- > deleteFindMin set = (findMin set, deleteMin set)
 
-deleteFindMin :: Set a -> (a,Set a)
+deleteFindMin :: HasCallStack => Set a -> (a,Set a)
 deleteFindMin t
   | Just r <- minView t = r
   | otherwise = (error "Set.deleteFindMin: can not return the minimal element of an empty set", Tip)
@@ -1472,7 +1474,7 @@ deleteFindMin t
 -- | /O(log n)/. Delete and find the maximal element.
 --
 -- > deleteFindMax set = (findMax set, deleteMax set)
-deleteFindMax :: Set a -> (a,Set a)
+deleteFindMax :: HasCallStack => Set a -> (a,Set a)
 deleteFindMax t
   | Just r <- maxView t = r
   | otherwise = (error "Set.deleteFindMax: can not return the maximal element of an empty set", Tip)


### PR DESCRIPTION
As discussed on Issue https://github.com/haskell/containers/issues/489, this PR adds `HasCallStack` to the constraints of partial functions.  I think I got all of the relevant partial functions, but I'd be happy for someone to double check that I didn't miss anything.

I ran the benchmarks (`stack bench`) before and after these changes and have attached them ([before_hascallstack.bench.txt](https://github.com/haskell/containers/files/1628500/before_hascallstack.bench.txt), [after_hascallstack.bench.txt](https://github.com/haskell/containers/files/1628499/after_hascallstack.bench.txt)).  I scanned through the results, trying to pay attention to tests on partial functions specifically, but I didn't notice any changes (outside of expected deviations within the margin of error).

Please let me know if there's more that I can do to help get this PR successfully merged.