### PR TITLE
Implement stimes for sequences

### DIFF
--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -891,6 +891,7 @@ instance Monoid (Seq a) where
 -- | @since 0.5.7
 instance Semigroup.Semigroup (Seq a) where
     (<>)    = (><)
+    stimes = cycleNTimes . fromIntegral
 #endif
 
 INSTANCE_TYPEABLE1(Seq)

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,13 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
 
-## 0.6.0.2
+## 0.6.0.2?
 
 * Fix Foldable instance for IntMap, which previously placed positively
   keyed entries before negatively keyed ones for `fold`, `foldMap`, and
   `traverse`.
+
+* Make `stimes` for sequences work with 0 arguments, and make it more
+  efficient.
 
 ## 0.6.0.1
 

--- a/tests/seq-properties.hs
+++ b/tests/seq-properties.hs
@@ -25,6 +25,9 @@ import Data.Functor ((<$>), (<$))
 import Data.Maybe
 import Data.Function (on)
 import Data.Monoid (Monoid(..), All(..), Endo(..), Dual(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (stimes, stimesMonoid)
+#endif
 import Data.Traversable (Traversable(traverse), sequenceA)
 import Prelude hiding (
   lookup, null, length, take, drop, splitAt,
@@ -151,6 +154,9 @@ main = defaultMain
        , testProperty "Left view constructor" prop_viewl_con
        , testProperty "Right view pattern" prop_viewr_pat
        , testProperty "Right view constructor" prop_viewr_con
+#endif
+#if MIN_VERSION_base(4,9,0)
+       , testProperty "stimes" prop_stimes
 #endif
        ]
 
@@ -877,6 +883,14 @@ prop_viewr_con xs x = xs :|> x === xs |> x
 prop_bind :: Seq A -> Fun A (Seq B) -> Bool
 prop_bind xs (Fun _ f) =
     toList' (xs >>= f) ~= (toList xs >>= toList . f)
+
+-- Semigroup operations
+
+#if MIN_VERSION_base(4,9,0)
+prop_stimes :: NonNegative Int -> Seq A -> Property
+prop_stimes (NonNegative n) s =
+  stimes n s === stimesMonoid n s
+#endif
 
 -- MonadFix operation
 


### PR DESCRIPTION
Implement `stimes` for sequences using `cycleNTimes`. This makes
it work when the argument is 0 (unlike the default). `cycleNTimes`
is faster and lazier than `stimesMonoid` because it takes advantage
of the finger tree structure of sequences.

Closes #618