### PR TITLE
Add functions to optimize graph creation time (when keys are consecutive), add benchmarks.

### DIFF
--- a/bench.txt
+++ b/bench.txt
@@ -1,0 +1,318 @@
+
+Benchmark graph-creation: RUNNING...
+benchmarking Degree_LinearInVertices/10_ascending_graphFEConsecutiveAsc
+time                 1.326 μs   (1.268 μs .. 1.399 μs)
+                     0.985 R²   (0.970 R² .. 0.996 R²)
+mean                 1.347 μs   (1.309 μs .. 1.401 μs)
+std dev              146.8 ns   (102.4 ns .. 204.6 ns)
+variance introduced by outliers: 90% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/10_ascending_graphFEConsecutive
+time                 1.626 μs   (1.571 μs .. 1.684 μs)
+                     0.993 R²   (0.990 R² .. 0.997 R²)
+mean                 1.664 μs   (1.634 μs .. 1.702 μs)
+std dev              114.9 ns   (90.21 ns .. 158.5 ns)
+variance introduced by outliers: 78% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/10_ascending_graphFE
+time                 2.368 μs   (2.249 μs .. 2.545 μs)
+                     0.985 R²   (0.975 R² .. 0.996 R²)
+mean                 2.430 μs   (2.376 μs .. 2.493 μs)
+std dev              212.4 ns   (179.9 ns .. 274.0 ns)
+variance introduced by outliers: 85% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/10_unsorted_graphFEConsecutive
+time                 2.257 μs   (2.216 μs .. 2.313 μs)
+                     0.995 R²   (0.993 R² .. 0.997 R²)
+mean                 2.350 μs   (2.304 μs .. 2.408 μs)
+std dev              175.4 ns   (142.8 ns .. 256.4 ns)
+variance introduced by outliers: 80% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/10_unsorted_graphFE
+time                 3.183 μs   (3.074 μs .. 3.282 μs)
+                     0.994 R²   (0.992 R² .. 0.996 R²)
+mean                 3.093 μs   (3.037 μs .. 3.169 μs)
+std dev              212.2 ns   (176.8 ns .. 262.0 ns)
+variance introduced by outliers: 77% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/100_ascending_graphFEConsecutiveAsc
+time                 95.35 μs   (91.58 μs .. 99.38 μs)
+                     0.986 R²   (0.980 R² .. 0.991 R²)
+mean                 98.45 μs   (95.36 μs .. 102.1 μs)
+std dev              11.81 μs   (9.321 μs .. 17.18 μs)
+variance introduced by outliers: 86% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/100_ascending_graphFEConsecutive
+time                 86.11 μs   (84.91 μs .. 87.53 μs)
+                     0.996 R²   (0.993 R² .. 0.997 R²)
+mean                 92.39 μs   (90.17 μs .. 95.00 μs)
+std dev              8.142 μs   (7.231 μs .. 9.407 μs)
+variance introduced by outliers: 78% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/100_ascending_graphFE
+time                 298.6 μs   (290.3 μs .. 306.0 μs)
+                     0.996 R²   (0.994 R² .. 0.997 R²)
+mean                 296.4 μs   (292.4 μs .. 301.3 μs)
+std dev              15.42 μs   (11.97 μs .. 19.33 μs)
+variance introduced by outliers: 48% (moderately inflated)
+               
+benchmarking Degree_LinearInVertices/100_unsorted_graphFEConsecutive
+time                 120.7 μs   (114.9 μs .. 127.0 μs)
+                     0.969 R²   (0.937 R² .. 0.989 R²)
+mean                 122.4 μs   (117.3 μs .. 132.5 μs)
+std dev              23.47 μs   (12.80 μs .. 41.56 μs)
+variance introduced by outliers: 94% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/100_unsorted_graphFE
+time                 324.5 μs   (317.0 μs .. 333.2 μs)
+                     0.992 R²   (0.987 R² .. 0.996 R²)
+mean                 357.2 μs   (344.2 μs .. 380.8 μs)
+std dev              58.70 μs   (28.78 μs .. 109.1 μs)
+variance introduced by outliers: 91% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/1000_ascending_graphFEConsecutiveAsc
+time                 20.32 ms   (19.66 ms .. 20.95 ms)
+                     0.996 R²   (0.994 R² .. 0.998 R²)
+mean                 20.69 ms   (20.27 ms .. 21.42 ms)
+std dev              1.315 ms   (833.2 μs .. 1.894 ms)
+variance introduced by outliers: 27% (moderately inflated)
+               
+benchmarking Degree_LinearInVertices/1000_ascending_graphFEConsecutive
+time                 24.34 ms   (20.09 ms .. 29.02 ms)
+                     0.833 R²   (0.612 R² .. 0.969 R²)
+mean                 25.05 ms   (23.38 ms .. 29.04 ms)
+std dev              5.234 ms   (2.551 ms .. 9.448 ms)
+variance introduced by outliers: 77% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/1000_ascending_graphFE
+time                 51.27 ms   (42.52 ms .. 55.98 ms)
+                     0.954 R²   (0.888 R² .. 0.990 R²)
+mean                 59.97 ms   (54.66 ms .. 67.60 ms)
+std dev              11.17 ms   (6.375 ms .. 14.67 ms)
+variance introduced by outliers: 65% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/1000_unsorted_graphFEConsecutive
+time                 24.79 ms   (22.97 ms .. 26.26 ms)
+                     0.978 R²   (0.955 R² .. 0.991 R²)
+mean                 28.68 ms   (27.18 ms .. 30.88 ms)
+std dev              3.802 ms   (2.619 ms .. 5.025 ms)
+variance introduced by outliers: 54% (severely inflated)
+               
+benchmarking Degree_LinearInVertices/1000_unsorted_graphFE
+time                 63.52 ms   (53.57 ms .. 72.01 ms)
+                     0.971 R²   (0.943 R² .. 0.995 R²)
+mean                 59.53 ms   (57.10 ms .. 62.74 ms)
+std dev              5.074 ms   (3.690 ms .. 7.192 ms)
+variance introduced by outliers: 24% (moderately inflated)
+               
+benchmarking Degree_Constant/10_ascending_graphFEConsecutiveAsc
+time                 1.244 μs   (1.218 μs .. 1.285 μs)
+                     0.994 R²   (0.985 R² .. 0.999 R²)
+mean                 1.239 μs   (1.220 μs .. 1.283 μs)
+std dev              89.88 ns   (37.00 ns .. 160.4 ns)
+variance introduced by outliers: 81% (severely inflated)
+               
+benchmarking Degree_Constant/10_ascending_graphFEConsecutive
+time                 1.547 μs   (1.470 μs .. 1.647 μs)
+                     0.980 R²   (0.957 R² .. 0.998 R²)
+mean                 1.516 μs   (1.486 μs .. 1.590 μs)
+std dev              149.3 ns   (73.91 ns .. 281.2 ns)
+variance introduced by outliers: 88% (severely inflated)
+               
+benchmarking Degree_Constant/10_ascending_graphFE
+time                 2.317 μs   (2.301 μs .. 2.340 μs)
+                     0.998 R²   (0.995 R² .. 1.000 R²)
+mean                 2.343 μs   (2.306 μs .. 2.523 μs)
+std dev              191.5 ns   (67.77 ns .. 426.1 ns)
+variance introduced by outliers: 83% (severely inflated)
+               
+benchmarking Degree_Constant/10_unsorted_graphFEConsecutive
+time                 2.317 μs   (2.226 μs .. 2.425 μs)
+                     0.991 R²   (0.984 R² .. 0.999 R²)
+mean                 2.233 μs   (2.196 μs .. 2.292 μs)
+std dev              155.8 ns   (80.66 ns .. 256.8 ns)
+variance introduced by outliers: 78% (severely inflated)
+               
+benchmarking Degree_Constant/10_unsorted_graphFE
+time                 2.980 μs   (2.936 μs .. 3.037 μs)
+                     0.998 R²   (0.996 R² .. 0.999 R²)
+mean                 2.998 μs   (2.956 μs .. 3.092 μs)
+std dev              194.4 ns   (113.0 ns .. 351.3 ns)
+variance introduced by outliers: 75% (severely inflated)
+               
+benchmarking Degree_Constant/100_ascending_graphFEConsecutiveAsc
+time                 14.95 μs   (13.97 μs .. 15.94 μs)
+                     0.979 R²   (0.966 R² .. 0.995 R²)
+mean                 14.03 μs   (13.65 μs .. 14.67 μs)
+std dev              1.617 μs   (1.035 μs .. 2.338 μs)
+variance introduced by outliers: 89% (severely inflated)
+               
+benchmarking Degree_Constant/100_ascending_graphFEConsecutive
+time                 15.42 μs   (15.33 μs .. 15.49 μs)
+                     0.999 R²   (0.998 R² .. 1.000 R²)
+mean                 15.73 μs   (15.48 μs .. 16.35 μs)
+std dev              1.163 μs   (378.6 ns .. 2.106 μs)
+variance introduced by outliers: 76% (severely inflated)
+               
+benchmarking Degree_Constant/100_ascending_graphFE
+time                 41.75 μs   (40.23 μs .. 43.67 μs)
+                     0.990 R²   (0.980 R² .. 0.998 R²)
+mean                 41.04 μs   (40.25 μs .. 42.38 μs)
+std dev              3.122 μs   (2.103 μs .. 4.777 μs)
+variance introduced by outliers: 74% (severely inflated)
+               
+benchmarking Degree_Constant/100_unsorted_graphFEConsecutive
+time                 32.20 μs   (31.74 μs .. 32.81 μs)
+                     0.997 R²   (0.996 R² .. 0.998 R²)
+mean                 33.19 μs   (32.65 μs .. 34.11 μs)
+std dev              2.247 μs   (1.483 μs .. 3.517 μs)
+variance introduced by outliers: 71% (severely inflated)
+               
+benchmarking Degree_Constant/100_unsorted_graphFE
+time                 61.28 μs   (58.31 μs .. 64.39 μs)
+                     0.987 R²   (0.975 R² .. 0.997 R²)
+mean                 57.99 μs   (57.08 μs .. 59.92 μs)
+std dev              4.380 μs   (2.615 μs .. 7.623 μs)
+variance introduced by outliers: 74% (severely inflated)
+               
+benchmarking Degree_Constant/1000_ascending_graphFEConsecutiveAsc
+time                 171.8 μs   (170.3 μs .. 173.0 μs)
+                     0.999 R²   (0.999 R² .. 0.999 R²)
+mean                 169.9 μs   (168.9 μs .. 170.9 μs)
+std dev              3.111 μs   (2.765 μs .. 3.762 μs)
+variance introduced by outliers: 12% (moderately inflated)
+               
+benchmarking Degree_Constant/1000_ascending_graphFEConsecutive
+time                 211.5 μs   (197.2 μs .. 228.5 μs)
+                     0.978 R²   (0.963 R² .. 0.996 R²)
+mean                 198.8 μs   (195.3 μs .. 206.3 μs)
+std dev              16.67 μs   (8.062 μs .. 29.10 μs)
+variance introduced by outliers: 73% (severely inflated)
+               
+benchmarking Degree_Constant/1000_ascending_graphFE
+time                 667.5 μs   (661.1 μs .. 677.0 μs)
+                     0.998 R²   (0.995 R² .. 0.999 R²)
+mean                 693.2 μs   (678.6 μs .. 741.3 μs)
+std dev              85.73 μs   (22.12 μs .. 177.4 μs)
+variance introduced by outliers: 82% (severely inflated)
+               
+benchmarking Degree_Constant/1000_unsorted_graphFEConsecutive
+time                 699.1 μs   (629.6 μs .. 779.9 μs)
+                     0.943 R²   (0.921 R² .. 0.987 R²)
+mean                 625.5 μs   (602.8 μs .. 672.0 μs)
+std dev              106.8 μs   (66.32 μs .. 159.8 μs)
+variance introduced by outliers: 91% (severely inflated)
+               
+benchmarking Degree_Constant/1000_unsorted_graphFE
+time                 1.278 ms   (1.233 ms .. 1.331 ms)
+                     0.982 R²   (0.962 R² .. 0.994 R²)
+mean                 1.303 ms   (1.267 ms .. 1.357 ms)
+std dev              148.4 μs   (98.74 μs .. 218.5 μs)
+variance introduced by outliers: 76% (severely inflated)
+               
+benchmarking Degree_Zero/10_ascending_graphFEConsecutiveAsc
+time                 498.0 ns   (457.0 ns .. 541.7 ns)
+                     0.972 R²   (0.958 R² .. 0.993 R²)
+mean                 472.3 ns   (455.8 ns .. 495.4 ns)
+std dev              61.92 ns   (48.92 ns .. 90.20 ns)
+variance introduced by outliers: 94% (severely inflated)
+               
+benchmarking Degree_Zero/10_ascending_graphFEConsecutive
+time                 742.8 ns   (721.5 ns .. 761.0 ns)
+                     0.993 R²   (0.990 R² .. 0.996 R²)
+mean                 713.7 ns   (696.1 ns .. 749.1 ns)
+std dev              77.67 ns   (45.16 ns .. 133.4 ns)
+variance introduced by outliers: 91% (severely inflated)
+               
+benchmarking Degree_Zero/10_ascending_graphFE
+time                 712.7 ns   (678.2 ns .. 746.8 ns)
+                     0.986 R²   (0.982 R² .. 0.992 R²)
+mean                 732.2 ns   (702.2 ns .. 791.6 ns)
+std dev              128.5 ns   (70.12 ns .. 207.4 ns)
+variance introduced by outliers: 97% (severely inflated)
+               
+benchmarking Degree_Zero/10_unsorted_graphFEConsecutive
+time                 1.395 μs   (1.357 μs .. 1.443 μs)
+                     0.992 R²   (0.989 R² .. 0.995 R²)
+mean                 1.473 μs   (1.427 μs .. 1.553 μs)
+std dev              197.7 ns   (139.0 ns .. 280.5 ns)
+variance introduced by outliers: 93% (severely inflated)
+               
+benchmarking Degree_Zero/10_unsorted_graphFE
+time                 1.434 μs   (1.378 μs .. 1.502 μs)
+                     0.988 R²   (0.982 R² .. 0.994 R²)
+mean                 1.460 μs   (1.415 μs .. 1.510 μs)
+std dev              155.3 ns   (128.9 ns .. 206.8 ns)
+variance introduced by outliers: 90% (severely inflated)
+               
+benchmarking Degree_Zero/100_ascending_graphFEConsecutiveAsc
+time                 4.502 μs   (4.346 μs .. 4.636 μs)
+                     0.993 R²   (0.991 R² .. 0.996 R²)
+mean                 4.457 μs   (4.341 μs .. 4.596 μs)
+std dev              398.1 ns   (297.0 ns .. 555.9 ns)
+variance introduced by outliers: 85% (severely inflated)
+               
+benchmarking Degree_Zero/100_ascending_graphFEConsecutive
+time                 6.268 μs   (6.053 μs .. 6.451 μs)
+                     0.991 R²   (0.988 R² .. 0.994 R²)
+mean                 6.154 μs   (5.955 μs .. 6.397 μs)
+std dev              692.1 ns   (593.6 ns .. 855.7 ns)
+variance introduced by outliers: 90% (severely inflated)
+               
+benchmarking Degree_Zero/100_ascending_graphFE
+time                 6.156 μs   (6.012 μs .. 6.316 μs)
+                     0.995 R²   (0.993 R² .. 0.997 R²)
+mean                 6.229 μs   (6.102 μs .. 6.370 μs)
+std dev              443.1 ns   (373.0 ns .. 539.4 ns)
+variance introduced by outliers: 77% (severely inflated)
+               
+benchmarking Degree_Zero/100_unsorted_graphFEConsecutive
+time                 23.78 μs   (23.11 μs .. 24.67 μs)
+                     0.990 R²   (0.985 R² .. 0.994 R²)
+mean                 24.92 μs   (24.14 μs .. 25.84 μs)
+std dev              2.719 μs   (2.230 μs .. 3.670 μs)
+variance introduced by outliers: 87% (severely inflated)
+               
+benchmarking Degree_Zero/100_unsorted_graphFE
+time                 24.31 μs   (23.72 μs .. 24.92 μs)
+                     0.993 R²   (0.989 R² .. 0.995 R²)
+mean                 24.93 μs   (24.22 μs .. 26.14 μs)
+std dev              3.082 μs   (2.172 μs .. 4.562 μs)
+variance introduced by outliers: 90% (severely inflated)
+               
+benchmarking Degree_Zero/1000_ascending_graphFEConsecutiveAsc
+time                 54.99 μs   (53.43 μs .. 56.42 μs)
+                     0.995 R²   (0.993 R² .. 0.997 R²)
+mean                 53.63 μs   (52.40 μs .. 54.98 μs)
+std dev              4.123 μs   (3.445 μs .. 5.061 μs)
+variance introduced by outliers: 74% (severely inflated)
+               
+benchmarking Degree_Zero/1000_ascending_graphFEConsecutive
+time                 70.48 μs   (68.85 μs .. 72.44 μs)
+                     0.993 R²   (0.989 R² .. 0.996 R²)
+mean                 71.15 μs   (69.34 μs .. 73.33 μs)
+std dev              6.444 μs   (4.965 μs .. 9.045 μs)
+variance introduced by outliers: 80% (severely inflated)
+               
+benchmarking Degree_Zero/1000_ascending_graphFE
+time                 74.36 μs   (71.52 μs .. 77.64 μs)
+                     0.987 R²   (0.979 R² .. 0.994 R²)
+mean                 73.55 μs   (71.74 μs .. 76.33 μs)
+std dev              6.978 μs   (4.920 μs .. 9.604 μs)
+variance introduced by outliers: 81% (severely inflated)
+               
+benchmarking Degree_Zero/1000_unsorted_graphFEConsecutive
+time                 437.2 μs   (422.3 μs .. 451.9 μs)
+                     0.989 R²   (0.984 R² .. 0.993 R²)
+mean                 466.8 μs   (451.8 μs .. 487.4 μs)
+std dev              58.99 μs   (44.42 μs .. 89.45 μs)
+variance introduced by outliers: 84% (severely inflated)
+               
+benchmarking Degree_Zero/1000_unsorted_graphFE
+time                 436.9 μs   (423.9 μs .. 449.0 μs)
+                     0.995 R²   (0.992 R² .. 0.997 R²)
+mean                 444.4 μs   (435.4 μs .. 454.8 μs)
+std dev              31.75 μs   (25.71 μs .. 38.71 μs)
+variance introduced by outliers: 62% (severely inflated)
+               
+Benchmark graph-creation: FINISH

