### PR TITLE
Minmaxview fixup

### DIFF
--- a/benchmarks/IntMap.hs
+++ b/benchmarks/IntMap.hs
@@ -40,6 +40,8 @@ main = do
         , bench "fromList" $ whnf M.fromList elems
         , bench "fromAscList" $ whnf M.fromAscList elems
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
+        , bench "minView" $ whnf (maybe 0 (\((k,v), m) -> k+v+M.size m) . M.minViewWithKey)
+                    (M.fromList $ zip [1..10] [1..10])
         ]
   where
     elems = zip keys values

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -91,6 +91,7 @@ main = do
         , bench "fromList-desc" $ whnf M.fromList (reverse elems)
         , bench "fromAscList" $ whnf M.fromAscList elems
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
+        , bench "minView" $ whnf (\m' -> case M.minViewWithKey m' of {Nothing -> 0; Just ((k,v),m'') -> k+v+M.size m''}) (M.fromAscList $ zip [1..10::Int] [100..110::Int])
         ]
   where
     bound = 2^12


### PR DESCRIPTION
* Harmonize laziness (not strictness!) of min and max views between
`IntMap` and `Map`.

* Improve GHC's ability to unbox the results of min and max views
  for `IntMap`.

Benchmark improvements are tiny, but I think we should do this anyway because it can potentially reduce allocation.