### PR TITLE
Sequence <*

### DIFF
--- a/containers-tests/benchmarks/Sequence.hs
+++ b/containers-tests/benchmarks/Sequence.hs
@@ -142,6 +142,9 @@ main = do
         [ bench "10/10" $ nf (uncurry (<*)) (s10,s10)
         , bench "1000/10" $ nf (uncurry (<*)) (s1000,s10)
         , bench "10/1000" $ nf (uncurry (<*)) (s10,s1000)
+        , bench "10000/10" $ nf (uncurry (<*)) (s10000,s10)
+        , bench "10/10000" $ nf (uncurry (<*)) (s10,s10000)
+        , bench "1000/1000" $ nf (uncurry (<*)) (s1000,s1000)
         ]
       , bgroup "sort"
          [ bgroup "already sorted"

--- a/containers-tests/benchmarks/Sequence.hs
+++ b/containers-tests/benchmarks/Sequence.hs
@@ -138,6 +138,11 @@ main = do
          , bench "nf2500/100/ff" $
               nf (\(s,t) -> (,) <$> S.fromFunction s (+1) <*> S.fromFunction t (*2)) (2500,100)
          ]
+      , bgroup "<*"
+        [ bench "10/10" $ nf (uncurry (<*)) (s10,s10)
+        , bench "1000/10" $ nf (uncurry (<*)) (s1000,s10)
+        , bench "10/1000" $ nf (uncurry (<*)) (s10,s1000)
+        ]
       , bgroup "sort"
          [ bgroup "already sorted"
             [ bench "10" $ nf S.sort s10

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -143,6 +143,7 @@ main = defaultMain
        , testProperty "<*> NOINLINE" prop_ap_NOINLINE
        , testProperty "liftA2" prop_liftA2
        , testProperty "*>" prop_then
+       , testProperty "<*" prop_after
        , testProperty "cycleTaking" prop_cycleTaking
        , testProperty "intersperse" prop_intersperse
        , testProperty ">>=" prop_bind
@@ -842,6 +843,10 @@ prop_liftA2 xs ys = valid q .&&.
 prop_then :: Seq A -> Seq B -> Bool
 prop_then xs ys =
     toList' (xs *> ys) ~= (toList xs *> toList ys)
+
+prop_after :: Seq A -> Seq B -> Bool
+prop_after xs ys =
+    toList' (xs <* ys) ~= (toList xs <* toList ys)
 
 prop_intersperse :: A -> Seq A -> Bool
 prop_intersperse x xs =

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -511,6 +511,9 @@ instance Applicative Seq where
     pure = singleton
     xs *> ys = cycleNTimes (length xs) ys
     (<*>) = apSeq
+    xs <* ys = xs >>= replicate n
+      where
+        !n = length ys
 #if MIN_VERSION_base(4,10,0)
     liftA2 = liftA2Seq
 #endif


### PR DESCRIPTION
This addresses #314 

I tried playing around with the `aptyMiddle` functions and so on, but I realised that the only difference between `<*` and `*>` was the order of the output. i.e.:

```haskell
[(),()] *> [1,2,3] = [1,2,3,1,2,3]
[1,2,3] <* [(),()] = [1,1,2,2,3,3]
```

Which is achieved with:

```haskell
xs <* ys = xs >>= replicate (length ys)
```

I think this also has the desired performance (m <* n => |m| log |n|), and the benchmarks seem to agree. 

```
old                                                           | new
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/10/10                                          | benchmarked <*/10/10
--------------------------------------------------------------|---------------------------------------------------------
time                 3.512 μs   (3.470 μs .. 3.556 μs)        | time                 1.505 μs   (1.492 μs .. 1.520 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)        |                      0.999 R²   (0.998 R² .. 1.000 R²)
mean                 3.517 μs   (3.499 μs .. 3.539 μs)        | mean                 1.495 μs   (1.487 μs .. 1.506 μs)
std dev              65.86 ns   (46.98 ns .. 91.42 ns)        | std dev              29.48 ns   (22.87 ns .. 41.57 ns)
                                                              |
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/1000/10                                        | benchmarked <*/1000/10
--------------------------------------------------------------|---------------------------------------------------------
time                 346.2 μs   (343.7 μs .. 349.5 μs)        | time                 220.1 μs   (217.4 μs .. 223.4 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)        |                      0.999 R²   (0.998 R² .. 0.999 R²)
mean                 345.5 μs   (344.0 μs .. 348.0 μs)        | mean                 218.3 μs   (217.1 μs .. 219.9 μs)
std dev              6.302 μs   (4.375 μs .. 10.57 μs)        | std dev              4.475 μs   (3.716 μs .. 6.444 μs)
                                                              |
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/10/1000                                        | benchmarked <*/10/1000
--------------------------------------------------------------|---------------------------------------------------------
time                 289.8 μs   (287.7 μs .. 292.0 μs)        | time                 56.68 μs   (56.06 μs .. 57.37 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)        |                      0.999 R²   (0.998 R² .. 1.000 R²)
mean                 291.9 μs   (290.5 μs .. 294.2 μs)        | mean                 56.75 μs   (56.46 μs .. 57.23 μs)
std dev              6.123 μs   (3.239 μs .. 10.19 μs)        | std dev              1.173 μs   (899.7 ns .. 1.717 μs)
                                                              |
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/10000/10                                       | benchmarked <*/10000/10
--------------------------------------------------------------|---------------------------------------------------------
time                 5.282 ms   (5.232 ms .. 5.337 ms)        | time                 4.713 ms   (4.504 ms .. 4.972 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)        |                      0.992 R²   (0.987 R² .. 0.999 R²)
mean                 5.206 ms   (5.172 ms .. 5.241 ms)        | mean                 4.611 ms   (4.556 ms .. 4.734 ms)
std dev              105.9 μs   (85.13 μs .. 129.0 μs)        | std dev              238.6 μs   (135.6 μs .. 412.8 μs)
                                                              | variance introduced by outliers: 28% (moderately inflated) |
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/10/10000                                       | benchmarked <*/10/10000
--------------------------------------------------------------|---------------------------------------------------------
time                 3.925 ms   (3.857 ms .. 4.042 ms)        | time                 499.2 μs   (489.4 μs .. 508.2 μs)     
                     0.996 R²   (0.991 R² .. 1.000 R²)        |                      0.999 R²   (0.998 R² .. 1.000 R²)     
mean                 3.917 ms   (3.889 ms .. 3.969 ms)        | mean                 491.1 μs   (489.0 μs .. 493.8 μs)     
std dev              117.9 μs   (71.25 μs .. 172.3 μs)        | std dev              7.816 μs   (6.100 μs .. 12.11 μs)     
variance introduced by outliers: 12% (moderately inflated)    |                                                           
--------------------------------------------------------------|---------------------------------------------------------
benchmarked <*/1000/1000                                      | benchmarked <*/1000/1000
--------------------------------------------------------------|---------------------------------------------------------
time                 47.89 ms   (47.61 ms .. 48.14 ms)        | time                 5.932 ms   (5.819 ms .. 6.059 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)        |                     0.997 R²   (0.994 R² .. 0.999 R²)
mean                 48.33 ms   (48.09 ms .. 48.83 ms)        | mean                 5.956 ms   (5.899 ms .. 6.057 ms)
std dev              651.2 μs   (361.5 μs .. 1.072 ms)        | std dev              221.5 μs   (135.3 μs .. 360.0 μs)
                                                              | variance introduced by outliers: 17% (moderately inflated)  
```