--- a/bench.txt
+++ b/bench.txt
@@ -1,318 +1,318 @@
 
 Benchmark graph-creation: RUNNING...
-benchmarking Degree_LinearInVertices/10_ascending_graphFEConsecutiveAsc
-time                 1.326 μs   (1.268 μs .. 1.399 μs)
-                     0.985 R²   (0.970 R² .. 0.996 R²)
-mean                 1.347 μs   (1.309 μs .. 1.401 μs)
-std dev              146.8 ns   (102.4 ns .. 204.6 ns)
-variance introduced by outliers: 90% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/10_ascending_graphFEConsecutive
-time                 1.626 μs   (1.571 μs .. 1.684 μs)
-                     0.993 R²   (0.990 R² .. 0.997 R²)
-mean                 1.664 μs   (1.634 μs .. 1.702 μs)
-std dev              114.9 ns   (90.21 ns .. 158.5 ns)
-variance introduced by outliers: 78% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/10_ascending_graphFE
-time                 2.368 μs   (2.249 μs .. 2.545 μs)
-                     0.985 R²   (0.975 R² .. 0.996 R²)
-mean                 2.430 μs   (2.376 μs .. 2.493 μs)
-std dev              212.4 ns   (179.9 ns .. 274.0 ns)
-variance introduced by outliers: 85% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/10_unsorted_graphFEConsecutive
-time                 2.257 μs   (2.216 μs .. 2.313 μs)
-                     0.995 R²   (0.993 R² .. 0.997 R²)
-mean                 2.350 μs   (2.304 μs .. 2.408 μs)
-std dev              175.4 ns   (142.8 ns .. 256.4 ns)
-variance introduced by outliers: 80% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/10_unsorted_graphFE
-time                 3.183 μs   (3.074 μs .. 3.282 μs)
-                     0.994 R²   (0.992 R² .. 0.996 R²)
-mean                 3.093 μs   (3.037 μs .. 3.169 μs)
-std dev              212.2 ns   (176.8 ns .. 262.0 ns)
-variance introduced by outliers: 77% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/100_ascending_graphFEConsecutiveAsc
-time                 95.35 μs   (91.58 μs .. 99.38 μs)
-                     0.986 R²   (0.980 R² .. 0.991 R²)
-mean                 98.45 μs   (95.36 μs .. 102.1 μs)
-std dev              11.81 μs   (9.321 μs .. 17.18 μs)
-variance introduced by outliers: 86% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/100_ascending_graphFEConsecutive
-time                 86.11 μs   (84.91 μs .. 87.53 μs)
-                     0.996 R²   (0.993 R² .. 0.997 R²)
-mean                 92.39 μs   (90.17 μs .. 95.00 μs)
-std dev              8.142 μs   (7.231 μs .. 9.407 μs)
-variance introduced by outliers: 78% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/100_ascending_graphFE
-time                 298.6 μs   (290.3 μs .. 306.0 μs)
-                     0.996 R²   (0.994 R² .. 0.997 R²)
-mean                 296.4 μs   (292.4 μs .. 301.3 μs)
-std dev              15.42 μs   (11.97 μs .. 19.33 μs)
-variance introduced by outliers: 48% (moderately inflated)
-               
-benchmarking Degree_LinearInVertices/100_unsorted_graphFEConsecutive
-time                 120.7 μs   (114.9 μs .. 127.0 μs)
-                     0.969 R²   (0.937 R² .. 0.989 R²)
-mean                 122.4 μs   (117.3 μs .. 132.5 μs)
-std dev              23.47 μs   (12.80 μs .. 41.56 μs)
+benchmarking Degree_LinearInVertices/10_ascending_graphFromConsecutiveAscKeys
+time                 1.508 μs   (1.435 μs .. 1.602 μs)
+                     0.972 R²   (0.951 R² .. 0.991 R²)
+mean                 1.653 μs   (1.521 μs .. 1.994 μs)
+std dev              705.3 ns   (257.4 ns .. 1.284 μs)
+variance introduced by outliers: 99% (severely inflated)
+
+benchmarking Degree_LinearInVertices/10_ascending_graphFromConsecutiveKeys
+time                 1.957 μs   (1.853 μs .. 2.079 μs)
+                     0.977 R²   (0.961 R² .. 0.993 R²)
+mean                 1.968 μs   (1.895 μs .. 2.065 μs)
+std dev              278.0 ns   (227.3 ns .. 361.6 ns)
 variance introduced by outliers: 94% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/100_unsorted_graphFE
