### PR TITLE
Move bitcount to Utils.Internal.BitUtil.

### DIFF
--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -1457,28 +1457,6 @@ foldr'Bits prefix f z bm = let lb = lowestBitSet bm
 
 #endif
 
-{----------------------------------------------------------------------
-  [bitcount] as posted by David F. Place to haskell-cafe on April 11, 2006,
-  based on the code on
-  http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan,
-  where the following source is given:
-    Published in 1988, the C Programming Language 2nd Ed. (by Brian W.
-    Kernighan and Dennis M. Ritchie) mentions this in exercise 2-9. On April
-    19, 2006 Don Knuth pointed out to me that this method "was first published
-    by Peter Wegner in CACM 3 (1960), 322. (Also discovered independently by
-    Derrick Lehmer and published in 1964 in a book edited by Beckenbach.)"
-----------------------------------------------------------------------}
-
-bitcount :: Int -> Word -> Int
-#if MIN_VERSION_base(4,5,0)
-bitcount a x = a + popCount x
-#else
-bitcount a0 x0 = go a0 x0
-  where go a 0 = a
-        go a x = go (a + 1) (x .&. (x-1))
-#endif
-{-# INLINE bitcount #-}
-
 
 {--------------------------------------------------------------------
   Utilities

--- a/Utils/Containers/Internal/BitUtil.hs
+++ b/Utils/Containers/Internal/BitUtil.hs
@@ -42,7 +42,7 @@ import Data.Bits ((.|.), xor)
 #if MIN_VERSION_base(4,5,0)
 import Data.Bits (popCount, unsafeShiftL, unsafeShiftR)
 #else
-import Data.Bits (shiftL, shiftR)
+import Data.Bits ((.&.), shiftL, shiftR)
 #endif
 #if MIN_VERSION_base(4,7,0)
 import Data.Bits (finiteBitSize)

--- a/Utils/Containers/Internal/BitUtil.hs
+++ b/Utils/Containers/Internal/BitUtil.hs
@@ -31,7 +31,8 @@
 -- closely.
 
 module Utils.Containers.Internal.BitUtil
-    ( highestBitMask
+    ( bitcount
+    , highestBitMask
     , shiftLL
     , shiftRL
     , wordSize
@@ -39,7 +40,7 @@ module Utils.Containers.Internal.BitUtil
 
 import Data.Bits ((.|.), xor)
 #if MIN_VERSION_base(4,5,0)
-import Data.Bits (unsafeShiftL, unsafeShiftR)
+import Data.Bits (popCount, unsafeShiftL, unsafeShiftR)
 #else
 import Data.Bits (shiftL, shiftR)
 #endif
@@ -52,6 +53,28 @@ import Data.Bits (bitSize)
 #if !MIN_VERSION_base (4,8,0)
 import Data.Word (Word)
 #endif
+
+{----------------------------------------------------------------------
+  [bitcount] as posted by David F. Place to haskell-cafe on April 11, 2006,
+  based on the code on
+  http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan,
+  where the following source is given:
+    Published in 1988, the C Programming Language 2nd Ed. (by Brian W.
+    Kernighan and Dennis M. Ritchie) mentions this in exercise 2-9. On April
+    19, 2006 Don Knuth pointed out to me that this method "was first published
+    by Peter Wegner in CACM 3 (1960), 322. (Also discovered independently by
+    Derrick Lehmer and published in 1964 in a book edited by Beckenbach.)"
+----------------------------------------------------------------------}
+
+bitcount :: Int -> Word -> Int
+#if MIN_VERSION_base(4,5,0)
+bitcount a x = a + popCount x
+#else
+bitcount a0 x0 = go a0 x0
+  where go a 0 = a
+        go a x = go (a + 1) (x .&. (x-1))
+#endif
+{-# INLINE bitcount #-}
 
 -- The highestBitMask implementation is based on
 -- http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2


### PR DESCRIPTION
This utility function will be needed by IntSet.Internal, IntSetValidity, and IntMapValidity.