### PR TITLE
benchmarks comparer: Use `/usr/bin/env` to find perl

### DIFF
--- a/benchmarks/bench-cmp.pl
+++ b/benchmarks/bench-cmp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use warnings;
 use strict;
 


### PR DESCRIPTION
This is needed on NixOS. FHS does say if perl is installed it shoul be
found at `/usr/bin/perl`, so can't say this is more portable in general,
but doesn't hurt FHS systems either