### PR TITLE
Unbox the `SetM` array

### DIFF
--- a/Data/Graph.hs
+++ b/Data/Graph.hs
@@ -72,7 +72,7 @@ module Data.Graph(
 -- Extensions
 #if USE_ST_MONAD
 import Control.Monad.ST
-import Data.Array.ST (STArray, newArray, readArray, writeArray)
+import Data.Array.ST (STUArray, newArray, readArray, writeArray)
 #else
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as Set
@@ -372,7 +372,7 @@ chop (Node v ts : us)
 
 -- Use the ST monad if available, for constant-time primitives.
 
-newtype SetM s a = SetM { runSetM :: STArray s Vertex Bool -> ST s a }
+newtype SetM s a = SetM { runSetM :: STUArray s Vertex Int -> ST s a }
 
 instance Monad (SetM s) where
     return = pure
@@ -394,13 +394,13 @@ instance Applicative (SetM s) where
     {-# INLINE (<*>) #-}
 
 run          :: Bounds -> (forall s. SetM s a) -> a
-run bnds act  = runST (newArray bnds False >>= runSetM act)
+run bnds act  = runST (newArray bnds 0 >>= runSetM act)
 
 contains     :: Vertex -> SetM s Bool
-contains v    = SetM $ \ m -> readArray m v
+contains v    = SetM $ \ m -> fmap (== 1) (readArray m v)
 
 include      :: Vertex -> SetM s ()
-include v     = SetM $ \ m -> writeArray m v True
+include v     = SetM $ \ m -> writeArray m v 1
 
 #else /* !USE_ST_MONAD */
 


### PR DESCRIPTION
`Data.Graph` uses a mutable array to track which vertices have
been visited. This was implemented using an `STArray s Vertex Bool`.
This is obviously bad, because the garbage collector will have to
trace the array if it's alive during a collection. Using an unboxed
array instead should always be slightly better.

It may be better to go further and use a bit array to save space,
but I'm not entirely comfortable making that change until we have
some tests for `Data.Graph`--any mistakes there will likely be
subtle.