### PR TITLE
Reorganize Map and IntMap Haddocks.

### DIFF
--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -95,6 +95,7 @@ module Data.IntMap.Lazy (
     , alterF
 
     -- * Query
+    -- ** Lookup
     , IM.lookup
     , (!?)
     , (!)
@@ -105,6 +106,8 @@ module Data.IntMap.Lazy (
     , lookupGT
     , lookupLE
     , lookupGE
+
+    -- ** Size
     , IM.null
     , size
 

--- a/Data/IntMap/Lazy.hs
+++ b/Data/IntMap/Lazy.hs
@@ -62,32 +62,29 @@ module Data.IntMap.Lazy (
     IntMap(..), Key          -- instance Eq,Show
 #endif
 
-    -- * Operators
-    , (!), (!?), (\\)
-
-    -- * Query
-    , IM.null
-    , size
-    , member
-    , notMember
-    , IM.lookup
-    , findWithDefault
-    , lookupLT
-    , lookupGT
-    , lookupLE
-    , lookupGE
-
     -- * Construction
     , empty
     , singleton
+    , fromSet
 
-    -- ** Insertion
+    -- ** From Unordered Lists
+    , fromList
+    , fromListWith
+    , fromListWithKey
+
+    -- ** From Ascending Lists
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+
+    -- * Insertion
     , insert
     , insertWith
     , insertWithKey
     , insertLookupWithKey
 
-    -- ** Delete\/Update
+    -- * Deletion\/Update
     , delete
     , adjust
     , adjustWithKey
@@ -96,6 +93,20 @@ module Data.IntMap.Lazy (
     , updateLookupWithKey
     , alter
     , alterF
+
+    -- * Query
+    , IM.lookup
+    , (!?)
+    , (!)
+    , findWithDefault
+    , member
+    , notMember
+    , lookupLT
+    , lookupGT
+    , lookupLE
+    , lookupGE
+    , IM.null
+    , size
 
     -- * Combine
 
@@ -108,6 +119,7 @@ module Data.IntMap.Lazy (
 
     -- ** Difference
     , difference
+    , (\\)
     , differenceWith
     , differenceWithKey
 
@@ -149,21 +161,13 @@ module Data.IntMap.Lazy (
     , keys
     , assocs
     , keysSet
-    , fromSet
 
     -- ** Lists
     , toList
-    , fromList
-    , fromListWith
-    , fromListWithKey
 
     -- ** Ordered lists
     , toAscList
     , toDescList
-    , fromAscList
-    , fromAscListWith
-    , fromAscListWithKey
-    , fromDistinctAscList
 
     -- * Filter
     , IM.filter

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -69,32 +69,29 @@ module Data.IntMap.Strict (
     IntMap(..), Key          -- instance Eq,Show
 #endif
 
-    -- * Operators
-    , (!), (!?), (\\)
-
-    -- * Query
-    , null
-    , size
-    , member
-    , notMember
-    , lookup
-    , findWithDefault
-    , lookupLT
-    , lookupGT
-    , lookupLE
-    , lookupGE
-
     -- * Construction
     , empty
     , singleton
+    , fromSet
 
-    -- ** Insertion
+    -- ** From Unordered Lists
+    , fromList
+    , fromListWith
+    , fromListWithKey
+
+    -- ** From Ascending Lists
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+
+    -- * Insertion
     , insert
     , insertWith
     , insertWithKey
     , insertLookupWithKey
 
-    -- ** Delete\/Update
+    -- * Deletion\/Update
     , delete
     , adjust
     , adjustWithKey
@@ -103,6 +100,20 @@ module Data.IntMap.Strict (
     , updateLookupWithKey
     , alter
     , alterF
+
+    -- * Query
+    , lookup
+    , (!?)
+    , (!)
+    , findWithDefault
+    , member
+    , notMember
+    , lookupLT
+    , lookupGT
+    , lookupLE
+    , lookupGE
+    , null
+    , size
 
     -- * Combine
 
@@ -115,6 +126,7 @@ module Data.IntMap.Strict (
 
     -- ** Difference
     , difference
+    , (\\)
     , differenceWith
     , differenceWithKey
 
@@ -156,21 +168,13 @@ module Data.IntMap.Strict (
     , keys
     , assocs
     , keysSet
-    , fromSet
 
     -- ** Lists
     , toList
-    , fromList
-    , fromListWith
-    , fromListWithKey
 
-    -- ** Ordered lists
+-- ** Ordered lists
     , toAscList
     , toDescList
-    , fromAscList
-    , fromAscListWith
-    , fromAscListWithKey
-    , fromDistinctAscList
 
     -- * Filter
     , filter

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -102,6 +102,7 @@ module Data.IntMap.Strict (
     , alterF
 
     -- * Query
+    -- ** Lookup
     , lookup
     , (!?)
     , (!)
@@ -112,6 +113,8 @@ module Data.IntMap.Strict (
     , lookupGT
     , lookupLE
     , lookupGE
+
+    -- ** Size
     , null
     , size
 

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -91,11 +91,20 @@ module Data.Map.Lazy (
     -- * Construction
     , empty
     , singleton
+    , fromSet
+
+    -- ** From Lists
     , fromList
     , fromListWith
     , fromListWithKey
-
-    -- * Operators
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+    , fromDescList
+    , fromDescListWith
+    , fromDescListWithKey
+    , fromDistinctDescList
 
     -- * Query
     , lookup
@@ -185,7 +194,6 @@ module Data.Map.Lazy (
     , keys
     , assocs
     , keysSet
-    , fromSet
 
     -- ** Lists
     , toList
@@ -193,14 +201,6 @@ module Data.Map.Lazy (
     -- ** Ordered lists
     , toAscList
     , toDescList
-    , fromAscList
-    , fromAscListWith
-    , fromAscListWithKey
-    , fromDistinctAscList
-    , fromDescList
-    , fromDescListWith
-    , fromDescListWithKey
-    , fromDistinctDescList
 
     -- * Filter
     , filter

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -110,6 +110,22 @@ module Data.Map.Lazy (
     , fromDescListWithKey
     , fromDistinctDescList
 
+    -- * Insertion
+    , insert
+    , insertWith
+    , insertWithKey
+    , insertLookupWithKey
+
+    -- * Deletion\/Update
+    , delete
+    , adjust
+    , adjustWithKey
+    , update
+    , updateWithKey
+    , updateLookupWithKey
+    , alter
+    , alterF
+
     -- * Query
     , lookup
     , (!?)
@@ -123,22 +139,6 @@ module Data.Map.Lazy (
     , lookupGE
     , null
     , size
-
-    -- ** Insertion
-    , insert
-    , insertWith
-    , insertWithKey
-    , insertLookupWithKey
-
-    -- ** Delete\/Update
-    , delete
-    , adjust
-    , adjustWithKey
-    , update
-    , updateWithKey
-    , updateLookupWithKey
-    , alter
-    , alterF
 
     -- * Combine
 

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -93,14 +93,18 @@ module Data.Map.Lazy (
     , singleton
     , fromSet
 
-    -- ** From Lists
+    -- ** From Unordered Lists
     , fromList
     , fromListWith
     , fromListWithKey
+
+    -- ** From Ascending Lists
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
     , fromDistinctAscList
+
+    -- ** From Descending Lists
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
@@ -109,6 +113,7 @@ module Data.Map.Lazy (
     -- * Query
     , lookup
     , (!?)
+    , (!)
     , findWithDefault
     , member
     , notMember
@@ -118,7 +123,6 @@ module Data.Map.Lazy (
     , lookupGE
     , null
     , size
-    , (!)
 
     -- ** Insertion
     , insert

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -127,6 +127,7 @@ module Data.Map.Lazy (
     , alterF
 
     -- * Query
+    -- ** Lookup
     , lookup
     , (!?)
     , (!)
@@ -137,6 +138,8 @@ module Data.Map.Lazy (
     , lookupGT
     , lookupLE
     , lookupGE
+
+    -- ** Size
     , null
     , size
 

--- a/Data/Map/Lazy.hs
+++ b/Data/Map/Lazy.hs
@@ -88,24 +88,28 @@ module Data.Map.Lazy (
     -- * Map type
     Map              -- instance Eq,Show,Read
 
+    -- * Construction
+    , empty
+    , singleton
+    , fromList
+    , fromListWith
+    , fromListWithKey
+
     -- * Operators
-    , (!), (!?), (\\)
 
     -- * Query
-    , null
-    , size
+    , lookup
+    , (!?)
+    , findWithDefault
     , member
     , notMember
-    , lookup
-    , findWithDefault
     , lookupLT
     , lookupGT
     , lookupLE
     , lookupGE
-
-    -- * Construction
-    , empty
-    , singleton
+    , null
+    , size
+    , (!)
 
     -- ** Insertion
     , insert
@@ -134,6 +138,7 @@ module Data.Map.Lazy (
 
     -- ** Difference
     , difference
+    , (\\)
     , differenceWith
     , differenceWithKey
 
@@ -184,9 +189,6 @@ module Data.Map.Lazy (
 
     -- ** Lists
     , toList
-    , fromList
-    , fromListWith
-    , fromListWithKey
 
     -- ** Ordered lists
     , toAscList

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -104,24 +104,26 @@ module Data.Map.Strict
     -- * Map type
     Map              -- instance Eq,Show,Read
 
-    -- * Operators
-    , (!), (!?), (\\)
+    -- * Construction
+    , empty
+    , singleton
+    , fromList
+    , fromListWith
+    , fromListWithKey
 
     -- * Query
-    , null
-    , size
+    , lookup
+    , (!?)
+    , findWithDefault
     , member
     , notMember
-    , lookup
-    , findWithDefault
     , lookupLT
     , lookupGT
     , lookupLE
     , lookupGE
-
-    -- * Construction
-    , empty
-    , singleton
+    , null
+    , size
+    , (!)
 
     -- ** Insertion
     , insert
@@ -150,6 +152,7 @@ module Data.Map.Strict
 
     -- ** Difference
     , difference
+    , (\\)
     , differenceWith
     , differenceWithKey
 
@@ -200,9 +203,6 @@ module Data.Map.Strict
 
     -- ** Lists
     , toList
-    , fromList
-    , fromListWith
-    , fromListWithKey
 
     -- ** Ordered lists
     , toAscList

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -126,6 +126,22 @@ module Data.Map.Strict
     , fromDescListWithKey
     , fromDistinctDescList
 
+    -- * Insertion
+    , insert
+    , insertWith
+    , insertWithKey
+    , insertLookupWithKey
+
+    -- * Deletion\/Update
+    , delete
+    , adjust
+    , adjustWithKey
+    , update
+    , updateWithKey
+    , updateLookupWithKey
+    , alter
+    , alterF
+
     -- * Query
     , lookup
     , (!?)
@@ -139,22 +155,6 @@ module Data.Map.Strict
     , lookupGE
     , null
     , size
-
-    -- ** Insertion
-    , insert
-    , insertWith
-    , insertWithKey
-    , insertLookupWithKey
-
-    -- ** Delete\/Update
-    , delete
-    , adjust
-    , adjustWithKey
-    , update
-    , updateWithKey
-    , updateLookupWithKey
-    , alter
-    , alterF
 
     -- * Combine
 

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -107,9 +107,20 @@ module Data.Map.Strict
     -- * Construction
     , empty
     , singleton
+    , fromSet
+
+    -- ** From Lists
     , fromList
     , fromListWith
     , fromListWithKey
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+    , fromDescList
+    , fromDescListWith
+    , fromDescListWithKey
+    , fromDistinctDescList
 
     -- * Query
     , lookup
@@ -199,7 +210,6 @@ module Data.Map.Strict
     , keys
     , assocs
     , keysSet
-    , fromSet
 
     -- ** Lists
     , toList
@@ -207,14 +217,6 @@ module Data.Map.Strict
     -- ** Ordered lists
     , toAscList
     , toDescList
-    , fromAscList
-    , fromAscListWith
-    , fromAscListWithKey
-    , fromDistinctAscList
-    , fromDescList
-    , fromDescListWith
-    , fromDescListWithKey
-    , fromDistinctDescList
 
     -- * Filter
     , filter

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -143,6 +143,7 @@ module Data.Map.Strict
     , alterF
 
     -- * Query
+    -- ** Lookup
     , lookup
     , (!?)
     , (!)
@@ -153,6 +154,8 @@ module Data.Map.Strict
     , lookupGT
     , lookupLE
     , lookupGE
+
+    -- ** Size
     , null
     , size
 

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -109,14 +109,18 @@ module Data.Map.Strict
     , singleton
     , fromSet
 
-    -- ** From Lists
+    -- ** From Unordered Lists
     , fromList
     , fromListWith
     , fromListWithKey
+
+    -- ** From Ascending Lists
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
     , fromDistinctAscList
+
+    -- ** From Descending Lists
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
@@ -125,6 +129,7 @@ module Data.Map.Strict
     -- * Query
     , lookup
     , (!?)
+    , (!)
     , findWithDefault
     , member
     , notMember
@@ -134,7 +139,6 @@ module Data.Map.Strict
     , lookupGE
     , null
     , size
-    , (!)
 
     -- ** Insertion
     , insert


### PR DESCRIPTION
**Changes:**

- Move "construction" section to the top
- Include fromList functions in "construction" section
- Remove "operators" section, you don't go "looking for operators", you go
  "looking for functionality" which may be available as an operator.
- Move most common query operations (lookup and friends) to the top
- Move partial functions to the bottom of sections.

**Rationale:**

The other approach I considered was that [employed by Data.HashMap](https://hackage.haskell.org/package/unordered-containers-0.2.8.0/docs/Data-HashMap-Strict.html#g:3) which groups the "basic interface" API functions together. I didn't use that approach because I feel it defeats the purpose of an API reference, specifically that all related functions are grouped together. By separating out the "basic interface" from the "advanced interface" you now need to look at two places if you're looking for a particular function. Instead a introduction and tutorial (a la https://haskell-containers.readthedocs.io) is a more appropriate place to present the basic interface in my opinion.

This partially addresses #495.