### PR TITLE
add fromList tests

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -460,14 +460,19 @@ test-suite map-strictness-properties
     , base                        >=4.6     && <5
     , ChasingBottoms
     , deepseq                     >=1.2     && <1.5
+    , HUnit
     , QuickCheck                  >=2.7.1
     , test-framework              >=0.3.3
     , test-framework-quickcheck2  >=0.2.9
+    , test-framework-hunit
 
   ghc-options:      -Wall
   other-extensions:
     BangPatterns
     CPP
+
+  other-modules:
+    Utils.IsUnit
 
 test-suite intmap-strictness-properties
   default-language: Haskell2010
@@ -484,11 +489,16 @@ test-suite intmap-strictness-properties
     , base                        >=4.6     && <5
     , ChasingBottoms
     , deepseq                     >=1.2     && <1.5
+    , HUnit
     , QuickCheck                  >=2.7.1
     , test-framework              >=0.3.3
     , test-framework-quickcheck2  >=0.2.9
+    , test-framework-hunit
 
   ghc-options:      -Wall
+
+  other-modules:
+    Utils.IsUnit
 
 test-suite intset-strictness-properties
   default-language: Haskell2010

--- a/containers-tests/tests/Utils/IsUnit.hs
+++ b/containers-tests/tests/Utils/IsUnit.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE MagicHash #-}
+#endif
+
+module Utils.IsUnit (isUnit, isUnitSupported) where
+
+#ifdef __GLASGOW_HASKELL__
+import GHC.Exts
+#endif
+
+-- | Check whether the argument is a fully evaluated unit `()`.
+--
+-- Always returns `False` is `isUnitSupported` returns `False`.
+--
+-- Uses `reallyUnsafePtrEquality#`.
+isUnit :: () -> Bool
+
+-- | Checks whether `isUnit` is supported by the Haskell implementation.
+--
+-- Currently returns `True` for ghc and `False` for all other implementations.
+isUnitSupported :: Bool
+
+#ifdef __GLASGOW_HASKELL__
+
+-- simplified from  Utils.Containers.Internal.PtrEquality
+ptrEq :: a -> a -> Bool
+ptrEq x y = case reallyUnsafePtrEquality# x y of
+    0# -> False
+    _  -> True
+
+isUnit = ptrEq ()
+
+isUnitSupported = True
+
+#else /* !__GLASGOW_HASKELL__ */
+
+isUnit = False
+
+isUnitSupported = False
+
+#endif

--- a/containers-tests/tests/intmap-strictness.hs
+++ b/containers-tests/tests/intmap-strictness.hs
@@ -3,15 +3,19 @@
 module Main (main) where
 
 import Test.ChasingBottoms.IsBottom
-import Test.Framework (Test, defaultMain, testGroup)
+import Test.Framework (Test, TestName, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck (Arbitrary(arbitrary))
 import Test.QuickCheck.Function (Fun(..), apply)
+import Test.Framework.Providers.HUnit
+import Test.HUnit hiding (Test)
 
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Data.IntMap as L
 import Data.Containers.ListUtils
+
+import Utils.IsUnit
 
 instance Arbitrary v => Arbitrary (IntMap v) where
     arbitrary = M.fromList `fmap` arbitrary
@@ -98,6 +102,60 @@ pFromAscListStrict ks
     elems = [(k, v) | k <- nubInt ks, v <- [undefined, undefined, ()]]
 
 ------------------------------------------------------------------------
+-- check for extra thunks
+--
+-- These tests distinguish between `()`, a fully evaluated value, and
+-- things like `id ()` which are extra thunks that should be avoided
+-- in most cases. An exception is `L.fromListWith const`, which cannot
+-- evaluate the `const` calls.
+
+tExtraThunksM :: Test
+tExtraThunksM = testGroup "IntMap.Strict - extra thunks" $
+    if not isUnitSupported then [] else
+    -- for strict maps, all the values should be evaluated to ()
+    [ check "singleton"           $ m0
+    , check "insert"              $ M.insert 42 () m0
+    , check "insertWith"          $ M.insertWith const 42 () m0
+    , check "fromList"            $ M.fromList [(42,()),(42,())]
+    , check "fromListWith"        $ M.fromListWith const [(42,()),(42,())]
+    , check "fromAscList"         $ M.fromAscList [(42,()),(42,())]
+    , check "fromAscListWith"     $ M.fromAscListWith const [(42,()),(42,())]
+    , check "fromDistinctAscList" $ M.fromAscList [(42,())]
+    ]
+  where
+    m0 = M.singleton 42 ()
+    check :: TestName -> IntMap () -> Test
+    check n m = testCase n $ case M.lookup 42 m of
+        Just v -> assertBool msg (isUnit v)
+        _      -> assertString "key not found"
+      where
+        msg = "too lazy -- expected fully evaluated ()"
+
+tExtraThunksL :: Test
+tExtraThunksL = testGroup "IntMap.Strict - extra thunks" $
+    if not isUnitSupported then [] else
+    -- for lazy maps, the *With functions should leave `const () ()` thunks,
+    -- but the other functions should produce fully evaluated ().
+    [ check "singleton"       True  $ m0
+    , check "insert"          True  $ L.insert 42 () m0
+    , check "insertWith"      False $ L.insertWith const 42 () m0
+    , check "fromList"        True  $ L.fromList [(42,()),(42,())]
+    , check "fromListWith"    False $ L.fromListWith const [(42,()),(42,())]
+    , check "fromAscList"     True  $ L.fromAscList [(42,()),(42,())]
+    , check "fromAscListWith" False $ L.fromAscListWith const [(42,()),(42,())]
+    , check "fromDistinctAscList" True $ L.fromAscList [(42,())]
+    ]
+  where
+    m0 = L.singleton 42 ()
+    check :: TestName -> Bool -> IntMap () -> Test
+    check n e m = testCase n $ case L.lookup 42 m of
+        Just v -> assertBool msg (e == isUnit v)
+        _      -> assertString "key not found"
+      where
+        msg | e         = "too lazy -- expected fully evaluated ()"
+            | otherwise = "too strict -- expected a thunk"
+
+------------------------------------------------------------------------
 -- * Test list
 
 tests :: [Test]
@@ -127,6 +185,8 @@ tests =
       , testProperty "fromAscList is somewhat value-lazy" pFromAscListLazy
       , testProperty "fromAscList is somewhat value-strict" pFromAscListStrict
       ]
+      , tExtraThunksM
+      , tExtraThunksL
     ]
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
This is adding some test cases that were previously part of #658.

Note that one test is currently failing because `Data.IntMap.fromAscList` is a bit lazier than expected.