### PR TITLE
Fix Foldable instance for IntMap (fixes #579)

### DIFF
--- a/Data/IntMap/Internal.hs
+++ b/Data/IntMap/Internal.hs
@@ -441,7 +441,9 @@ instance Foldable.Foldable IntMap where
   fold = go
     where go Nil = mempty
           go (Tip _ v) = v
-          go (Bin _ _ l r) = go l `mappend` go r
+          go (Bin _ m l r)
+            | m < 0     = go r `mappend` go l
+            | otherwise = go l `mappend` go r
   {-# INLINABLE fold #-}
   foldr = foldr
   {-# INLINE foldr #-}
@@ -450,7 +452,9 @@ instance Foldable.Foldable IntMap where
   foldMap f t = go t
     where go Nil = mempty
           go (Tip _ v) = f v
-          go (Bin _ _ l r) = go l `mappend` go r
+          go (Bin _ m l r)
+            | m < 0     = go r `mappend` go l
+            | otherwise = go l `mappend` go r
   {-# INLINE foldMap #-}
   foldl' = foldl'
   {-# INLINE foldl' #-}
@@ -2416,7 +2420,9 @@ traverseWithKey f = go
   where
     go Nil = pure Nil
     go (Tip k v) = Tip k <$> f k v
-    go (Bin p m l r) = liftA2 (Bin p m) (go l) (go r)
+    go (Bin p m l r)
+      | m < 0     = liftA2 (Bin p m) (go r) (go l)
+      | otherwise = liftA2 (Bin p m) (go l) (go r)
 {-# INLINE traverseWithKey #-}
 
 -- | /O(n)/. The function @'mapAccum'@ threads an accumulating
@@ -2875,7 +2881,9 @@ foldMapWithKey f = go
   where
     go Nil           = mempty
     go (Tip kx x)    = f kx x
-    go (Bin _ _ l r) = go l `mappend` go r
+    go (Bin _ m l r)
+      | m < 0     = go r `mappend` go l
+      | otherwise = go l `mappend` go r
 {-# INLINE foldMapWithKey #-}
 
 {--------------------------------------------------------------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
 
+## 0.6.0.2
+
+* Fix Foldable instance for IntMap, which previously placed positively
+  keyed entries before negatively keyed ones for `fold`, `foldMap`, and
+  `traverse`.
+
 ## 0.6.0.1
 
 * Released with GHC 8.6

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -28,6 +28,7 @@ import Test.Framework.Providers.QuickCheck2
 import Test.HUnit hiding (Test, Testable)
 import Test.QuickCheck
 import Test.QuickCheck.Function (Fun(..), apply)
+import Test.QuickCheck.Poly (A, B)
 
 default (Int)
 
@@ -1167,16 +1168,16 @@ prop_foldl' n ys = length ys > 0 ==>
       foldlWithKey' (\xs k x -> (k,x):xs) [] m == reverse (List.sort xs)
 
 prop_foldrEqFoldMap :: [(Int, String)] -> Property
-prop_foldrEqFoldMap ys = property $
+prop_foldrEqFoldMap ys =
   let m  = fromList ys
-  in  foldr (:) [] m == Data.Foldable.foldMap (:[]) m
+  in  foldr (:) [] m === Data.Foldable.foldMap (:[]) m
 
 prop_foldrWithKeyEqFoldMapWithKey :: [(Int, String)] -> Property
-prop_foldrWithKeyEqFoldMapWithKey ys = property $
+prop_foldrWithKeyEqFoldMapWithKey ys =
   let m  = fromList ys
-  in  foldrWithKey (\k v -> ((k,v):)) [] m == foldMapWithKey (\k v -> ([(k,v)])) m
+  in  foldrWithKey (\k v -> ((k,v):)) [] m === foldMapWithKey (\k v -> ([(k,v)])) m
 
-prop_FoldableTraversableCompat :: Fun String [Int] -> IntMap String -> Property
+prop_FoldableTraversableCompat :: Fun A [B] -> IntMap A -> Property
 prop_FoldableTraversableCompat fun m = foldMap f m === foldMapDefault f m
   where f = apply fun
 

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -8,6 +8,7 @@ import Data.IntMap.Lazy as Data.IntMap hiding (showTree)
 import Data.IntMap.Internal.Debug (showTree)
 import IntMapValidity (valid)
 
+import Control.Applicative (Applicative(..))
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -1174,22 +1174,19 @@ prop_foldl' n ys = length ys > 0 ==>
       foldlWithKey' (\b k _ -> k + b) n m == List.foldr (+) n (List.map fst xs) &&
       foldlWithKey' (\xs k x -> (k,x):xs) [] m == reverse (List.sort xs)
 
-prop_foldrEqFoldMap :: Int -> [(Int, String)] -> Property
-prop_foldrEqFoldMap n ys = length ys > 0 ==>
-  let xs = List.nubBy ((==) `on` fst) ys
-      m  = fromList xs
+prop_foldrEqFoldMap :: [(Int, String)] -> Property
+prop_foldrEqFoldMap ys = property $
+  let m  = fromList ys
   in  foldr (:) [] m == Data.Foldable.foldMap (:[]) m
 
-prop_foldrWithKeyEqFoldMapWithKey :: Int -> [(Int, String)] -> Property
-prop_foldrWithKeyEqFoldMapWithKey n ys = length ys > 0 ==>
-  let xs = List.nubBy ((==) `on` fst) ys
-      m  = fromList xs
+prop_foldrWithKeyEqFoldMapWithKey :: [(Int, String)] -> Property
+prop_foldrWithKeyEqFoldMapWithKey ys = property $
+  let m  = fromList ys
   in  foldrWithKey (\k v -> ((k,v):)) [] m == foldMapWithKey (\k v -> ([(k,v)])) m
 
-prop_traverseEqTraverse_ :: Int -> [(Int, String)] -> Property
-prop_traverseEqTraverse_ n ys = length ys > 0 ==>
-  let xs = List.nubBy ((==) `on` fst) ys
-      m  = fromList xs
+prop_traverseEqTraverse_ :: [(Int, String)] -> Property
+prop_traverseEqTraverse_ ys = property $
+  let m  = fromList ys
   in  getConsty (Data.Traversable.traverse (Consty . (:[])) m)
       == getConsty (Data.Foldable.traverse_ (Consty . (:[])) m)
 

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -12,7 +12,7 @@ import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
 import Data.Ord
-import qualified Data.Foldable (foldMap)
+import Data.Foldable (foldMap)
 import Data.Function
 import Data.Traversable (Traversable(traverse), foldMapDefault)
 import Prelude hiding (lookup, null, map, filter, foldr, foldl)

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -8,12 +8,11 @@ import Data.IntMap.Lazy as Data.IntMap hiding (showTree)
 import Data.IntMap.Internal.Debug (showTree)
 import IntMapValidity (valid)
 
-import Control.Applicative (Applicative(..))
 import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
 import Data.Ord
-import qualified Data.Foldable (foldMap, traverse_)
+import qualified Data.Foldable (foldMap)
 import Data.Function
 import Data.Traversable (Traversable(traverse), foldMapDefault)
 import Prelude hiding (lookup, null, map, filter, foldr, foldl)

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -1184,7 +1184,7 @@ prop_foldrWithKeyEqFoldMapWithKey :: Int -> [(Int, String)] -> Property
 prop_foldrWithKeyEqFoldMapWithKey n ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  foldrWithKey (\_ -> (:)) [] m == foldMapWithKey (\_ -> (:[])) m
+  in  foldrWithKey (\k v -> ((k,v):)) [] m == foldMapWithKey (\k v -> ([(k,v)])) m
 
 prop_traverseEqTraverse_ :: Int -> [(Int, String)] -> Property
 prop_traverseEqTraverse_ n ys = length ys > 0 ==>

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -13,8 +13,9 @@ import Data.Monoid
 import Data.Maybe hiding (mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
 import Data.Ord
-import qualified Data.Foldable as Foldable (traverse_)
+import qualified Data.Foldable (foldMap, traverse_)
 import Data.Function
+import Data.Traversable (Traversable(traverse))
 import Prelude hiding (lookup, null, map, filter, foldr, foldl)
 import qualified Prelude (map)
 
@@ -1177,7 +1178,7 @@ prop_foldrEqFoldMap :: Int -> [(Int, String)] -> Property
 prop_foldrEqFoldMap n ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  foldr (:) [] m == foldMap (:[]) m
+  in  foldr (:) [] m == Data.Foldable.foldMap (:[]) m
 
 prop_foldrWithKeyEqFoldMapWithKey :: Int -> [(Int, String)] -> Property
 prop_foldrWithKeyEqFoldMapWithKey n ys = length ys > 0 ==>
@@ -1189,8 +1190,8 @@ prop_traverseEqTraverse_ :: Int -> [(Int, String)] -> Property
 prop_traverseEqTraverse_ n ys = length ys > 0 ==>
   let xs = List.nubBy ((==) `on` fst) ys
       m  = fromList xs
-  in  getConsty (traverse (Consty . (:[])) m)
-      == getConsty (Foldable.traverse_ (Consty . (:[])) m)
+  in  getConsty (Data.Traversable.traverse (Consty . (:[])) m)
+      == getConsty (Data.Foldable.traverse_ (Consty . (:[])) m)
 
 prop_keysSet :: [(Int, Int)] -> Bool
 prop_keysSet xs =

--- a/tests/intmap-properties.hs
+++ b/tests/intmap-properties.hs
@@ -1167,15 +1167,13 @@ prop_foldl' n ys = length ys > 0 ==>
       foldlWithKey' (\b k _ -> k + b) n m == List.foldr (+) n (List.map fst xs) &&
       foldlWithKey' (\xs k x -> (k,x):xs) [] m == reverse (List.sort xs)
 
-prop_foldrEqFoldMap :: [(Int, String)] -> Property
-prop_foldrEqFoldMap ys =
-  let m  = fromList ys
-  in  foldr (:) [] m === Data.Foldable.foldMap (:[]) m
+prop_foldrEqFoldMap :: IntMap Int -> Property
+prop_foldrEqFoldMap m =
+  foldr (:) [] m === Data.Foldable.foldMap (:[]) m
 
-prop_foldrWithKeyEqFoldMapWithKey :: [(Int, String)] -> Property
-prop_foldrWithKeyEqFoldMapWithKey ys =
-  let m  = fromList ys
-  in  foldrWithKey (\k v -> ((k,v):)) [] m === foldMapWithKey (\k v -> ([(k,v)])) m
+prop_foldrWithKeyEqFoldMapWithKey :: IntMap Int -> Property
+prop_foldrWithKeyEqFoldMapWithKey m =
+  foldrWithKey (\k v -> ((k,v):)) [] m === foldMapWithKey (\k v -> ([(k,v)])) m
 
 prop_FoldableTraversableCompat :: Fun A [B] -> IntMap A -> Property
 prop_FoldableTraversableCompat fun m = foldMap f m === foldMapDefault f m


### PR DESCRIPTION
# Overview

As reported in https://github.com/haskell/containers/issues/579 the `Foldable` instance for `IntMap` is unlawful and internally inconsistent. This was caused as a result of the internal representation used by `IntMap`.

More specifically, `fold`, `foldMap`, and `traverse` (via `traverseWithKey`) always placed positively keyed entries before negative keyed ones. To fix this we need to check to see if the mask is positive or negative.

This fixes #579.

# Testing

Tested by adding new property tests, verifying they failed with the implementation at HEAD, and then passed after the changes. The property tests check that:

- `foldr (:) [] == foldMap (:[])`
- `foldrWithKey (\_ -> (:)) [] == foldMapWithKey (\_ -> (:[]))`
- `getConst (traverse (Const . (:[]))) == getConst (Foldable.traverse_ (Const . (:[])))`

/cc @mstksg