### PR TITLE
Add readthedocs.yml config file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+
+sphinx:
+  configuration: containers/docs/conf.py
+
+submodules:
+  include:
+    - containers/docs/_extensions/haddock-autolink
+
+python:
+  version: 2.7


### PR DESCRIPTION
Make previously (grandfathered) ReadTheDocs configuration explicit. This is in
preparation for upgrading to Python 3 which is the default on ReadTheDocs now.

[ci skip]