### PR TITLE
make test Makefiles more robust

### DIFF
--- a/containers-tests/benchmarks/Makefile
+++ b/containers-tests/benchmarks/Makefile
@@ -1,7 +1,7 @@
 all:
 
 bench-%: %.hs force
-	ghc -O2 -DTESTING $< -I$(TOP)../include -i$(TOP).. -o $@ -outputdir tmp -rtsopts
+	ghc -O2 -DTESTING $< -I$(TOP)../include -i$(TOP).. -o $@ -outputdir tmp/$@ -rtsopts
 
 .PRECIOUS: bench-%
 

--- a/containers-tests/tests/Makefile
+++ b/containers-tests/tests/Makefile
@@ -8,10 +8,10 @@
 all:
 
 %-properties: %-properties.hs force
-	ghc -I../include -O2 -DTESTING $< -i.. -o $@ -outputdir tmp
+	ghc -I../include -O2 -DTESTING $< -i.. -o $@ -outputdir tmp/$@
 
 %-strict-properties: %-properties.hs force
-	ghc -I../include -O2 -DTESTING -DSTRICT $< -o $@ -i.. -outputdir tmp
+	ghc -I../include -O2 -DTESTING -DSTRICT $< -o $@ -i.. -outputdir tmp/$@
 
 .PHONY: force clean
 force:


### PR DESCRIPTION
The `Makefile` for tests uses the same `outputdir` value for all
targets. This interacts badly with ghc's recompilation check:

```
> make bench-IntMap bench-IntSet
ghc -O2 -DTESTING IntMap.hs -I../include -i.. -o bench-IntMap -outputdir tmp -rtsopts
[1 of 1] Compiling Main             ( IntMap.hs, tmp/Main.o )
Linking bench-IntMap ...
ghc -O2 -DTESTING IntSet.hs -I../include -i.. -o bench-IntSet -outputdir tmp -rtsopts
Linking bench-IntSet ...
> ./bench-IntSet --small lookup
lookup                                   mean 218.5 μs  ( +- 1.470 μs  )
> make clean; make bench-IntSet
[...]
> ./bench-IntSet --small lookup
Error: none of the specified names matches a benchmark
Run "bench-IntSet --help" for usage information
> ghc --version
The Glorious Glasgow Haskell Compilation System, version 8.6.5
```

To avoid this problem, use individual output directories for each
program.