### PR TITLE
Add unzips for sequences

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -211,13 +211,15 @@ module Data.Sequence (
     traverseWithIndex, -- :: Applicative f => (Int -> a -> f b) -> Seq a -> f (Seq b)
     reverse,        -- :: Seq a -> Seq a
     intersperse,    -- :: a -> Seq a -> Seq a
-    -- ** Zips
+    -- ** Zips and unzip
     zip,            -- :: Seq a -> Seq b -> Seq (a, b)
     zipWith,        -- :: (a -> b -> c) -> Seq a -> Seq b -> Seq c
     zip3,           -- :: Seq a -> Seq b -> Seq c -> Seq (a, b, c)
     zipWith3,       -- :: (a -> b -> c -> d) -> Seq a -> Seq b -> Seq c -> Seq d
     zip4,           -- :: Seq a -> Seq b -> Seq c -> Seq d -> Seq (a, b, c, d)
     zipWith4,       -- :: (a -> b -> c -> d -> e) -> Seq a -> Seq b -> Seq c -> Seq d -> Seq e
+    unzip,          -- :: Seq (a, b) -> (Seq a, Seq b)
+    unzipWith       -- :: (a -> (b, c)) -> Seq a -> (Seq b, Seq c)
     ) where
 
 import Data.Sequence.Internal

--- a/changelog.md
+++ b/changelog.md
@@ -11,12 +11,15 @@
 * Add `powerSet`, `cartesianProduct`, and `disjointUnion` for
   `Data.Set` (Thanks, Edward Kmett!)
 
-* Make `Data.Sequence.replicateM` a synonym for `replicateA`
-  for post-AMP `base`.
-
 * Add `lookupMin` and `lookupMax` to `Data.IntMap` (Thanks, bwroga!)
 
+* Add `unzip` and `unzipWith` to `Data.Sequence`. Make unzipping
+  build its results in lockstep to avoid certain space leaks.
+
 ### Changes to existing functions and features
+
+* Make `Data.Sequence.replicateM` a synonym for `replicateA`
+  for post-AMP `base`.
 
 * Rewrite the `IsString` instance head for sequences, improving compatibility
   with the list instance and also improving type inference.


### PR DESCRIPTION
* Add `unzip` and `unzipWith` to `Data.Sequence`.

* Make `unzipWith` *actually* avoid certain space leaks by
  ensuring that the result trees are constructed in lock-step.