### PR TITLE
IntSetValidity: Fix the maskPowerOfTwo invariant check

### DIFF
--- a/tests/IntSetValidity.hs
+++ b/tests/IntSetValidity.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 module IntSetValidity (valid) where
 
-import Data.Bits (xor, (.&.), popCount)
+import Data.Bits (xor, (.&.))
 import Data.IntSet.Internal
 import Test.QuickCheck (Property, counterexample, property, (.&&.))
 
@@ -39,7 +39,7 @@ maskPowerOfTwo t =
     Nil -> True
     Tip _ _ -> True
     Bin _ m l r ->
-      popCount m == 1 && maskPowerOfTwo l && maskPowerOfTwo r
+      bitcount 0 m == 1 && maskPowerOfTwo l && maskPowerOfTwo r
 
 -- Invariant: Prefix is the common high-order bits that all elements share to
 --            the left of the Mask bit.

--- a/tests/IntSetValidity.hs
+++ b/tests/IntSetValidity.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 module IntSetValidity (valid) where
 
-import Data.Bits (xor, (.&.))
+import Data.Bits (xor, (.&.), popCount)
 import Data.IntSet.Internal
 import Test.QuickCheck (Property, counterexample, property, (.&&.))
 
@@ -39,7 +39,7 @@ maskPowerOfTwo t =
     Nil -> True
     Tip _ _ -> True
     Bin _ m l r ->
-      (m `mod` 2 == 0) && maskPowerOfTwo l && maskPowerOfTwo r
+      popCount m == 1 && maskPowerOfTwo l && maskPowerOfTwo r
 
 -- Invariant: Prefix is the common high-order bits that all elements share to
 --            the left of the Mask bit.


### PR DESCRIPTION
    m `mod` 2 == 0

does not check that `m` is a power fo two. But every number with a
popCount of 1 is!