### PR TITLE
Remove "strict map" wording from docs

### DIFF
--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -71,7 +71,7 @@
 -- The 'Map' type is shared between the lazy and strict modules, meaning that
 -- the same 'Map' value can be passed to functions in both modules. This means
 -- that the 'Functor', 'Traversable' and 'Data' instances are the same as for
--- the "Data.Map.Lazy" module, so if they are used the resulting map may contain
+-- the "Data.Map.Lazy" module, so if they are used the resulting maps may contain
 -- suspended values (thunks).
 --
 --

--- a/Data/Map/Strict.hs
+++ b/Data/Map/Strict.hs
@@ -71,8 +71,8 @@
 -- The 'Map' type is shared between the lazy and strict modules, meaning that
 -- the same 'Map' value can be passed to functions in both modules. This means
 -- that the 'Functor', 'Traversable' and 'Data' instances are the same as for
--- the "Data.Map.Lazy" module, so if they are used on strict maps, the resulting
--- maps may contain suspended values (thunks).
+-- the "Data.Map.Lazy" module, so if they are used the resulting map may contain
+-- suspended values (thunks).
 --
 --
 -- == Implementation


### PR DESCRIPTION
There's no such things as a "strict map", only a Strict API which forces evaluation of values before inserting them into the map.

[ci skip]