### PR TITLE
Update Internal.hs: Lambda formatting

### DIFF
--- a/Data/Map/Internal.hs
+++ b/Data/Map/Internal.hs
@@ -1899,8 +1899,8 @@ difference t1 (Bin _ k _ l2 r2) = case split k t1 of
 -- | /O(m*log(n\/m + 1)), m <= n/. Remove all keys in a 'Set' from a 'Map'.
 --
 -- @
--- m \`withoutKeys\` s = 'filterWithKey' (\k _ -> k ``Set.notMember`` s) m
--- m \`withoutKeys\` s = m ``difference`` 'fromSet' (const ()) s
+-- > m \`withoutKeys\` s = 'filterWithKey' (\ k _ -> k ``Set.notMember`` s) m
+-- > m \`withoutKeys\` s = m ``difference`` 'fromSet' (const ()) s
 -- @
 --
 -- @since 0.5.8
@@ -1981,8 +1981,8 @@ intersection t1@(Bin _ k x l1 r1) t2
 -- found in a 'Set'.
 --
 -- @
--- m \`restrictKeys\` s = 'filterWithKey' (\k _ -> k ``Set.member`` s) m
--- m \`restrictKeys\` s = m ``intersect`` 'fromSet' (const ()) s
+-- > m \`restrictKeys\` s = 'filterWithKey' (\ k _ -> k ``Set.member`` s) m
+-- > m \`restrictKeys\` s = m ``intersect`` 'fromSet' (const ()) s
 -- @
 --
 -- @since 0.5.8


### PR DESCRIPTION
Lambda not correctly formatted on hackage. (withoutKeys, restrictKeys)
> Possible fixes:
* space after lambda
* '-- >' at start of the line
* double backslash?