### PR TITLE
Remove unused imports.

### DIFF
--- a/Data/Graph.hs
+++ b/Data/Graph.hs
@@ -124,6 +124,8 @@ import qualified Data.Array as UA
 import Data.List
 #if MIN_VERSION_base(4,9,0)
 import Data.Functor.Classes
+#endif
+#if (!MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup (..))
 #endif
 #ifdef __GLASGOW_HASKELL__

--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -296,14 +296,22 @@ import Data.Traversable (Traversable(traverse))
 import Data.Word (Word)
 #endif
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+import Data.Semigroup (Semigroup(stimes))
+#endif
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup((<>)))
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (stimesIdempotentMonoid)
 import Data.Functor.Classes
 #endif
 
 import Control.DeepSeq (NFData(rnf))
 import Data.Bits
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
+#endif
 import Data.Maybe (fromMaybe)
 import Data.Typeable
 import Prelude hiding (lookup, map, filter, foldr, foldl, null)

--- a/Data/IntMap/Strict.hs
+++ b/Data/IntMap/Strict.hs
@@ -344,7 +344,9 @@ import Data.Functor((<$>))
 #endif
 import Control.Applicative (Applicative (..), liftA2)
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
+#endif
 
 {--------------------------------------------------------------------
   Query

--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -195,7 +195,13 @@ import Data.Monoid (Monoid(..))
 import Data.Word (Word)
 #endif
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+import Data.Semigroup (Semigroup(stimes))
+#endif
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup((<>)))
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (stimesIdempotentMonoid)
 #endif
 import Data.Typeable
 import Prelude hiding (filter, foldr, foldl, null, map)
@@ -217,7 +223,9 @@ import GHC.Prim (indexInt8OffAddr#)
 #endif
 
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
+#endif
 
 infixl 9 \\{-This comment teaches CPP correct behaviour -}
 

--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -372,13 +372,21 @@ import Data.Traversable (Traversable(traverse))
 #endif
 #if MIN_VERSION_base(4,9,0)
 import Data.Functor.Classes
-import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+import Data.Semigroup (stimesIdempotentMonoid)
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(stimes))
+#endif
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup((<>)))
 #endif
 import Control.Applicative (Const (..))
 import Control.DeepSeq (NFData(rnf))
 import Data.Bits (shiftL, shiftR)
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
+#endif
 import Data.Typeable
 import Prelude hiding (lookup, map, filter, foldr, foldl, null, splitAt, take, drop)
 

--- a/Data/Map/Strict/Internal.hs
+++ b/Data/Map/Strict/Internal.hs
@@ -422,7 +422,9 @@ import Data.Functor.Identity (Identity (..))
 #endif
 
 import qualified Data.Foldable as Foldable
+#if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
+#endif
 
 -- $strictness
 --

--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -236,7 +236,13 @@ import Data.Bits (shiftL, shiftR)
 import Data.Monoid (Monoid(..))
 #endif
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+import Data.Semigroup (Semigroup(stimes))
+#endif
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup((<>)))
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (stimesIdempotentMonoid)
 import Data.Functor.Classes
 #endif
 import qualified Data.Foldable as Foldable

--- a/Data/Tree.hs
+++ b/Data/Tree.hs
@@ -81,6 +81,8 @@ import Data.Coerce
 
 #if MIN_VERSION_base(4,9,0)
 import Data.Functor.Classes
+#endif
+#if (!MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup (..))
 #endif
 


### PR DESCRIPTION
Due to a bug in ghc, some unused imports do not yield warnings.
This commit will remove such unused imports in preparation for
the ghc bug fix (see https://ghc.haskell.org/trac/ghc/ticket/13064).