### PR TITLE
Fix Documentation Typo in Data/Sequence.hs

### DIFF
--- a/Data/Sequence.hs
+++ b/Data/Sequence.hs
@@ -65,7 +65,7 @@
 --
 --     but
 --
---     @ (1 :<| undefined) `index` 0 = undefined @
+--     @ (1 :<| undefined) \`index\` 0 = undefined @
 --
 -- Sequences may also be compared to immutable
 -- [arrays](https://hackage.haskell.org/package/array)


### PR DESCRIPTION
In the module header, in a code example where “index” is used infix, the back-ticks need to be escaped, otherwise haddock interprets them as (an alternative form of) quotes for a hyperlinked identifier which in particular makes the back-ticks invisible in the documentation and displays invalid Haskell code in the code example.