### PR TITLE
Speed up some Cartesian products

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
   keyed entries before negatively keyed ones for `fold`, `foldMap`, and
   `traverse`.
 
+* Improve the performance of `Data.Set.cartesianProduct` when the first
+  argument is much larger than the second.
+
 ## 0.6.0.1
 
 * Released with GHC 8.6


### PR DESCRIPTION
`Data.Set.cartesianProduct` was considerably slower when its first
argument was much larger than its second than it was in the opposite
situation. Hack around that to make it just as fast.