### PR TITLE
Add examples for foldTree

### DIFF
--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -313,6 +313,14 @@ levels t =
 --
 -- > foldTree (\x xs -> maximum (x:xs)) (Node 1 [Node 2 [], Node 3 []]) == 3
 --
+-- Count the number of leaves in the tree:
+--
+-- > foldTree (\_ xs -> if null xs then 1 else sum xs) (Node 1 [Node 2 [], Node 3 []]) == 2
+--
+-- Find depth of the tree; i.e. the number of branches from the root of the tree to the furthest leaf:
+--
+-- > foldTree (\_ xs -> if null xs then 0 else 1 + maximum xs) (Node 1 [Node 2[], Node 3 []]) == 1
+--
 --
 -- @since 0.5.8
 foldTree :: (a -> [b] -> b) -> Tree a -> b

--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -324,7 +324,6 @@ levels t =
 -- You can even implement traverse using foldTree:
 --
 -- > traverse' f = foldTree (\x xs -> liftA2 Node (f x) (sequenceA xs))
--- > fmap sum (traverse' Just (Node 1 [Node 2 [], Node 3[]])) == Just 6
 --
 --
 -- @since 0.5.8

--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -321,6 +321,11 @@ levels t =
 --
 -- > foldTree (\_ xs -> if null xs then 0 else 1 + maximum xs) (Node 1 [Node 2[], Node 3 []]) == 1
 --
+-- You can even implement traverse using foldTree:
+--
+-- > traverse' f = foldTree (\x xs -> liftA2 Node (f x) (sequenceA xs))
+-- > fmap sum (traverse' Just (Node 1 [Node 2 [], Node 3[]])) == Just 6
+--
 --
 -- @since 0.5.8
 foldTree :: (a -> [b] -> b) -> Tree a -> b


### PR DESCRIPTION
The two existing examples could also be implemented using the `Foldable` instance of `Tree`, although I realize that the `Foldable` `maximum` implementation is partial, while the example using `foldTree` is total.

The two additional examples are operations that, as far as I can tell, can't be implemented with `Foldable`, but only with the full catamorphism. This, hopefully, might be compelling examples.