### PR TITLE
Switch to using 'friendly' pygments style for docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'friendly'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
The 'sphinx' style changed to have a dull green background colour which is ugly
and more difficult to read. The 'friendly' style has a neutral background and is
nicer to look at (and looks like what the 'sphinx' style used to look like).