### PR TITLE
Replace criterion with gauge as the benchmark framework

### DIFF
--- a/benchmarks/IntMap.hs
+++ b/benchmarks/IntMap.hs
@@ -3,7 +3,7 @@ module Main where
 
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (bench, defaultMain, whnf)
+import Gauge (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.IntMap as M
 import qualified Data.IntMap.Strict as MS

--- a/benchmarks/IntSet.hs
+++ b/benchmarks/IntSet.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (bench, defaultMain, whnf)
+import Gauge (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.IntSet as S
 

--- a/benchmarks/LookupGE/IntMap.hs
+++ b/benchmarks/LookupGE/IntMap.hs
@@ -3,7 +3,7 @@ module Main where
 
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (bench, defaultMain, nf)
+import Gauge (bench, defaultMain, nf)
 import Data.List (foldl')
 import qualified Data.IntMap as M
 import qualified LookupGE_IntMap as M

--- a/benchmarks/LookupGE/Map.hs
+++ b/benchmarks/LookupGE/Map.hs
@@ -3,7 +3,7 @@ module Main where
 
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (defaultMain, bench, nf)
+import Gauge (defaultMain, bench, nf)
 import Data.List (foldl')
 import qualified Data.Map as M
 import qualified LookupGE_Map as M

--- a/benchmarks/Map.hs
+++ b/benchmarks/Map.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Applicative (Const(Const, getConst), pure)
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (bench, defaultMain, whnf, nf)
+import Gauge (bench, defaultMain, whnf, nf)
 import Data.Functor.Identity (Identity(..))
 import Data.List (foldl')
 import qualified Data.Map as M

--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -4,7 +4,7 @@ import Control.Applicative
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Control.Monad.Trans.State.Strict
-import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Gauge (bench, bgroup, defaultMain, nf)
 import Data.Foldable (foldl', foldr')
 import qualified Data.Sequence as S
 import qualified Data.Foldable

--- a/benchmarks/Set.hs
+++ b/benchmarks/Set.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
-import Criterion.Main (bench, defaultMain, whnf)
+import Gauge (bench, defaultMain, whnf)
 import Data.List (foldl')
 import qualified Data.Set as S
 

--- a/benchmarks/SetOperations/SetOperations.hs
+++ b/benchmarks/SetOperations/SetOperations.hs
@@ -2,7 +2,7 @@
 
 module SetOperations (benchmark) where
 
-import Criterion.Main (bench, defaultMain, whnf)
+import Gauge (bench, defaultMain, whnf)
 import Data.List (partition)
 
 benchmark :: ([Int] -> container) -> Bool -> [(String, container -> container -> container)] -> IO ()

--- a/containers.cabal
+++ b/containers.cabal
@@ -103,7 +103,7 @@ benchmark intmap-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark intset-benchmarks
@@ -114,7 +114,7 @@ benchmark intset-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark map-benchmarks
@@ -125,7 +125,7 @@ benchmark map-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5,
     transformers
 
@@ -137,7 +137,7 @@ benchmark sequence-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5,
     random < 1.2,
     transformers
@@ -150,7 +150,7 @@ benchmark set-benchmarks
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5
 
 benchmark set-operations-intmap
@@ -162,7 +162,7 @@ benchmark set-operations-intmap
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6
+    gauge >= 0.2.3 && < 0.3
 
 benchmark set-operations-intset
   type: exitcode-stdio-1.0
@@ -173,7 +173,7 @@ benchmark set-operations-intset
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6
+    gauge >= 0.2.3 && < 0.3
 
 benchmark set-operations-map
   type: exitcode-stdio-1.0
@@ -184,7 +184,7 @@ benchmark set-operations-map
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6
+    gauge >= 0.2.3 && < 0.3
 
 benchmark set-operations-set
   type: exitcode-stdio-1.0
@@ -195,7 +195,7 @@ benchmark set-operations-set
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6
+    gauge >= 0.2.3 && < 0.3
 
 benchmark lookupge-intmap
   type: exitcode-stdio-1.0
@@ -218,7 +218,7 @@ benchmark lookupge-intmap
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5,
     ghc-prim
 
@@ -247,7 +247,7 @@ benchmark lookupge-map
   build-depends:
     base >= 4.6 && < 5,
     containers,
-    criterion >= 0.4.0 && < 1.6,
+    gauge >= 0.2.3 && < 0.3,
     deepseq >= 1.1.0.0 && < 1.5,
     ghc-prim
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 
 ### Uncoment the resolver you want to use and re-run `stack build/test/bench`.
 # resolver: lts-10.0
-resolver: lts-9.20
+resolver: lts-12.13
 
 ### ChasingBottoms is only in Stackage snapshots lts-7.24 and below.
 extra-deps:


### PR DESCRIPTION
This removes the circular dependency on ~~criterion~~ containers in the benchmarks.

One consequence of this is that we can now simply use `cabal new-bench`
to run the benchmarks.