### PR TITLE
Test with ghc-head too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,11 @@ matrix:
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.8.4","cabal-install-2.4"]}}
     - compiler: ghc-7.6.3
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.6.3","cabal-install-2.4"]}}
+    - compiler: ghc-head
+      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-head","cabal-install-head"]}}
+      env: GHCHEAD=true
+  allow_failures:
+    - compiler: ghc-head
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - HCPKG="$HC-pkg"
@@ -95,6 +100,18 @@ install:
     echo "  prefix: $CABALHOME"                         >> $CABALHOME/config
     echo "repository hackage.haskell.org"               >> $CABALHOME/config
     echo "  url: http://hackage.haskell.org/"           >> $CABALHOME/config
+  - |
+    if $GHCHEAD; then
+    echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABALHOME/config
+    
+    echo "repository head.hackage"                                                        >> $CABALHOME/config
+    echo "   url: http://head.hackage.haskell.org/"                                       >> $CABALHOME/config
+    echo "   secure: True"                                                                >> $CABALHOME/config
+    echo "   root-keys: 07c59cb65787dedfaef5bd5f987ceb5f7e5ebf88b904bbd4c5cbdeb2ff71b740" >> $CABALHOME/config
+    echo "              2e8555dde16ebd8df076f1a8ef13b8f14c66bad8eafefd7d9e37d0ed711821fb" >> $CABALHOME/config
+    echo "              8f79fd2389ab2967354407ec852cbe73f2e8635793ac446d09461ffb99527f6e" >> $CABALHOME/config
+    echo "   key-threshold: 3"                                                            >> $CABALHOME/config
+    fi
   - cat $CABALHOME/config
   - rm -fv cabal.project cabal.project.local cabal.project.freeze
   - travis_retry ${CABAL} v2-update -v


### PR DESCRIPTION
The `.travis.yml` isn't meant to be edited by hand anymore.

If you install `haskell-ci` (from the repository), you can

```
haskell-ci --help
```

to see all the options and

```
haskell-ci regenerate --ghc-head
```

to e.g. add some more.

Alternatively you can look for `REGENDATA` in the `.travis.yml` and hand edit it.

---

This PR does exactly what I described, i.e. `haskell-ci regenerate --ghc-head`.