### PR TITLE
Upgrade ReadTheDocs to use Python 3.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,4 @@ submodules:
     - containers/docs/_extensions/haddock-autolink
 
 python:
-  version: 2.7
+  version: 3.7


### PR DESCRIPTION
- Update .readthedocs.yml
- Use Python 3 compatible haddock-autolink Sphinx extension.

[ci skip]