-time                 324.5 μs   (317.0 μs .. 333.2 μs)
-                     0.992 R²   (0.987 R² .. 0.996 R²)
-mean                 357.2 μs   (344.2 μs .. 380.8 μs)
-std dev              58.70 μs   (28.78 μs .. 109.1 μs)
-variance introduced by outliers: 91% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/1000_ascending_graphFEConsecutiveAsc
-time                 20.32 ms   (19.66 ms .. 20.95 ms)
-                     0.996 R²   (0.994 R² .. 0.998 R²)
-mean                 20.69 ms   (20.27 ms .. 21.42 ms)
-std dev              1.315 ms   (833.2 μs .. 1.894 ms)
-variance introduced by outliers: 27% (moderately inflated)
-               
-benchmarking Degree_LinearInVertices/1000_ascending_graphFEConsecutive
-time                 24.34 ms   (20.09 ms .. 29.02 ms)
-                     0.833 R²   (0.612 R² .. 0.969 R²)
-mean                 25.05 ms   (23.38 ms .. 29.04 ms)
-std dev              5.234 ms   (2.551 ms .. 9.448 ms)
-variance introduced by outliers: 77% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/1000_ascending_graphFE
-time                 51.27 ms   (42.52 ms .. 55.98 ms)
-                     0.954 R²   (0.888 R² .. 0.990 R²)
-mean                 59.97 ms   (54.66 ms .. 67.60 ms)
-std dev              11.17 ms   (6.375 ms .. 14.67 ms)
-variance introduced by outliers: 65% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/1000_unsorted_graphFEConsecutive
-time                 24.79 ms   (22.97 ms .. 26.26 ms)
-                     0.978 R²   (0.955 R² .. 0.991 R²)
-mean                 28.68 ms   (27.18 ms .. 30.88 ms)
-std dev              3.802 ms   (2.619 ms .. 5.025 ms)
-variance introduced by outliers: 54% (severely inflated)
-               
-benchmarking Degree_LinearInVertices/1000_unsorted_graphFE
-time                 63.52 ms   (53.57 ms .. 72.01 ms)
-                     0.971 R²   (0.943 R² .. 0.995 R²)
-mean                 59.53 ms   (57.10 ms .. 62.74 ms)
-std dev              5.074 ms   (3.690 ms .. 7.192 ms)
-variance introduced by outliers: 24% (moderately inflated)
-               
-benchmarking Degree_Constant/10_ascending_graphFEConsecutiveAsc
-time                 1.244 μs   (1.218 μs .. 1.285 μs)
-                     0.994 R²   (0.985 R² .. 0.999 R²)
-mean                 1.239 μs   (1.220 μs .. 1.283 μs)
-std dev              89.88 ns   (37.00 ns .. 160.4 ns)
-variance introduced by outliers: 81% (severely inflated)
-               
-benchmarking Degree_Constant/10_ascending_graphFEConsecutive
-time                 1.547 μs   (1.470 μs .. 1.647 μs)
-                     0.980 R²   (0.957 R² .. 0.998 R²)
-mean                 1.516 μs   (1.486 μs .. 1.590 μs)
-std dev              149.3 ns   (73.91 ns .. 281.2 ns)
+
+benchmarking Degree_LinearInVertices/10_ascending_graphFromEdges
+time                 2.783 μs   (2.630 μs .. 3.012 μs)
+                     0.979 R²   (0.963 R² .. 0.998 R²)
+mean                 2.672 μs   (2.609 μs .. 2.770 μs)
+std dev              262.8 ns   (160.3 ns .. 422.7 ns)
 variance introduced by outliers: 88% (severely inflated)
