### PR TITLE
Disable building the containers package in stack.yaml and cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages:
-  containers/
+--   containers/
   containers-tests/
 
 tests: True

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 flags: {}
 packages:
-- containers
+# - containers  # Unnecessary for development. Uncomment to produce an sdist or similar.
 - containers-tests
 
 ### Uncoment the resolver you want to use and re-run `stack build/test/bench`.


### PR DESCRIPTION
This is a more sensible setting for development.

Fixes https://github.com/haskell/containers/issues/671.