### PR TITLE
Add haddock-autolink module back in.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "docs/_extensions/haddock-autolink"]
-	path = docs/_extensions/haddock-autolink
+[submodule "containers/docs/_extensions/haddock-autolink"]
+	path = containers/docs/_extensions/haddock-autolink
 	url = https://github.com/m-renaud/haddock-autolink


### PR DESCRIPTION
This submodule appears to have been erroneously removed in [30ccbaa2].

[30ccbaa2]: https://github.com/haskell/containers/commit/30ccbaa201043109bf1ee905c66ccd0dbe24422f#diff-fc048ebf98a95fc8a8ff9c949d9b49a9.