-               
-benchmarking Degree_Constant/10_ascending_graphFE
-time                 2.317 μs   (2.301 μs .. 2.340 μs)
-                     0.998 R²   (0.995 R² .. 1.000 R²)
-mean                 2.343 μs   (2.306 μs .. 2.523 μs)
-std dev              191.5 ns   (67.77 ns .. 426.1 ns)
-variance introduced by outliers: 83% (severely inflated)
-               
-benchmarking Degree_Constant/10_unsorted_graphFEConsecutive
-time                 2.317 μs   (2.226 μs .. 2.425 μs)
-                     0.991 R²   (0.984 R² .. 0.999 R²)
-mean                 2.233 μs   (2.196 μs .. 2.292 μs)
-std dev              155.8 ns   (80.66 ns .. 256.8 ns)
-variance introduced by outliers: 78% (severely inflated)
-               
-benchmarking Degree_Constant/10_unsorted_graphFE
-time                 2.980 μs   (2.936 μs .. 3.037 μs)
-                     0.998 R²   (0.996 R² .. 0.999 R²)
-mean                 2.998 μs   (2.956 μs .. 3.092 μs)
-std dev              194.4 ns   (113.0 ns .. 351.3 ns)
-variance introduced by outliers: 75% (severely inflated)
-               
-benchmarking Degree_Constant/100_ascending_graphFEConsecutiveAsc
-time                 14.95 μs   (13.97 μs .. 15.94 μs)
-                     0.979 R²   (0.966 R² .. 0.995 R²)
-mean                 14.03 μs   (13.65 μs .. 14.67 μs)
-std dev              1.617 μs   (1.035 μs .. 2.338 μs)
-variance introduced by outliers: 89% (severely inflated)
-               
-benchmarking Degree_Constant/100_ascending_graphFEConsecutive
-time                 15.42 μs   (15.33 μs .. 15.49 μs)
-                     0.999 R²   (0.998 R² .. 1.000 R²)
-mean                 15.73 μs   (15.48 μs .. 16.35 μs)
-std dev              1.163 μs   (378.6 ns .. 2.106 μs)
-variance introduced by outliers: 76% (severely inflated)
-               
-benchmarking Degree_Constant/100_ascending_graphFE
-time                 41.75 μs   (40.23 μs .. 43.67 μs)
-                     0.990 R²   (0.980 R² .. 0.998 R²)
-mean                 41.04 μs   (40.25 μs .. 42.38 μs)
-std dev              3.122 μs   (2.103 μs .. 4.777 μs)
-variance introduced by outliers: 74% (severely inflated)
-               
-benchmarking Degree_Constant/100_unsorted_graphFEConsecutive
-time                 32.20 μs   (31.74 μs .. 32.81 μs)
-                     0.997 R²   (0.996 R² .. 0.998 R²)
-mean                 33.19 μs   (32.65 μs .. 34.11 μs)
-std dev              2.247 μs   (1.483 μs .. 3.517 μs)
-variance introduced by outliers: 71% (severely inflated)
-               
-benchmarking Degree_Constant/100_unsorted_graphFE
-time                 61.28 μs   (58.31 μs .. 64.39 μs)
-                     0.987 R²   (0.975 R² .. 0.997 R²)
-mean                 57.99 μs   (57.08 μs .. 59.92 μs)
-std dev              4.380 μs   (2.615 μs .. 7.623 μs)
-variance introduced by outliers: 74% (severely inflated)
-               
-benchmarking Degree_Constant/1000_ascending_graphFEConsecutiveAsc
-time                 171.8 μs   (170.3 μs .. 173.0 μs)
-                     0.999 R²   (0.999 R² .. 0.999 R²)
-mean                 169.9 μs   (168.9 μs .. 170.9 μs)
-std dev              3.111 μs   (2.765 μs .. 3.762 μs)
-variance introduced by outliers: 12% (moderately inflated)
-               
-benchmarking Degree_Constant/1000_ascending_graphFEConsecutive
-time                 211.5 μs   (197.2 μs .. 228.5 μs)
-                     0.978 R²   (0.963 R² .. 0.996 R²)
-mean                 198.8 μs   (195.3 μs .. 206.3 μs)
-std dev              16.67 μs   (8.062 μs .. 29.10 μs)
-variance introduced by outliers: 73% (severely inflated)
-               
-benchmarking Degree_Constant/1000_ascending_graphFE
-time                 667.5 μs   (661.1 μs .. 677.0 μs)
-                     0.998 R²   (0.995 R² .. 0.999 R²)
-mean                 693.2 μs   (678.6 μs .. 741.3 μs)
-std dev              85.73 μs   (22.12 μs .. 177.4 μs)
-variance introduced by outliers: 82% (severely inflated)
-               
-benchmarking Degree_Constant/1000_unsorted_graphFEConsecutive
-time                 699.1 μs   (629.6 μs .. 779.9 μs)
-                     0.943 R²   (0.921 R² .. 0.987 R²)
-mean                 625.5 μs   (602.8 μs .. 672.0 μs)
-std dev              106.8 μs   (66.32 μs .. 159.8 μs)
-variance introduced by outliers: 91% (severely inflated)
-               
-benchmarking Degree_Constant/1000_unsorted_graphFE
-time                 1.278 ms   (1.233 ms .. 1.331 ms)
-                     0.982 R²   (0.962 R² .. 0.994 R²)
-mean                 1.303 ms   (1.267 ms .. 1.357 ms)
-std dev              148.4 μs   (98.74 μs .. 218.5 μs)
-variance introduced by outliers: 76% (severely inflated)
-               
-benchmarking Degree_Zero/10_ascending_graphFEConsecutiveAsc
-time                 498.0 ns   (457.0 ns .. 541.7 ns)
-                     0.972 R²   (0.958 R² .. 0.993 R²)
-mean                 472.3 ns   (455.8 ns .. 495.4 ns)
-std dev              61.92 ns   (48.92 ns .. 90.20 ns)
-variance introduced by outliers: 94% (severely inflated)
-               
-benchmarking Degree_Zero/10_ascending_graphFEConsecutive
-time                 742.8 ns   (721.5 ns .. 761.0 ns)
-                     0.993 R²   (0.990 R² .. 0.996 R²)
-mean                 713.7 ns   (696.1 ns .. 749.1 ns)
-std dev              77.67 ns   (45.16 ns .. 133.4 ns)
-variance introduced by outliers: 91% (severely inflated)
-               
-benchmarking Degree_Zero/10_ascending_graphFE
-time                 712.7 ns   (678.2 ns .. 746.8 ns)
-                     0.986 R²   (0.982 R² .. 0.992 R²)
-mean                 732.2 ns   (702.2 ns .. 791.6 ns)
-std dev              128.5 ns   (70.12 ns .. 207.4 ns)
-variance introduced by outliers: 97% (severely inflated)
-               
-benchmarking Degree_Zero/10_unsorted_graphFEConsecutive
-time                 1.395 μs   (1.357 μs .. 1.443 μs)
-                     0.992 R²   (0.989 R² .. 0.995 R²)
-mean                 1.473 μs   (1.427 μs .. 1.553 μs)
-std dev              197.7 ns   (139.0 ns .. 280.5 ns)
-variance introduced by outliers: 93% (severely inflated)
-               
-benchmarking Degree_Zero/10_unsorted_graphFE
-time                 1.434 μs   (1.378 μs .. 1.502 μs)
-                     0.988 R²   (0.982 R² .. 0.994 R²)
-mean                 1.460 μs   (1.415 μs .. 1.510 μs)
-std dev              155.3 ns   (128.9 ns .. 206.8 ns)
-variance introduced by outliers: 90% (severely inflated)
-               
-benchmarking Degree_Zero/100_ascending_graphFEConsecutiveAsc
-time                 4.502 μs   (4.346 μs .. 4.636 μs)
-                     0.993 R²   (0.991 R² .. 0.996 R²)
-mean                 4.457 μs   (4.341 μs .. 4.596 μs)
-std dev              398.1 ns   (297.0 ns .. 555.9 ns)
-variance introduced by outliers: 85% (severely inflated)
-               
-benchmarking Degree_Zero/100_ascending_graphFEConsecutive
-time                 6.268 μs   (6.053 μs .. 6.451 μs)
-                     0.991 R²   (0.988 R² .. 0.994 R²)
-mean                 6.154 μs   (5.955 μs .. 6.397 μs)
-std dev              692.1 ns   (593.6 ns .. 855.7 ns)
-variance introduced by outliers: 90% (severely inflated)
-               
-benchmarking Degree_Zero/100_ascending_graphFE
-time                 6.156 μs   (6.012 μs .. 6.316 μs)
-                     0.995 R²   (0.993 R² .. 0.997 R²)
-mean                 6.229 μs   (6.102 μs .. 6.370 μs)
-std dev              443.1 ns   (373.0 ns .. 539.4 ns)
-variance introduced by outliers: 77% (severely inflated)
-               
-benchmarking Degree_Zero/100_unsorted_graphFEConsecutive
-time                 23.78 μs   (23.11 μs .. 24.67 μs)
-                     0.990 R²   (0.985 R² .. 0.994 R²)
-mean                 24.92 μs   (24.14 μs .. 25.84 μs)
-std dev              2.719 μs   (2.230 μs .. 3.670 μs)
-variance introduced by outliers: 87% (severely inflated)
-               
-benchmarking Degree_Zero/100_unsorted_graphFE
-time                 24.31 μs   (23.72 μs .. 24.92 μs)
-                     0.993 R²   (0.989 R² .. 0.995 R²)
-mean                 24.93 μs   (24.22 μs .. 26.14 μs)
-std dev              3.082 μs   (2.172 μs .. 4.562 μs)
-variance introduced by outliers: 90% (severely inflated)
-               
-benchmarking Degree_Zero/1000_ascending_graphFEConsecutiveAsc
-time                 54.99 μs   (53.43 μs .. 56.42 μs)
-                     0.995 R²   (0.993 R² .. 0.997 R²)
-mean                 53.63 μs   (52.40 μs .. 54.98 μs)
-std dev              4.123 μs   (3.445 μs .. 5.061 μs)
-variance introduced by outliers: 74% (severely inflated)
-               
-benchmarking Degree_Zero/1000_ascending_graphFEConsecutive
-time                 70.48 μs   (68.85 μs .. 72.44 μs)
-                     0.993 R²   (0.989 R² .. 0.996 R²)
-mean                 71.15 μs   (69.34 μs .. 73.33 μs)
-std dev              6.444 μs   (4.965 μs .. 9.045 μs)
+
+benchmarking Degree_LinearInVertices/10_unsorted_graphFromConsecutiveKeys
+time                 3.040 μs   (2.913 μs .. 3.203 μs)
+                     0.975 R²   (0.962 R² .. 0.985 R²)
+mean                 3.283 μs   (3.053 μs .. 3.634 μs)
+std dev              985.5 ns   (737.8 ns .. 1.311 μs)
+variance introduced by outliers: 99% (severely inflated)
+
+benchmarking Degree_LinearInVertices/10_unsorted_graphFromEdges
+time                 3.454 μs   (3.401 μs .. 3.521 μs)
+                     0.996 R²   (0.994 R² .. 0.998 R²)
+mean                 3.584 μs   (3.497 μs .. 3.669 μs)
+std dev              273.5 ns   (229.0 ns .. 350.2 ns)
 variance introduced by outliers: 80% (severely inflated)
