### PR TITLE
Faster traverse

### DIFF
--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -248,7 +248,7 @@ import qualified Data.Array
 import qualified GHC.Arr
 #endif
 
-import Utils.Containers.Internal.Coercions ((.#), (.^#), (#.))
+import Utils.Containers.Internal.Coercions ((.#), (.^#))
 -- Coercion on GHC 7.8+
 #if __GLASGOW_HASKELL__ >= 708
 import Data.Coerce
@@ -427,37 +427,75 @@ instance Foldable Seq where
 instance Traversable Seq where
     {-# INLINE traverse #-}
     traverse f' (Seq EmptyT) = pure (Seq EmptyT)
-    traverse f' (Seq (Single (Elem x'))) = (Seq . Single . Elem) <$> f' x'
+    traverse f' (Seq (Single (Elem x'))) =
+        (\x'' -> Seq (Single (Elem x''))) <$> f' x'
     traverse f' (Seq (Deep s' pr' m' sf')) =
-        liftA3 (\pr'' m'' sf'' -> Seq (Deep s' pr'' m'' sf''))
+        liftA3
+            (\pr'' m'' sf'' -> Seq (Deep s' pr'' m'' sf''))
             (traverseDigitE f' pr')
             (traverseTree (traverseNodeE f') m')
             (traverseDigitE f' sf')
       where
-        traverseTree :: Applicative f => (Node a -> f (Node b)) -> FingerTree (Node a) -> f (FingerTree (Node b))
+        traverseTree
+            :: Applicative f
+            => (Node a -> f (Node b))
+            -> FingerTree (Node a)
+            -> f (FingerTree (Node b))
         traverseTree _ EmptyT = pure EmptyT
         traverseTree f (Single x) = Single <$> f x
-        traverseTree f (Deep s pr m sf) = 
-            liftA3 (Deep s) 
+        traverseTree f (Deep s pr m sf) =
+            liftA3
+                (Deep s)
                 (traverseDigitN f pr)
                 (traverseTree (traverseNodeN f) m)
                 (traverseDigitN f sf)
-
-        traverseDigitE :: Applicative f => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
-        traverseDigitE f (One (Elem a)) = One . Elem <$> f a
-        traverseDigitE f (Two (Elem a) (Elem b)) = liftA2 (\a' b' -> Two (Elem a') (Elem b')) (f a) (f b)
-        traverseDigitE f (Three (Elem a) (Elem b) (Elem c)) = liftA3 (\a' b' c' -> Three (Elem a') (Elem b') (Elem c')) (f a) (f b) (f c)
-        traverseDigitE f (Four (Elem a) (Elem b) (Elem c) (Elem d)) = liftA3 (\a' b' c' d' -> Four (Elem a') (Elem b') (Elem c') (Elem d')) (f a) (f b) (f c) <*> f d
-
-        traverseDigitN :: Applicative f => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
+        traverseDigitE
+            :: Applicative f
+            => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
+        traverseDigitE f (One (Elem a)) =
+            (\a' -> One (Elem a')) <$>
+            f a
+        traverseDigitE f (Two (Elem a) (Elem b)) =
+            liftA2
+                (\a' b' -> Two (Elem a') (Elem b'))
+                (f a)
+                (f b)
+        traverseDigitE f (Three (Elem a) (Elem b) (Elem c)) =
+            liftA3
+                (\a' b' c' ->
+                      Three (Elem a') (Elem b') (Elem c'))
+                (f a)
+                (f b)
+                (f c)
+        traverseDigitE f (Four (Elem a) (Elem b) (Elem c) (Elem d)) =
+            liftA3
+                (\a' b' c' d' -> Four (Elem a') (Elem b') (Elem c') (Elem d'))
+                (f a)
+                (f b)
+                (f c) <*> 
+                (f d)
+        traverseDigitN
+            :: Applicative f
+            => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
         traverseDigitN f t = traverse f t
-
-        traverseNodeE :: Applicative f => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
-        traverseNodeE f (Node2 s (Elem a) (Elem b)) = liftA2 (\a' b' -> Node2 s (Elem a') (Elem b')) (f a) (f b)
-        traverseNodeE f (Node3 s (Elem a) (Elem b) (Elem c)) = liftA3 (\a' b' c' -> Node3 s (Elem a') (Elem b') (Elem c')) (f a) (f b) (f c)
-
-
-        traverseNodeN :: Applicative f => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))
+        traverseNodeE
+            :: Applicative f
+            => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
+        traverseNodeE f (Node2 s (Elem a) (Elem b)) =
+            liftA2
+                (\a' b' -> Node2 s (Elem a') (Elem b'))
+                (f a)
+                (f b)
+        traverseNodeE f (Node3 s (Elem a) (Elem b) (Elem c)) =
+            liftA3
+                (\a' b' c' ->
+                      Node3 s (Elem a') (Elem b') (Elem c'))
+                (f a)
+                (f b)
+                (f c)
+        traverseNodeN
+            :: Applicative f
+            => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))
         traverseNodeN f t = traverse f t
 
 instance NFData a => NFData (Seq a) where

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -428,7 +428,37 @@ instance Traversable Seq where
 #if __GLASGOW_HASKELL__
     {-# INLINABLE traverse #-}
 #endif
-    traverse f (Seq xs) = Seq <$> traverse (traverse f) xs
+    traverse _ (Seq EmptyT) = pure (Seq EmptyT)
+    traverse f' (Seq (Single (Elem x'))) =
+        (\x'' -> Seq (Single (Elem x''))) <$> f' x'
+    traverse f' (Seq (Deep s' pr' m' sf')) =
+        liftA3
+            (\pr'' m'' sf'' -> Seq (Deep s' pr'' m'' sf''))
+            (traverseDigitE f' pr')
+            (traverseTree (traverseNodeE f') m')
+            (traverseDigitE f' sf')
+      where
+        traverseTree
+            :: Applicative f
+            => (Node a -> f (Node b))
+            -> FingerTree (Node a)
+            -> f (FingerTree (Node b))
+        traverseTree _ EmptyT = pure EmptyT
+        traverseTree f (Single x) = Single <$> f x
+        traverseTree f (Deep s pr m sf) =
+            liftA3
+                (Deep s)
+                (traverse f pr)
+                (traverseTree (traverse f) m)
+                (traverse f sf)
+        traverseDigitE
+            :: Applicative f
+            => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
+        traverseDigitE f t = traverse (traverse f) t
+        traverseNodeE
+            :: Applicative f
+            => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
+        traverseNodeE f t = traverse (traverse f) t
 
 instance NFData a => NFData (Seq a) where
     rnf (Seq xs) = rnf xs
@@ -1025,29 +1055,11 @@ instance Functor FingerTree where
         Deep v (fmap f pr) (fmap (fmap f) m) (fmap f sf)
 
 instance Traversable FingerTree where
-    {-# INLINE traverse #-}
     traverse _ EmptyT = pure EmptyT
-    traverse f' (Single x') = Single <$> f' x'
-    traverse f' (Deep s' pr' m' sf') =
-        liftA3
-            (Deep s')
-            (traverse f' pr')
-            (traverseTree (traverse f') m')
-            (traverse f' sf')
-      where
-        traverseTree
-            :: Applicative f
-            => (Node a -> f (Node b))
-            -> FingerTree (Node a)
-            -> f (FingerTree (Node b))
-        traverseTree _ EmptyT = pure EmptyT
-        traverseTree f (Single x) = Single <$> f x
-        traverseTree f (Deep s pr m sf) =
-            liftA3
-                (Deep s)
-                (traverse f pr)
-                (traverseTree (traverse f) m)
-                (traverse f sf)
+    traverse f (Single x) = Single <$> f x
+    traverse f (Deep v pr m sf) =
+        liftA3 (Deep v) (traverse f pr) (traverse (traverse f) m)
+            (traverse f sf)
 
 instance NFData a => NFData (FingerTree a) where
     rnf EmptyT = ()

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -428,7 +428,7 @@ instance Traversable Seq where
 #if __GLASGOW_HASKELL__
     {-# INLINABLE traverse #-}
 #endif
-    traverse f' (Seq EmptyT) = pure (Seq EmptyT)
+    traverse _ (Seq EmptyT) = pure (Seq EmptyT)
     traverse f' (Seq (Single (Elem x'))) =
         (\x'' -> Seq (Single (Elem x''))) <$> f' x'
     traverse f' (Seq (Deep s' pr' m' sf')) =
@@ -448,25 +448,17 @@ instance Traversable Seq where
         traverseTree f (Deep s pr m sf) =
             liftA3
                 (Deep s)
-                (traverseDigitN f pr)
-                (traverseTree (traverseNodeN f) m)
-                (traverseDigitN f sf)
+                (traverse f pr)
+                (traverseTree (traverse f) m)
+                (traverse f sf)
         traverseDigitE
             :: Applicative f
             => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
         traverseDigitE f t = traverse (traverse f) t
-        traverseDigitN
-            :: Applicative f
-            => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
-        traverseDigitN f t = traverse f t
         traverseNodeE
             :: Applicative f
             => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
         traverseNodeE f t = traverse (traverse f) t
-        traverseNodeN
-            :: Applicative f
-            => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))
-        traverseNodeN f t = traverse f t
 
 instance NFData a => NFData (Seq a) where
     rnf (Seq xs) = rnf xs

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -428,7 +428,7 @@ instance Traversable Seq where
 #if __GLASGOW_HASKELL__
     {-# INLINABLE traverse #-}
 #endif
-    traverse _ (Seq EmptyT) = pure (Seq EmptyT)
+    traverse f' (Seq EmptyT) = pure (Seq EmptyT)
     traverse f' (Seq (Single (Elem x'))) =
         (\x'' -> Seq (Single (Elem x''))) <$> f' x'
     traverse f' (Seq (Deep s' pr' m' sf')) =
