### PR TITLE
Reorganize Set and IntSet Haddocks.

### DIFF
--- a/Data/IntSet.hs
+++ b/Data/IntSet.hs
@@ -80,24 +80,24 @@ module Data.IntSet (
             , fromAscList
             , fromDistinctAscList
 
-            -- * Queries
-            , IS.null
-            , size
+            -- * Insertion
+            , insert
+
+            -- * Deletion
+            , delete
+
+            -- * Query
             , member
             , notMember
             , lookupLT
             , lookupGT
             , lookupLE
             , lookupGE
+            , IS.null
+            , size
             , isSubsetOf
             , isProperSubsetOf
             , disjoint
-
-            -- ** Insertion
-            , insert
-
-            -- * Delete
-            , delete
 
             -- * Combine
             , union
@@ -140,8 +140,6 @@ module Data.IntSet (
             -- ** List
             , elems
             , toList
-
-            -- ** Ordered list
             , toAscList
             , toDescList
 

--- a/Data/IntSet.hs
+++ b/Data/IntSet.hs
@@ -73,10 +73,14 @@ module Data.IntSet (
 #endif
             , Key
 
-            -- * Operators
-            , (\\)
+            -- * Construction
+            , empty
+            , singleton
+            , fromList
+            , fromAscList
+            , fromDistinctAscList
 
-            -- * Query
+            -- * Queries
             , IS.null
             , size
             , member
@@ -89,16 +93,17 @@ module Data.IntSet (
             , isProperSubsetOf
             , disjoint
 
-            -- * Construction
-            , empty
-            , singleton
+            -- ** Insertion
             , insert
+
+            -- * Delete
             , delete
 
             -- * Combine
             , union
             , unions
             , difference
+            , (\\)
             , intersection
 
             -- * Filter
@@ -135,13 +140,10 @@ module Data.IntSet (
             -- ** List
             , elems
             , toList
-            , fromList
 
             -- ** Ordered list
             , toAscList
             , toDescList
-            , fromAscList
-            , fromDistinctAscList
 
             -- * Debugging
             , showTree

--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -72,33 +72,40 @@ module Data.Set (
               Set(..)
 #endif
 
-            -- * Operators
-            , (\\)
+            -- * Construction
+            , empty
+            , singleton
+            , fromList
+            , fromAscList
+            , fromDescList
+            , fromDistinctAscList
+            , fromDistinctDescList
+            , powerSet
 
-            -- * Query
-            , S.null
-            , size
+            -- * Queries
             , member
             , notMember
             , lookupLT
             , lookupGT
             , lookupLE
             , lookupGE
+            , S.null
+            , size
             , isSubsetOf
             , isProperSubsetOf
             , disjoint
 
-            -- * Construction
-            , empty
-            , singleton
+            -- ** Insertion
             , insert
+
+            -- ** Delete
             , delete
-            , powerSet
 
             -- * Combine
             , union
             , unions
             , difference
+            , (\\)
             , intersection
             , cartesianProduct
             , disjointUnion
@@ -152,15 +159,10 @@ module Data.Set (
             -- ** List
             , elems
             , toList
-            , fromList
 
             -- ** Ordered list
             , toAscList
             , toDescList
-            , fromAscList
-            , fromDescList
-            , fromDistinctAscList
-            , fromDistinctDescList
 
             -- * Debugging
             , showTree

--- a/Data/Set.hs
+++ b/Data/Set.hs
@@ -82,7 +82,13 @@ module Data.Set (
             , fromDistinctDescList
             , powerSet
 
-            -- * Queries
+            -- * Insertion
+            , insert
+
+            -- * Deletion
+            , delete
+
+            -- * Query
             , member
             , notMember
             , lookupLT
@@ -94,12 +100,6 @@ module Data.Set (
             , isSubsetOf
             , isProperSubsetOf
             , disjoint
-
-            -- ** Insertion
-            , insert
-
-            -- ** Delete
-            , delete
 
             -- * Combine
             , union
@@ -159,8 +159,6 @@ module Data.Set (
             -- ** List
             , elems
             , toList
-
-            -- ** Ordered list
             , toAscList
             , toDescList
 


### PR DESCRIPTION
This moves the Construction section to the top and puts all "construction like"
functions under that heading. Also, moves operators out of their own section and
into the appropriate section.

This partially addresses #495.