### PR TITLE
Remove INLINE pragma on foldToMaybeTree

### DIFF
--- a/containers/src/Data/Sequence/Internal/Sorting.hs
+++ b/containers/src/Data/Sequence/Internal/Sorting.hs
@@ -394,7 +394,6 @@ foldToMaybeTree (<+>) f (Deep _ pr m sf) =
     pr' = foldDigit (<+>) f pr
     sf' = foldDigit (<+>) f sf
     m' = foldToMaybeTree (<+>) (foldNode (<+>) f) m
-{-# INLINE foldToMaybeTree #-}
 
 -- | A 'Data.Sequence.foldMapWithIndex'-like function, specialized to the
 -- 'Data.Semigroup.Option' monoid, which takes advantage of the


### PR DESCRIPTION
The function is self-recursive and not overloaded, therefore I see no reason for the pragma. 

Core lint warns - 

```
*** Core Lint warnings : in result of Simplifier ***
libraries/containers/containers/src/Data/Sequence/Internal/Sorting.hs:389:1: warning:
    [RHS of foldToMaybeTree :: forall b a.
                               (b -> b -> b) -> (a -> b) -> FingerTree a -> Maybe b]
    INLINE binder is (non-rule) loop breaker: foldToMaybeTree
```