@@ -448,17 +448,25 @@ instance Traversable Seq where
         traverseTree f (Deep s pr m sf) =
             liftA3
                 (Deep s)
-                (traverse f pr)
-                (traverseTree (traverse f) m)
-                (traverse f sf)
+                (traverseDigitN f pr)
+                (traverseTree (traverseNodeN f) m)
+                (traverseDigitN f sf)
         traverseDigitE
             :: Applicative f
             => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
         traverseDigitE f t = traverse (traverse f) t
+        traverseDigitN
+            :: Applicative f
+            => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
+        traverseDigitN f t = traverse f t
         traverseNodeE
             :: Applicative f
             => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
         traverseNodeE f t = traverse (traverse f) t
+        traverseNodeN
+            :: Applicative f
+            => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))
+        traverseNodeN f t = traverse f t
 
 instance NFData a => NFData (Seq a) where
     rnf (Seq xs) = rnf xs

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -425,7 +425,7 @@ instance Foldable Seq where
 #endif
 
 instance Traversable Seq where
-    {-# INLINE traverse #-}
+    {-# INLINABLE traverse #-}
     traverse f' (Seq EmptyT) = pure (Seq EmptyT)
     traverse f' (Seq (Single (Elem x'))) =
         (\x'' -> Seq (Single (Elem x''))) <$> f' x'

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -454,28 +454,7 @@ instance Traversable Seq where
         traverseDigitE
             :: Applicative f
             => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
