### PR TITLE
fix documentation of isProperSubmapOfBy

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -2309,7 +2309,7 @@ isProperSubmapOf m1 m2
 
 {- | /O(n+m)/. Is this a proper submap? (ie. a submap but not equal).
  The expression (@'isProperSubmapOfBy' f m1 m2@) returns 'True' when
- @m1@ and @m2@ are not equal,
+ @keys m1@ and @keys m2@ are not equal,
  all keys in @m1@ are in @m2@, and when @f@ returns 'True' when
  applied to their respective values. For example, the following
  expressions are all 'True':

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2830,7 +2830,7 @@ isProperSubmapOf m1 m2
 
 {- | /O(m*log(n\/m + 1)), m <= n/. Is this a proper submap? (ie. a submap but not equal).
  The expression (@'isProperSubmapOfBy' f m1 m2@) returns 'True' when
- @m1@ and @m2@ are not equal,
+ @keys m1@ and @keys m2@ are not equal,
  all keys in @m1@ are in @m2@, and when @f@ returns 'True' when
  applied to their respective values. For example, the following
  expressions are all 'True':


### PR DESCRIPTION
The `isProperSubmapOfBy` function takes two maps with different contained value types. Its documentation specifies its behavior in terms of whether the two maps are equal, which is clearly not doable in Haskell. I think it should be specified in terms of whether the two maps have the same keys or not instead.

This tiny commit makes that documentation change.