### PR TITLE
Update Data.Set.unions documentation

### DIFF
--- a/Data/Set/Internal.hs
+++ b/Data/Set/Internal.hs
@@ -706,7 +706,7 @@ deleteMax Tip             = Tip
 {--------------------------------------------------------------------
   Union.
 --------------------------------------------------------------------}
--- | The union of a list of sets: (@'unions' == 'foldl' 'union' 'empty'@).
+-- | The union of the sets in a Foldable structure : (@'unions' == 'foldl' 'union' 'empty'@).
 unions :: (Foldable f, Ord a) => f (Set a) -> Set a
 unions = Foldable.foldl' union empty
 #if __GLASGOW_HASKELL__


### PR DESCRIPTION
The previous documentation for Data.Set.unions said that you need a list of sets, 
but the type says that it can be any Foldable structure. `unions :: (Foldable f, Ord a) => f (Set a) -> Set a`.

Changed the wording to `The union of the sets in a Foldable structure`.
(Feel free to change the wording into something better, ofc)