### PR TITLE
Fix power of 2 validity check.

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -359,6 +359,8 @@ data IntMap a = Bin {-# UNPACK #-} !Prefix
 --   mask: The switching bit to determine if a key should follow the left
 --         or right subtree of a 'Bin'.
 -- Invariant: Nil is never found as a child of Bin.
+-- Invariant: The Mask is a power of 2. It is the largest bit position at which
+--            two keys of the map differ.
 -- Invariant: Prefix is the common high-order bits that all elements share to
 --            the left of the Mask bit.
 -- Invariant: In Bin prefix mask left right, left consists of the elements that

--- a/tests/IntMapValidity.hs
+++ b/tests/IntMapValidity.hs
@@ -3,6 +3,7 @@ module IntMapValidity (valid) where
 import Data.Bits (xor, (.&.))
 import Data.IntMap.Internal
 import Test.QuickCheck (Property, counterexample, property, (.&&.))
+import Utils.Containers.Internal.BitUtil (bitcount)
 
 {--------------------------------------------------------------------
   Assertions
@@ -27,6 +28,16 @@ nilNeverChildOfBin t =
         Nil -> False
         Tip _ _ -> True
         Bin _ _ l' r' -> noNilInSet l' && noNilInSet r'
+
+-- Invariant: The Mask is a power of 2. It is the largest bit position at which
+--            two keys of the map differ.
+maskPowerOfTwo :: IntMap a -> Bool
+maskPowerOfTwo t =
+  case t of
+    Nil -> True
+    Tip _ _ -> True
+    Bin _ m l r ->
+      bitcount 0 (fromIntegral m) == 1 && maskPowerOfTwo l && maskPowerOfTwo r
 
 -- Invariant: Prefix is the common high-order bits that all elements share to
 --            the left of the Mask bit.

--- a/tests/IntSetValidity.hs
+++ b/tests/IntSetValidity.hs
@@ -4,6 +4,7 @@ module IntSetValidity (valid) where
 import Data.Bits (xor, (.&.))
 import Data.IntSet.Internal
 import Test.QuickCheck (Property, counterexample, property, (.&&.))
+import Utils.Containers.Internal.BitUtil (bitcount)
 
 {--------------------------------------------------------------------
   Assertions
@@ -39,7 +40,7 @@ maskPowerOfTwo t =
     Nil -> True
     Tip _ _ -> True
     Bin _ m l r ->
-      (m `mod` 2 == 0) && maskPowerOfTwo l && maskPowerOfTwo r
+      bitcount 0 (fromIntegral m) == 1 && maskPowerOfTwo l && maskPowerOfTwo r
 
 -- Invariant: Prefix is the common high-order bits that all elements share to
 --            the left of the Mask bit.


### PR DESCRIPTION
Previously an incorrect check of divisible by 2 was being performed, this fixes
the existing behaviour for `IntSet` and adds the check to `IntMap` as wel.