### PR TITLE
Replace convoluted indexOfTheOnlyBit implementation with ctz# primop

### DIFF
--- a/Data/IntSet/Internal.hs
+++ b/Data/IntSet/Internal.hs
@@ -219,7 +219,9 @@ import GHC.Exts (Int(..), build)
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
 #endif
+#if !MIN_VERSION_base(4,8,0)
 import GHC.Prim (indexInt8OffAddr#)
+#endif
 #endif
 
 import qualified Data.Foldable as Foldable
@@ -1392,6 +1394,9 @@ foldr'Bits :: Int -> (Int -> a -> a) -> a -> Nat -> a
 
 indexOfTheOnlyBit :: Nat -> Int
 {-# INLINE indexOfTheOnlyBit #-}
+#if MIN_VERSION_base(4,8,0)
+indexOfTheOnlyBit = countTrailingZeros
+#else
 indexOfTheOnlyBit bitmask =
   I# (lsbArray `indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
   where unboxInt (I# i) = i
@@ -1403,6 +1408,7 @@ indexOfTheOnlyBit bitmask =
         magic = 0x07EDD5E59A4E28C2
         offset = 58
         !lsbArray = "\63\0\58\1\59\47\53\2\60\39\48\27\54\33\42\3\61\51\37\40\49\18\28\20\55\30\34\11\43\14\22\4\62\57\46\52\38\26\32\41\50\36\17\19\29\10\13\21\56\45\25\31\35\16\9\12\44\24\15\8\23\7\6\5"#
+#endif
 #endif
 -- The lsbArray gets inlined to every call site of indexOfTheOnlyBit.
 -- That cannot be easily avoided, as GHC forbids top-level Addr# literal.


### PR DESCRIPTION
Performance is the same or slightly better in microbenchmark. I
suspect it can perform better in the wild.

I was also interested in `revNat` but GHC doesn't expose an
appropriate primop, presumably because GCC doesn't. It could still be
faster on clang (`__builtin_bitreverse64` and friends).