-               
-benchmarking Degree_Zero/1000_ascending_graphFE
-time                 74.36 μs   (71.52 μs .. 77.64 μs)
-                     0.987 R²   (0.979 R² .. 0.994 R²)
-mean                 73.55 μs   (71.74 μs .. 76.33 μs)
-std dev              6.978 μs   (4.920 μs .. 9.604 μs)
-variance introduced by outliers: 81% (severely inflated)
-               
-benchmarking Degree_Zero/1000_unsorted_graphFEConsecutive
-time                 437.2 μs   (422.3 μs .. 451.9 μs)
-                     0.989 R²   (0.984 R² .. 0.993 R²)
-mean                 466.8 μs   (451.8 μs .. 487.4 μs)
-std dev              58.99 μs   (44.42 μs .. 89.45 μs)
-variance introduced by outliers: 84% (severely inflated)
-               
-benchmarking Degree_Zero/1000_unsorted_graphFE
-time                 436.9 μs   (423.9 μs .. 449.0 μs)
-                     0.995 R²   (0.992 R² .. 0.997 R²)
-mean                 444.4 μs   (435.4 μs .. 454.8 μs)
-std dev              31.75 μs   (25.71 μs .. 38.71 μs)
+
+benchmarking Degree_LinearInVertices/100_ascending_graphFromConsecutiveAscKeys
+time                 107.3 μs   (101.6 μs .. 113.9 μs)
+                     0.979 R²   (0.966 R² .. 0.993 R²)
+mean                 105.5 μs   (101.8 μs .. 110.4 μs)
+std dev              14.33 μs   (10.33 μs .. 18.32 μs)
+variance introduced by outliers: 89% (severely inflated)
+
+benchmarking Degree_LinearInVertices/100_ascending_graphFromConsecutiveKeys
+time                 102.8 μs   (99.51 μs .. 106.1 μs)
+                     0.994 R²   (0.991 R² .. 0.997 R²)
+mean                 99.02 μs   (97.31 μs .. 101.4 μs)
+std dev              6.489 μs   (4.779 μs .. 9.515 μs)
+variance introduced by outliers: 65% (severely inflated)
+
+benchmarking Degree_LinearInVertices/100_ascending_graphFromEdges
+time                 389.1 μs   (358.0 μs .. 413.3 μs)
+                     0.971 R²   (0.961 R² .. 0.985 R²)
+mean                 380.4 μs   (367.7 μs .. 394.8 μs)
+std dev              47.17 μs   (39.80 μs .. 64.34 μs)
+variance introduced by outliers: 85% (severely inflated)
+
+benchmarking Degree_LinearInVertices/100_unsorted_graphFromConsecutiveKeys
+time                 130.1 μs   (126.7 μs .. 134.0 μs)
+                     0.991 R²   (0.986 R² .. 0.995 R²)
+mean                 132.2 μs   (128.5 μs .. 138.1 μs)
+std dev              15.89 μs   (11.65 μs .. 23.76 μs)
+variance introduced by outliers: 86% (severely inflated)
+
+benchmarking Degree_LinearInVertices/100_unsorted_graphFromEdges
+time                 407.4 μs   (371.0 μs .. 436.1 μs)
+                     0.971 R²   (0.961 R² .. 0.989 R²)
+mean                 381.9 μs   (369.0 μs .. 396.9 μs)
+std dev              46.03 μs   (34.48 μs .. 58.97 μs)
+variance introduced by outliers: 83% (severely inflated)
+
+benchmarking Degree_LinearInVertices/1000_ascending_graphFromConsecutiveAscKeys
+time                 20.60 ms   (19.17 ms .. 21.85 ms)
+                     0.983 R²   (0.968 R² .. 0.995 R²)
+mean                 24.36 ms   (23.00 ms .. 26.23 ms)
+std dev              3.636 ms   (1.692 ms .. 5.363 ms)
 variance introduced by outliers: 62% (severely inflated)
