### PR TITLE
Fix 32-bit build

### DIFF
--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -219,10 +219,8 @@ import Text.Read
 
 #if __GLASGOW_HASKELL__
 import GHC.Exts (build)
-#if !MIN_VERSION_base(4,8,0)
+#if !MIN_VERSION_base(4,8,0) || (WORD_SIZE_IN_BITS!=64)
 import GHC.Exts (Int(..), indexInt8OffAddr#)
-#elif WORD_SIZE_IN_BITS!=64
-import GHC.Exts (Int(..))
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -221,6 +221,8 @@ import Text.Read
 import GHC.Exts (build)
 #if !MIN_VERSION_base(4,8,0)
 import GHC.Exts (Int(..), indexInt8OffAddr#)
+#elif WORD_SIZE_IN_BITS!=64
+import GHC.Exts (Int(..))
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -218,7 +218,7 @@ import Text.Read
 #endif
 
 #if __GLASGOW_HASKELL__
-import qualified GHC.Exts as GHCExts
+import qualified GHC.Exts
 #endif
 
 import qualified Data.Foldable as Foldable
@@ -1013,7 +1013,7 @@ elems
 --------------------------------------------------------------------}
 #if __GLASGOW_HASKELL__ >= 708
 -- | @since 0.5.6.2
-instance GHCExts.IsList IntSet where
+instance GHC.Exts.IsList IntSet where
   type Item IntSet = Key
   fromList = fromList
   toList   = toList
@@ -1057,9 +1057,9 @@ foldlFB = foldl
 -- before phase 0, otherwise the fusion rules would not fire at all.
 {-# NOINLINE[0] toAscList #-}
 {-# NOINLINE[0] toDescList #-}
-{-# RULES "IntSet.toAscList" [~1] forall s . toAscList s = GHCExts.build (\c n -> foldrFB c n s) #-}
+{-# RULES "IntSet.toAscList" [~1] forall s . toAscList s = GHC.Exts.build (\c n -> foldrFB c n s) #-}
 {-# RULES "IntSet.toAscListBack" [1] foldrFB (:) [] = toAscList #-}
-{-# RULES "IntSet.toDescList" [~1] forall s . toDescList s = GHCExts.build (\c n -> foldlFB (\xs x -> c x xs) n s) #-}
+{-# RULES "IntSet.toDescList" [~1] forall s . toDescList s = GHC.Exts.build (\c n -> foldlFB (\xs x -> c x xs) n s) #-}
 {-# RULES "IntSet.toDescListBack" [1] foldlFB (\xs x -> x : xs) [] = toDescList #-}
 #endif
 
@@ -1600,8 +1600,8 @@ highestBitSet x = WORD_SIZE_IN_BITS - 1 - countLeadingZeros x
 ----------------------------------------------------------------------}
 
 indexOfTheOnlyBit bitmask =
-  GHCExts.I# (lsbArray `GHCExts.indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
-  where unboxInt (GHCExts.I# i) = i
+  GHC.Exts.I# (lsbArray `GHC.Exts.indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
+  where unboxInt (GHC.Exts.I# i) = i
 #if WORD_SIZE_IN_BITS==32
         magic = 0x077CB531
         offset = 27

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -218,13 +218,7 @@ import Text.Read
 #endif
 
 #if __GLASGOW_HASKELL__
-import GHC.Exts (build)
-#if !MIN_VERSION_base(4,8,0) || (WORD_SIZE_IN_BITS!=64)
-import GHC.Exts (Int(..), indexInt8OffAddr#)
-#endif
-#if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as GHCExts
-#endif
 #endif
 
 import qualified Data.Foldable as Foldable
@@ -1063,9 +1057,9 @@ foldlFB = foldl
 -- before phase 0, otherwise the fusion rules would not fire at all.
 {-# NOINLINE[0] toAscList #-}
 {-# NOINLINE[0] toDescList #-}
-{-# RULES "IntSet.toAscList" [~1] forall s . toAscList s = build (\c n -> foldrFB c n s) #-}
+{-# RULES "IntSet.toAscList" [~1] forall s . toAscList s = GHCExts.build (\c n -> foldrFB c n s) #-}
 {-# RULES "IntSet.toAscListBack" [1] foldrFB (:) [] = toAscList #-}
-{-# RULES "IntSet.toDescList" [~1] forall s . toDescList s = build (\c n -> foldlFB (\xs x -> c x xs) n s) #-}
+{-# RULES "IntSet.toDescList" [~1] forall s . toDescList s = GHCExts.build (\c n -> foldlFB (\xs x -> c x xs) n s) #-}
 {-# RULES "IntSet.toDescListBack" [1] foldlFB (\xs x -> x : xs) [] = toDescList #-}
 #endif
 
@@ -1606,8 +1600,8 @@ highestBitSet x = WORD_SIZE_IN_BITS - 1 - countLeadingZeros x
 ----------------------------------------------------------------------}
 
 indexOfTheOnlyBit bitmask =
-  I# (lsbArray `indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
-  where unboxInt (I# i) = i
+  GHCExts.I# (lsbArray `GHCExts.indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
+  where unboxInt (GHCExts.I# i) = i
 #if WORD_SIZE_IN_BITS==32
         magic = 0x077CB531
         offset = 27


### PR DESCRIPTION
This fixes the build failure I had caused in https://github.com/haskell/containers/pull/697#issuecomment-569939436 (and nearly forgot about).

https://gitlab.haskell.org/sjakobi/ghc/pipelines/14130 shows the result of building GHC with df0905c. I currently assume that the remaining build failures were random flukes. `validate-i386-linux-deb9` notably passed.

Now I'd also like to try to simplify the CPP around imports a bit too.