### PR TITLE
Allowed inlining for traverseWithIndex

### DIFF
--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -2974,7 +2974,12 @@ traverseWithIndex f' (Seq xs') = Seq <$> traverseWithIndexTreeE (\s (Elem a) -> 
       !sPsab = sPsa + size b
 
 
+#ifdef __GLASGOW_HASKELL__
 {-# INLINABLE [1] traverseWithIndex #-}
+#else
+{-# INLINE [1] traverseWithIndex #-}
+#endif
+
 #ifdef __GLASGOW_HASKELL__
 {-# RULES
 "travWithIndex/mapWithIndex" forall f g xs . traverseWithIndex f (mapWithIndex g xs) =

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -2974,7 +2974,7 @@ traverseWithIndex f' (Seq xs') = Seq <$> traverseWithIndexTreeE (\s (Elem a) -> 
       !sPsab = sPsa + size b
 
 
-{-# INLINE [1] traverseWithIndex #-}
+{-# INLINABLE [1] traverseWithIndex #-}
 #ifdef __GLASGOW_HASKELL__
 {-# RULES
 "travWithIndex/mapWithIndex" forall f g xs . traverseWithIndex f (mapWithIndex g xs) =

--- a/Data/Sequence/Internal.hs
+++ b/Data/Sequence/Internal.hs
@@ -2974,7 +2974,7 @@ traverseWithIndex f' (Seq xs') = Seq <$> traverseWithIndexTreeE (\s (Elem a) -> 
       !sPsab = sPsa + size b
 
 
-{-# NOINLINE [1] traverseWithIndex #-}
+{-# INLINE [1] traverseWithIndex #-}
 #ifdef __GLASGOW_HASKELL__
 {-# RULES
 "travWithIndex/mapWithIndex" forall f g xs . traverseWithIndex f (mapWithIndex g xs) =

--- a/benchmarks/Sequence.hs
+++ b/benchmarks/Sequence.hs
@@ -90,6 +90,11 @@ main = do
          , bench "100" $ nf multiplyDown s100
          , bench "1000" $ nf multiplyDown s1000
          ]
+      , bgroup "sequenceA.mapWithIndex/State"
+         [ bench "10" $ nf multiplyDownMap s10
+         , bench "100" $ nf multiplyDownMap s100
+         , bench "1000" $ nf multiplyDownMap s1000
+         ]
       , bgroup "traverse/State"
          [ bench "10" $ nf multiplyUp s10
          , bench "100" $ nf multiplyUp s100
@@ -238,6 +243,13 @@ multiplyUp = flip evalState 0 . traverse go where
 
 multiplyDown :: S.Seq Int -> S.Seq Int
 multiplyDown = flip evalState 0 . S.traverseWithIndex go where
+  go i x = do
+    s <- get
+    put (s - 1)
+    return (s * i * x)
+
+multiplyDownMap :: S.Seq Int -> S.Seq Int
+multiplyDownMap = flip evalState 0 . sequenceA . S.mapWithIndex go where
   go i x = do
     s <- get
     put (s - 1)


### PR DESCRIPTION
Switched NOINLINE to INLINE:
- Ideally this would be INLINABLE, but that can't have phase controls
- This is the next best, which gets the proper performance benefits and also the phase controles so the rewrite rules still fire properly

Because this was prompted by `sequenceA.mapWithIndex` being faster  #603 , a benchamrk of that operation has been added to compare.

Old benchmarks:

```
benchmarking traverseWithIndex/State/10
time                 1.753 μs   (1.705 μs .. 1.841 μs)
                     0.986 R²   (0.969 R² .. 0.998 R²)
mean                 1.831 μs   (1.760 μs .. 1.998 μs)
std dev              338.5 ns   (141.6 ns .. 623.1 ns)
variance introduced by outliers: 96% (severely inflated)
                                 
benchmarking traverseWithIndex/State/100
time                 16.66 μs   (16.40 μs .. 17.00 μs)
                     0.992 R²   (0.986 R² .. 0.996 R²)
mean                 17.86 μs   (17.04 μs .. 19.51 μs)
std dev              3.499 μs   (2.232 μs .. 5.257 μs)
variance introduced by outliers: 96% (severely inflated)
                                 
benchmarking traverseWithIndex/State/1000
time                 320.0 μs   (295.3 μs .. 344.4 μs)
                     0.948 R²   (0.928 R² .. 0.966 R²)
mean                 305.1 μs   (285.2 μs .. 325.6 μs)
std dev              68.37 μs   (59.62 μs .. 80.02 μs)
variance introduced by outliers: 95% (severely inflated)
```

New:

```
benchmarking traverseWithIndex/State/10
time                 662.7 ns   (658.4 ns .. 666.6 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 659.9 ns   (656.6 ns .. 665.9 ns)
std dev              14.33 ns   (9.953 ns .. 21.46 ns)
variance introduced by outliers: 27% (moderately inflated)
                                   
benchmarking traverseWithIndex/State/100
time                 5.045 μs   (4.969 μs .. 5.139 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 5.144 μs   (5.059 μs .. 5.280 μs)
std dev              350.0 ns   (218.2 ns .. 530.1 ns)
variance introduced by outliers: 76% (severely inflated)
                                   
benchmarking traverseWithIndex/State/1000
time                 62.90 μs   (62.36 μs .. 63.68 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 63.04 μs   (62.65 μs .. 63.59 μs)
std dev              1.489 μs   (986.8 ns .. 2.024 μs)
variance introduced by outliers: 20% (moderately inflated)
                                   
benchmarking sequenceA.mapWithIndex/State/10
time                 580.4 ns   (571.5 ns .. 589.0 ns)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 574.7 ns   (569.8 ns .. 583.6 ns)
std dev              21.15 ns   (15.14 ns .. 30.62 ns)
variance introduced by outliers: 53% (severely inflated)
                                   
benchmarking sequenceA.mapWithIndex/State/100
time                 5.805 μs   (5.773 μs .. 5.844 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 5.864 μs   (5.821 μs .. 5.915 μs)
std dev              162.2 ns   (127.9 ns .. 199.7 ns)
variance introduced by outliers: 33% (moderately inflated)
                                   
benchmarking sequenceA.mapWithIndex/State/1000
time                 80.38 μs   (79.80 μs .. 81.27 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 80.93 μs   (80.40 μs .. 81.73 μs)
std dev              2.084 μs   (1.655 μs .. 2.590 μs)
variance introduced by outliers: 23% (moderately inflated)
```