-               
+
+benchmarking Degree_LinearInVertices/1000_ascending_graphFromConsecutiveKeys
+time                 27.99 ms   (24.73 ms .. 32.16 ms)
+                     0.952 R²   (0.922 R² .. 0.991 R²)
+mean                 24.00 ms   (23.05 ms .. 25.84 ms)
+std dev              2.883 ms   (1.725 ms .. 4.673 ms)
+variance introduced by outliers: 51% (severely inflated)
+
+benchmarking Degree_LinearInVertices/1000_ascending_graphFromEdges
+time                 54.33 ms   (52.56 ms .. 55.73 ms)
+                     0.996 R²   (0.990 R² .. 0.999 R²)
+mean                 57.22 ms   (55.98 ms .. 59.45 ms)
+std dev              2.836 ms   (1.813 ms .. 3.968 ms)
+variance introduced by outliers: 15% (moderately inflated)
+
+benchmarking Degree_LinearInVertices/1000_unsorted_graphFromConsecutiveKeys
+time                 30.17 ms   (26.56 ms .. 33.33 ms)
+                     0.966 R²   (0.929 R² .. 0.992 R²)
+mean                 28.90 ms   (27.89 ms .. 30.34 ms)
+std dev              2.448 ms   (1.778 ms .. 3.591 ms)
+variance introduced by outliers: 34% (moderately inflated)
+
+benchmarking Degree_LinearInVertices/1000_unsorted_graphFromEdges
+time                 74.38 ms   (66.96 ms .. 81.77 ms)
+                     0.983 R²   (0.961 R² .. 0.996 R²)
+mean                 68.81 ms   (65.90 ms .. 72.40 ms)
+std dev              5.419 ms   (4.311 ms .. 6.789 ms)
+variance introduced by outliers: 26% (moderately inflated)
+
+benchmarking Degree_Constant/10_ascending_graphFromConsecutiveAscKeys
+time                 1.535 μs   (1.460 μs .. 1.615 μs)
+                     0.980 R²   (0.970 R² .. 0.990 R²)
+mean                 1.440 μs   (1.383 μs .. 1.516 μs)
+std dev              207.6 ns   (161.9 ns .. 271.7 ns)
+variance introduced by outliers: 94% (severely inflated)
+
+benchmarking Degree_Constant/10_ascending_graphFromConsecutiveKeys
+time                 1.716 μs   (1.656 μs .. 1.780 μs)
+                     0.991 R²   (0.988 R² .. 0.995 R²)
+mean                 1.681 μs   (1.644 μs .. 1.734 μs)
+std dev              149.2 ns   (119.9 ns .. 184.3 ns)
+variance introduced by outliers: 86% (severely inflated)
+
+benchmarking Degree_Constant/10_ascending_graphFromEdges
+time                 2.550 μs   (2.495 μs .. 2.610 μs)
+                     0.992 R²   (0.986 R² .. 0.995 R²)
+mean                 2.694 μs   (2.592 μs .. 2.865 μs)
+std dev              452.4 ns   (313.0 ns .. 652.8 ns)
+variance introduced by outliers: 96% (severely inflated)
+
+benchmarking Degree_Constant/10_unsorted_graphFromConsecutiveKeys
+time                 2.432 μs   (2.349 μs .. 2.518 μs)
+                     0.990 R²   (0.985 R² .. 0.996 R²)
+mean                 2.356 μs   (2.300 μs .. 2.429 μs)
+std dev              223.8 ns   (177.6 ns .. 286.0 ns)
+variance introduced by outliers: 87% (severely inflated)
+
+benchmarking Degree_Constant/10_unsorted_graphFromEdges
+time                 3.211 μs   (3.148 μs .. 3.281 μs)
+                     0.995 R²   (0.993 R² .. 0.997 R²)
+mean                 3.215 μs   (3.140 μs .. 3.299 μs)
+std dev              261.7 ns   (217.7 ns .. 314.9 ns)
+variance introduced by outliers: 83% (severely inflated)
+
+benchmarking Degree_Constant/100_ascending_graphFromConsecutiveAscKeys
+time                 14.24 μs   (13.86 μs .. 14.67 μs)
+                     0.992 R²   (0.988 R² .. 0.996 R²)
+mean                 14.63 μs   (14.19 μs .. 15.23 μs)
+std dev              1.723 μs   (1.214 μs .. 2.708 μs)
+variance introduced by outliers: 89% (severely inflated)
+
+benchmarking Degree_Constant/100_ascending_graphFromConsecutiveKeys
+time                 17.49 μs   (16.64 μs .. 18.30 μs)
+                     0.985 R²   (0.978 R² .. 0.992 R²)
+mean                 17.86 μs   (17.07 μs .. 19.08 μs)
+std dev              3.236 μs   (2.191 μs .. 4.706 μs)
+variance introduced by outliers: 95% (severely inflated)
+
+benchmarking Degree_Constant/100_ascending_graphFromEdges
+time                 41.23 μs   (40.05 μs .. 42.75 μs)
+                     0.987 R²   (0.978 R² .. 0.994 R²)
+mean                 41.75 μs   (40.53 μs .. 43.59 μs)
+std dev              4.869 μs   (3.518 μs .. 6.654 μs)
+variance introduced by outliers: 87% (severely inflated)
+
+benchmarking Degree_Constant/100_unsorted_graphFromConsecutiveKeys
+time                 35.74 μs   (34.54 μs .. 37.01 μs)
+                     0.990 R²   (0.986 R² .. 0.995 R²)
+mean                 34.92 μs   (34.18 μs .. 35.96 μs)
+std dev              3.068 μs   (2.356 μs .. 3.985 μs)
+variance introduced by outliers: 80% (severely inflated)
+
+benchmarking Degree_Constant/100_unsorted_graphFromEdges
+time                 63.20 μs   (61.71 μs .. 64.84 μs)
+                     0.994 R²   (0.991 R² .. 0.997 R²)
+mean                 61.10 μs   (59.81 μs .. 62.63 μs)
+std dev              4.557 μs   (3.817 μs .. 5.762 μs)
+variance introduced by outliers: 73% (severely inflated)
+
+benchmarking Degree_Constant/1000_ascending_graphFromConsecutiveAscKeys
+time                 203.9 μs   (195.7 μs .. 214.5 μs)
+                     0.984 R²   (0.969 R² .. 0.994 R²)
+mean                 199.1 μs   (193.1 μs .. 209.7 μs)
+std dev              25.15 μs   (16.79 μs .. 36.09 μs)
+variance introduced by outliers: 87% (severely inflated)
+
+benchmarking Degree_Constant/1000_ascending_graphFromConsecutiveKeys
+time                 209.5 μs   (205.1 μs .. 214.6 μs)
+                     0.993 R²   (0.990 R² .. 0.996 R²)
+mean                 217.3 μs   (212.5 μs .. 224.6 μs)
+std dev              19.41 μs   (14.65 μs .. 28.43 μs)
+variance introduced by outliers: 75% (severely inflated)
+
+benchmarking Degree_Constant/1000_ascending_graphFromEdges
+time                 733.5 μs   (710.5 μs .. 756.7 μs)
+                     0.989 R²   (0.982 R² .. 0.994 R²)
+mean                 762.4 μs   (728.2 μs .. 811.5 μs)
+std dev              132.9 μs   (88.39 μs .. 209.6 μs)
+variance introduced by outliers: 90% (severely inflated)
+
+benchmarking Degree_Constant/1000_unsorted_graphFromConsecutiveKeys
+time                 622.1 μs   (603.4 μs .. 641.5 μs)
+                     0.987 R²   (0.980 R² .. 0.993 R²)
+mean                 665.2 μs   (637.5 μs .. 713.6 μs)
+std dev              119.8 μs   (76.02 μs .. 178.7 μs)
+variance introduced by outliers: 91% (severely inflated)
+
+benchmarking Degree_Constant/1000_unsorted_graphFromEdges
+time                 1.289 ms   (1.248 ms .. 1.330 ms)
+                     0.990 R²   (0.984 R² .. 0.994 R²)
+mean                 1.307 ms   (1.265 ms .. 1.384 ms)
+std dev              175.7 μs   (109.4 μs .. 316.1 μs)
+variance introduced by outliers: 82% (severely inflated)
+
+benchmarking Degree_Zero/10_ascending_graphFromConsecutiveAscKeys
+time                 484.1 ns   (468.8 ns .. 501.6 ns)
+                     0.992 R²   (0.988 R² .. 0.996 R²)
+mean                 488.9 ns   (474.1 ns .. 522.7 ns)
+std dev              69.70 ns   (38.61 ns .. 118.7 ns)
+variance introduced by outliers: 95% (severely inflated)
+
+benchmarking Degree_Zero/10_ascending_graphFromConsecutiveKeys
+time                 747.4 ns   (731.5 ns .. 765.6 ns)
+                     0.994 R²   (0.991 R² .. 0.997 R²)
+mean                 764.7 ns   (742.9 ns .. 795.7 ns)
+std dev              82.71 ns   (54.07 ns .. 125.6 ns)
+variance introduced by outliers: 91% (severely inflated)
+
+benchmarking Degree_Zero/10_ascending_graphFromEdges
+time                 721.2 ns   (702.0 ns .. 742.6 ns)
+                     0.991 R²   (0.983 R² .. 0.996 R²)
+mean                 740.0 ns   (716.4 ns .. 781.2 ns)
+std dev              101.3 ns   (65.36 ns .. 167.7 ns)
+variance introduced by outliers: 94% (severely inflated)
+
+benchmarking Degree_Zero/10_unsorted_graphFromConsecutiveKeys
+time                 1.499 μs   (1.464 μs .. 1.529 μs)
+                     0.994 R²   (0.991 R² .. 0.996 R²)
+mean                 1.510 μs   (1.468 μs .. 1.565 μs)
+std dev              161.2 ns   (126.5 ns .. 213.5 ns)
+variance introduced by outliers: 90% (severely inflated)
+
+benchmarking Degree_Zero/10_unsorted_graphFromEdges
+time                 1.428 μs   (1.384 μs .. 1.474 μs)
+                     0.992 R²   (0.989 R² .. 0.996 R²)
+mean                 1.439 μs   (1.399 μs .. 1.507 μs)
+std dev              168.9 ns   (109.7 ns .. 273.1 ns)
+variance introduced by outliers: 92% (severely inflated)
+
+benchmarking Degree_Zero/100_ascending_graphFromConsecutiveAscKeys
+time                 4.451 μs   (4.315 μs .. 4.594 μs)
+                     0.990 R²   (0.985 R² .. 0.994 R²)
+mean                 4.477 μs   (4.321 μs .. 4.675 μs)
+std dev              577.2 ns   (444.3 ns .. 904.2 ns)
+variance introduced by outliers: 92% (severely inflated)
+
+benchmarking Degree_Zero/100_ascending_graphFromConsecutiveKeys
+time                 6.169 μs   (5.902 μs .. 6.442 μs)
+                     0.987 R²   (0.981 R² .. 0.992 R²)
+mean                 6.473 μs   (6.215 μs .. 6.834 μs)
+std dev              1.061 μs   (780.4 ns .. 1.655 μs)
+variance introduced by outliers: 95% (severely inflated)
+
+benchmarking Degree_Zero/100_ascending_graphFromEdges
+time                 6.369 μs   (6.118 μs .. 6.668 μs)
+                     0.986 R²   (0.978 R² .. 0.994 R²)
+mean                 6.484 μs   (6.290 μs .. 6.721 μs)
+std dev              711.1 ns   (562.7 ns .. 902.2 ns)
+variance introduced by outliers: 89% (severely inflated)
+
+benchmarking Degree_Zero/100_unsorted_graphFromConsecutiveKeys
+time                 26.30 μs   (25.19 μs .. 27.33 μs)
+                     0.990 R²   (0.986 R² .. 0.994 R²)
+mean                 25.76 μs   (25.09 μs .. 26.89 μs)
+std dev              2.795 μs   (2.009 μs .. 3.970 μs)
+variance introduced by outliers: 87% (severely inflated)
+
+benchmarking Degree_Zero/100_unsorted_graphFromEdges
+time                 25.28 μs   (24.51 μs .. 26.13 μs)
+                     0.987 R²   (0.980 R² .. 0.992 R²)
+mean                 26.21 μs   (25.32 μs .. 27.24 μs)
+std dev              3.396 μs   (2.821 μs .. 4.107 μs)
+variance introduced by outliers: 90% (severely inflated)
+
+benchmarking Degree_Zero/1000_ascending_graphFromConsecutiveAscKeys
+time                 53.55 μs   (52.44 μs .. 54.76 μs)
+                     0.991 R²   (0.986 R² .. 0.995 R²)
+mean                 57.41 μs   (55.02 μs .. 61.75 μs)
+std dev              10.64 μs   (5.100 μs .. 17.09 μs)
+variance introduced by outliers: 95% (severely inflated)
+
+benchmarking Degree_Zero/1000_ascending_graphFromConsecutiveKeys
+time                 75.34 μs   (73.79 μs .. 76.85 μs)
+                     0.992 R²   (0.987 R² .. 0.995 R²)
+mean                 74.67 μs   (72.29 μs .. 77.47 μs)
+std dev              8.335 μs   (6.692 μs .. 10.70 μs)
+variance introduced by outliers: 85% (severely inflated)
+
+benchmarking Degree_Zero/1000_ascending_graphFromEdges
+time                 75.49 μs   (72.85 μs .. 78.53 μs)
+                     0.990 R²   (0.986 R² .. 0.994 R²)
+mean                 77.91 μs   (75.79 μs .. 80.02 μs)
+std dev              7.518 μs   (6.337 μs .. 9.200 μs)
+variance introduced by outliers: 81% (severely inflated)
+
+benchmarking Degree_Zero/1000_unsorted_graphFromConsecutiveKeys
+time                 462.8 μs   (448.7 μs .. 477.1 μs)
+                     0.991 R²   (0.987 R² .. 0.995 R²)
+mean                 465.5 μs   (452.6 μs .. 483.9 μs)
+std dev              52.15 μs   (38.75 μs .. 80.51 μs)
+variance introduced by outliers: 80% (severely inflated)
+
+benchmarking Degree_Zero/1000_unsorted_graphFromEdges
+time                 493.2 μs   (478.5 μs .. 506.9 μs)
+                     0.990 R²   (0.982 R² .. 0.995 R²)
+mean                 487.8 μs   (474.6 μs .. 506.2 μs)
+std dev              51.49 μs   (37.68 μs .. 79.08 μs)
+variance introduced by outliers: 79% (severely inflated)
+
 Benchmark graph-creation: FINISH

