### PR TITLE
BitUtil: Fix unused imports

### DIFF
--- a/containers/src/Utils/Containers/Internal/BitUtil.hs
+++ b/containers/src/Utils/Containers/Internal/BitUtil.hs
@@ -38,7 +38,9 @@ module Utils.Containers.Internal.BitUtil
     , wordSize
     ) where
 
+#if !MIN_VERSION_base(4,8,0)
 import Data.Bits ((.|.), xor)
+#endif
 import Data.Bits (popCount, unsafeShiftL, unsafeShiftR
 #if MIN_VERSION_base(4,8,0)
     , countLeadingZeros


### PR DESCRIPTION
GHC requires that boot packages are `-Wall` clean. This fixes an unused import warning and enables `-Werror` to ensure that this doesn't regress again.