### PR TITLE
reverse topological ordering

### DIFF
--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -67,7 +67,7 @@ module Data.Graph (
     , dfs
     , dff
     , topSort
-    , revTopSort
+    , reverseTopSort
     , components
     , scc
     , bcc
@@ -619,8 +619,8 @@ topSort      :: Graph -> [Vertex]
 topSort       = reverse . postOrd
 
 -- | Reverse ordering of `topSort`.
-revTopSort      :: Graph -> [Vertex]
-revTopSort       = postOrd
+reverseTopSort :: Graph -> [Vertex]
+reverseTopSort = postOrd
 
 ------------------------------------------------------------
 -- Algorithm 3: connected components

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -67,6 +67,7 @@ module Data.Graph (
     , dfs
     , dff
     , topSort
+    , revTopSort
     , components
     , scc
     , bcc
@@ -616,6 +617,10 @@ postOrd g = postorderF (dff g) []
 -- precedes /j/ whenever /j/ is reachable from /i/ but not vice versa.
 topSort      :: Graph -> [Vertex]
 topSort       = reverse . postOrd
+
+-- | Reverse ordering of `topSort`.
+revTopSort      :: Graph -> [Vertex]
+revTopSort       = postOrd
 
 ------------------------------------------------------------
 -- Algorithm 3: connected components


### PR DESCRIPTION
I needed the reverse topological ordering of a graph, so I exposed `revTopSort`. I'm not sure if GHC optimizes away `reverse . reverse` or not. 