--- a/benchmarks/Graph.hs
+++ b/benchmarks/Graph.hs
@@ -1,0 +1,105 @@
+module Main where
+
+import Control.DeepSeq (force, NFData(..))
+import Control.Exception (evaluate)
+import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Data.Graph(graphFromEdges, graphFromConsecutiveKeys, graphFromConsecutiveAscKeys)
+import Data.Maybe(mapMaybe)
+import System.Random (mkStdGen)
+import System.Random.Shuffle(shuffle')
+
+-- | Governs the average node degree in the generated graph.
+-- Note that we cannot have cycles in the graph, else criterion's normal form
+-- evaluation of the graph will not terminate.
+data DegreeDistribution =
+    Zero -- every node has 0 neighbour.
+  | Constant -- every node hase up to a constant number of neighbours
+  | LinearInVertices -- every node has a count of neigbours that is (up to)
+                     -- proportional to the number of nodes.
+  deriving (Show)
+
+-- | Governs the order in wich nodes are passed to the function creating the graph.
+data ConsecutiveKeys =
+    AscendingConsecutive -- The keys are consecutive and ascending (e.g. [4,5,6,7] or [12,13])
+  | UnsortedConsecutive -- The keys are consecutive but unsorted (e.g [6,5,7,4] or [13,12])
+  deriving (Show)
+
+instance NFData DegreeDistribution where
+  rnf _ = ()
+
+-- |
+mkTests :: DegreeDistribution
+        -- ^ Specifies the average number of neighbours for every node.
+        -> Int
+        -- ^ Count of nodes in the graph
+        -> ConsecutiveKeys
+        -- ^ Specifies nodes ordering.
+        -> (String, [(Int,Int,[Int])])
+        -- ^ Returns the test name, and nodes.
+mkTests degree n keysType = (show n ++ "_" ++ keysName, map mkNode keys)
+ where
+  (keysName,keys) = case keysType of
+    AscendingConsecutive -> ("ascending", ascendingKeys)
+    UnsortedConsecutive -> ("unsorted", unsortedKeys)
+  gen = mkStdGen 1
+  ascendingKeys = [0..n-1] :: [Int]
+  unsortedKeys = shuffle' ascendingKeys n gen
+
+  mkNode k = (k, k, mapMaybe (mkNeighbour k) neighbourDistances)
+
+  neighbourDistances = case degree of
+    Zero -> []
+    Constant -> [1..2]
+    LinearInVertices -> [1..quot n 5]
+
+  mkNeighbour k distance
+    | neighbour < n = Just neighbour
+    | otherwise = Nothing
+    where
+      neighbour = k + distance
+
+main :: IO ()
+main = do
+  let nodeCounts =
+        [ 10
+        , 100
+        , 1000
+        ]
+      tests = map
+        (\degree -> (degree, map (mkTests degree) nodeCounts))
+        [ LinearInVertices
+        , Constant
+        , Zero
+        ]
+
+  _ <- evaluate $ force tests
+
+  -- The tests verifies that to create a graph from a list of nodes with consecutive keys,
+  -- graphFromConsecutiveKeys and graphFromConsecutiveAscKeys
+  -- outperform graphFromEdges.
+  --
+  -- Respective time complexities are:
+  --
+  -- graphFromEdges              :   O( (E+V) * log V )
+  -- graphFromConsecutiveKeys    :   O( E + (V*log V) )
+  -- graphFromConsecutiveAscKeys :   O( E + V )
+  --
+  -- The test also shows that the bigger the degree of the graph (see 'DegreeDistribution'),
+  -- the more pronounced the time difference is, which is to be expected given the complexities.
+  defaultMain $ map
+    (\(degree, testsForDegree) -> bgroup ("Degree_" ++ show degree) $ concatMap
+      (\mkKeys ->
+        let ascendingCompatible =
+              (graphFromConsecutiveAscKeys, "graphFromConsecutiveAscKeys") :
+              randomCompatible
+            randomCompatible =
+              [ (graphFromConsecutiveKeys, "graphFromConsecutiveKeys")
+              , (graphFromEdges, "graphFromEdges")
+              ]
+            mkBench nameKeys keys createGraph label =
+              bench (nameKeys ++ "_" ++ label) $ nf createGraph keys
+        in map (uncurry $ uncurry mkBench $ mkKeys AscendingConsecutive) ascendingCompatible ++
+           map (uncurry $ uncurry mkBench $ mkKeys UnsortedConsecutive) randomCompatible
+        )
+      testsForDegree)
+    tests

--- a/containers.cabal
+++ b/containers.cabal
@@ -95,6 +95,20 @@ Library
 -- B E N C H M A R K I N G --
 -----------------------------
 
+benchmark graph-creation
+  type: exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is: Graph.hs
+  ghc-options: -O2
+  build-depends:
+    base >= 4.6 && < 5,
+    containers,
+    criterion >= 0.4.0 && < 1.4,
+    deepseq >= 1.1.0.0 && < 1.5,
+    random < 1.2,
+    random-shuffle < 0.1,
+    transformers
+
 benchmark intmap-benchmarks
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -103,7 +117,7 @@ benchmark intmap-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark intset-benchmarks
@@ -114,7 +128,7 @@ benchmark intset-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark map-benchmarks
@@ -125,7 +139,7 @@ benchmark map-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5,
     transformers
 
@@ -137,7 +151,7 @@ benchmark sequence-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5,
     random < 1.2,
     transformers
@@ -150,7 +164,7 @@ benchmark set-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark set-operations-intmap
@@ -162,7 +176,7 @@ benchmark set-operations-intmap
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3
+    criterion >= 0.4.0 && < 1.4
 
 benchmark set-operations-intset
   type: exitcode-stdio-1.0
@@ -173,7 +187,7 @@ benchmark set-operations-intset
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3
+    criterion >= 0.4.0 && < 1.4
 
 benchmark set-operations-map
   type: exitcode-stdio-1.0
@@ -184,7 +198,7 @@ benchmark set-operations-map
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3
+    criterion >= 0.4.0 && < 1.4
 
 benchmark set-operations-set
   type: exitcode-stdio-1.0
@@ -195,7 +209,7 @@ benchmark set-operations-set
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3
+    criterion >= 0.4.0 && < 1.4
 
 benchmark lookupge-intmap
   type: exitcode-stdio-1.0
@@ -218,7 +232,7 @@ benchmark lookupge-intmap
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5,
     ghc-prim
 
@@ -247,9 +261,11 @@ benchmark lookupge-map
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.3,
+    criterion >= 0.4.0 && < 1.4,
     deepseq >= 1.1.0.0 && < 1.5,
     ghc-prim
+
+
 
 -------------------
 -- T E S T I N G --

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 
 ### Uncoment the resolver you want to use and re-run `stack build/test/bench`.
 # resolver: lts-10.0
-resolver: lts-9.20
+resolver: lts-11.1
 
 ### ChasingBottoms is only in Stackage snapshots lts-7.24 and below.
 extra-deps:


### PR DESCRIPTION
The motivation for this PR is the following: I am developping a game where world creation is automated using graphs based on random matrices: in the process I need to create a lot of graphs before finding a valid configuration, hence I'm trying to optimize graph creation time.

Profiling showed that `graphFromEdges` was one of the bottlenecks. This function has a time complexity of O((E+V) * log V) (E is number of edges, V number of vertices). But if the keys are known to be ascending and consecutive, we can change the implementation and make the complexity drop to O(V+E).

This is what I did in this PR, and I added benchmarks to confirm this (note that bench.txt will be removed before merging of course)

This PR adds 2 functions to the public API of Data.Graph : `graphFromConsecutiveAscKeys` and `graphFromConsecutiveKeys`.

One further API change I'd like to introduce is to make the constructor of `Graph` public, to optimize graph creation even further, improving on the constant factor this time. But it is not part of this PR.

If needed I can discuss this on the mailing list but I open this PR as a first step, waiting for instructions on how to proceed next.
