### PR TITLE
Add Data.IntSet.mapMonotonic.

### DIFF
--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -337,6 +337,11 @@ prop_foldL' s = foldl' (flip (:)) [] s == List.foldl' (flip (:)) [] (toList s)
 prop_map :: IntSet -> Bool
 prop_map s = map id s == s
 
+prop_mapMonotonic :: (Key -> Key) -> IntSet -> Property
+prop_mapMonotonic f s =
+  (\x y -> x < y ==> f x < f y) .&&.
+  (mapMonotonic f s == map f s)
+
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of
     Nothing -> null s

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -340,7 +340,7 @@ prop_map s = map id s == s
 prop_mapMonotonic :: (Key -> Key) -> IntSet -> Property
 prop_mapMonotonic f s =
   (\x y -> x < y ==> f x < f y) .&&.
-  (mapMonotonic f s == map f s)
+  mapMonotonic f s == map f s
 
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -337,10 +337,20 @@ prop_foldL' s = foldl' (flip (:)) [] s == List.foldl' (flip (:)) [] (toList s)
 prop_map :: IntSet -> Bool
 prop_map s = map id s == s
 
-prop_mapMonotonic :: (Key -> Key) -> IntSet -> Property
-prop_mapMonotonic f s =
-  (\x y -> x < y ==> f x < f y) .&&.
-  mapMonotonic f s === map f s
+-- Note: we could generate an arbitrary strictly monotonic function by
+-- restricting f using @\x y -> x < y ==> f x < f y@
+-- but this will be inefficient given the probability of actually finding
+-- a function that meets the criteria.
+-- For now we settle on identity function and arbitrary linear functions
+-- f x = a*x + b (with a being positive).
+-- This might be insufficient to support any fancier implementation.
+prop_mapMonotonicId :: IntSet -> Property
+prop_mapMonotonicId s = mapMonotonic id s === map id s
+
+prop_mapMonotonicLinear :: Positive Int -> Int -> IntSet -> Property
+prop_mapMonotonicLinear (Positive a) b s = mapMonotonic f s === map f s
+  where
+    f x = a*x + b
 
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -340,7 +340,7 @@ prop_map s = map id s == s
 prop_mapMonotonic :: (Key -> Key) -> IntSet -> Property
 prop_mapMonotonic f s =
   (\x y -> x < y ==> f x < f y) .&&.
-  mapMonotonic f s == map f s
+  mapMonotonic f s === map f s
 
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -115,6 +115,7 @@ module Data.IntSet (
 
             -- * Map
             , IS.map
+            , mapMonotonic
 
             -- * Folds
             , IS.foldr

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -921,6 +921,8 @@ map f = fromList . List.map f . toList
 -- > and [x < y ==> f x < f y | x <- ls, y <- ls]
 -- >                     ==> mapMonotonic f s == map f s
 -- >     where ls = toList s
+
+-- Note that for now the test is insufficient to support any fancier implementation.
 mapMonotonic :: (Key -> Key) -> IntSet -> IntSet
 mapMonotonic f = fromDistinctAscList . List.map f . toAscList
 

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -141,6 +141,7 @@ module Data.IntSet.Internal (
 
     -- * Map
     , map
+    , mapMonotonic
 
     -- * Folds
     , foldr
@@ -910,6 +911,19 @@ deleteMax = maybe Nil snd . maxView
 
 map :: (Key -> Key) -> IntSet -> IntSet
 map f = fromList . List.map f . toList
+
+-- | /O(n)/. The
+--
+-- @'mapMonotonic' f s == 'map' f s@, but works only when @f@ is strictly increasing.
+-- /The precondition is not checked./
+-- Semi-formally, we have:
+--
+-- > and [x < y ==> f x < f y | x <- ls, y <- ls]
+-- >                     ==> mapMonotonic f s == map f s
+-- >     where ls = toList s
+mapMonotonic :: (Key -> Key) -> IntSet -> IntSet
+mapMonotonic f = fromDistinctAscList . List.map f . toAscList
+
 
 {--------------------------------------------------------------------
   Fold


### PR DESCRIPTION
This patch fills in the missing piece for Data.IntSet, since Data.{Map,IntMap} and Data.Set all have this function. (for Map variant it's `mapKeysMonotonic`)