-        traverseDigitE f (One (Elem a)) =
-            (\a' -> One (Elem a')) <$>
-            f a
-        traverseDigitE f (Two (Elem a) (Elem b)) =
-            liftA2
-                (\a' b' -> Two (Elem a') (Elem b'))
-                (f a)
-                (f b)
-        traverseDigitE f (Three (Elem a) (Elem b) (Elem c)) =
-            liftA3
-                (\a' b' c' ->
-                      Three (Elem a') (Elem b') (Elem c'))
-                (f a)
-                (f b)
-                (f c)
-        traverseDigitE f (Four (Elem a) (Elem b) (Elem c) (Elem d)) =
-            liftA3
-                (\a' b' c' d' -> Four (Elem a') (Elem b') (Elem c') (Elem d'))
-                (f a)
-                (f b)
-                (f c) <*> 
-                (f d)
+        traverseDigitE f t = traverse (traverse f) t
         traverseDigitN
             :: Applicative f
             => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
@@ -483,18 +462,7 @@ instance Traversable Seq where
         traverseNodeE
             :: Applicative f
             => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
-        traverseNodeE f (Node2 s (Elem a) (Elem b)) =
-            liftA2
-                (\a' b' -> Node2 s (Elem a') (Elem b'))
-                (f a)
-                (f b)
-        traverseNodeE f (Node3 s (Elem a) (Elem b) (Elem c)) =
-            liftA3
-                (\a' b' c' ->
-                      Node3 s (Elem a') (Elem b') (Elem c'))
-                (f a)
-                (f b)
-                (f c)
+        traverseNodeE f t = traverse (traverse f) t
         traverseNodeN
             :: Applicative f
             => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -428,7 +428,7 @@ instance Traversable Seq where
 #if __GLASGOW_HASKELL__
     {-# INLINABLE traverse #-}
 #endif
-    traverse f' (Seq EmptyT) = pure (Seq EmptyT)
+    traverse _ (Seq EmptyT) = pure (Seq EmptyT)
     traverse f' (Seq (Single (Elem x'))) =
         (\x'' -> Seq (Single (Elem x''))) <$> f' x'
     traverse f' (Seq (Deep s' pr' m' sf')) =

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -454,7 +454,28 @@ instance Traversable Seq where
         traverseDigitE
             :: Applicative f
             => (a -> f b) -> Digit (Elem a) -> f (Digit (Elem b))
-        traverseDigitE f t = traverse (traverse f) t
+        traverseDigitE f (One (Elem a)) =
+            (\a' -> One (Elem a')) <$>
+            f a
+        traverseDigitE f (Two (Elem a) (Elem b)) =
+            liftA2
+                (\a' b' -> Two (Elem a') (Elem b'))
+                (f a)
+                (f b)
+        traverseDigitE f (Three (Elem a) (Elem b) (Elem c)) =
+            liftA3
+                (\a' b' c' ->
+                      Three (Elem a') (Elem b') (Elem c'))
+                (f a)
+                (f b)
+                (f c)
+        traverseDigitE f (Four (Elem a) (Elem b) (Elem c) (Elem d)) =
+            liftA3
+                (\a' b' c' d' -> Four (Elem a') (Elem b') (Elem c') (Elem d'))
+                (f a)
+                (f b)
+                (f c) <*> 
+                (f d)
         traverseDigitN
             :: Applicative f
             => (Node a -> f (Node b)) -> Digit (Node a) -> f (Digit (Node b))
@@ -462,7 +483,18 @@ instance Traversable Seq where
         traverseNodeE
             :: Applicative f
             => (a -> f b) -> Node (Elem a) -> f (Node (Elem b))
-        traverseNodeE f t = traverse (traverse f) t
+        traverseNodeE f (Node2 s (Elem a) (Elem b)) =
+            liftA2
+                (\a' b' -> Node2 s (Elem a') (Elem b'))
+                (f a)
+                (f b)
+        traverseNodeE f (Node3 s (Elem a) (Elem b) (Elem c)) =
+            liftA3
+                (\a' b' c' ->
+                      Node3 s (Elem a') (Elem b') (Elem c'))
+                (f a)
+                (f b)
+                (f c)
         traverseNodeN
             :: Applicative f
             => (Node a -> f (Node b)) -> Node (Node a) -> f (Node (Node b))

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -425,7 +425,9 @@ instance Foldable Seq where
 #endif
 
 instance Traversable Seq where
+#if __GLASGOW_HASKELL__
     {-# INLINABLE traverse #-}
+#endif
     traverse f' (Seq EmptyT) = pure (Seq EmptyT)
     traverse f' (Seq (Single (Elem x'))) =
         (\x'' -> Seq (Single (Elem x''))) <$> f' x'

--- a/Utils/Containers/Internal/Coercions.hs
+++ b/Utils/Containers/Internal/Coercions.hs
@@ -16,7 +16,7 @@ infixr 9 #.
 (.#) f _ = coerce f
 
 (#.) :: Coercible c b => (b -> c) -> (a -> b) -> a -> c
-(#.) _ = coerce (\x -> x :: b) :: forall a b. Coercible b a => a -> b
+(#.) _ = coerce
 #else
 (.#) :: (b -> c) -> (a -> b) -> a -> c
 (.#) = (.)

--- a/Utils/Containers/Internal/Coercions.hs
+++ b/Utils/Containers/Internal/Coercions.hs
@@ -10,14 +10,22 @@ import Data.Coerce
 #endif
 
 infixl 8 .#
+infixr 9 #.
 #if __GLASGOW_HASKELL__ >= 708
 (.#) :: Coercible b a => (b -> c) -> (a -> b) -> a -> c
 (.#) f _ = coerce f
+
+(#.) :: Coercible c b => (b -> c) -> (a -> b) -> a -> c
+(#.) _ = coerce (\x -> x :: b) :: forall a b. Coercible b a => a -> b
 #else
 (.#) :: (b -> c) -> (a -> b) -> a -> c
 (.#) = (.)
+
+(#.) :: (b -> c) -> (a -> b) -> a -> c
+(#.) = (.)
 #endif
 {-# INLINE (.#) #-}
+{-# INLINE (#.) #-}
 
 infix 9 .^#
 

--- a/Utils/Containers/Internal/Coercions.hs
+++ b/Utils/Containers/Internal/Coercions.hs
@@ -10,22 +10,14 @@ import Data.Coerce
 #endif
 
 infixl 8 .#
-infixr 9 #.
 #if __GLASGOW_HASKELL__ >= 708
 (.#) :: Coercible b a => (b -> c) -> (a -> b) -> a -> c
 (.#) f _ = coerce f
-
-(#.) :: Coercible c b => (b -> c) -> (a -> b) -> a -> c
-(#.) _ = coerce
 #else
 (.#) :: (b -> c) -> (a -> b) -> a -> c
 (.#) = (.)
-
-(#.) :: (b -> c) -> (a -> b) -> a -> c
-(#.) = (.)
 #endif
 {-# INLINE (.#) #-}
-{-# INLINE (#.) #-}
 
 infix 9 .^#
 


### PR DESCRIPTION
So I applied the same techniques in the folds to the traverse, and I got similar speedups. On the multiplyup benchmark: 

```haskell
multiplyUp :: Seq.Seq Int -> Seq.Seq Int
multiplyUp = snd . flip runState 0 . traverse go where
  go x = do
    s <- State (\x -> (x + 1,x))
    return (s * x)
```

On a sequence of length 500000:

```
benchmarking 500000/multiplyUp/new
time                 137.6 ms   (129.7 ms .. 145.7 ms)
                     0.996 R²   (0.990 R² .. 1.000 R²)
mean                 138.8 ms   (136.4 ms .. 141.4 ms)
std dev              3.470 ms   (2.492 ms .. 4.484 ms)
variance introduced by outliers: 12% (moderately inflated)
             
benchmarking 500000/multiplyUp/old
time                 355.1 ms   (281.2 ms .. 407.7 ms)
                     0.995 R²   (0.983 R² .. 1.000 R²)
mean                 339.1 ms   (324.9 ms .. 346.0 ms)
std dev              12.30 ms   (0.0 s .. 12.63 ms)
variance introduced by outliers: 19% (moderately inflated)
```

And even old functions which use traverse internally get a speedup. `scanl (+) 0` for instance:

```
benchmarking 500000/scanl/new
time                 134.5 ms   (121.4 ms .. 156.0 ms)
                     0.979 R²   (0.945 R² .. 0.998 R²)
mean                 141.0 ms   (134.2 ms .. 148.6 ms)
std dev              9.440 ms   (6.655 ms .. 12.88 ms)
variance introduced by outliers: 13% (moderately inflated)
             
benchmarking 500000/scanl/old
time                 373.0 ms   (253.8 ms .. 471.4 ms)
                     0.988 R²   (0.957 R² .. 1.000 R²)
mean                 379.5 ms   (356.0 ms .. 396.6 ms)
std dev              25.81 ms   (0.0 s .. 29.52 ms)
variance introduced by outliers: 20% (moderately inflated)
```

The inlining of the inner functions also allows us to avoid coercion around `Elem`. The code is *much* longer, though.