### PR TITLE
Data.Sequence.Internal: canonicalise mappend

### DIFF
--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -885,7 +885,11 @@ instance Read1 Seq where
 
 instance Monoid (Seq a) where
     mempty = empty
+#if MIN_VERSION_base(4,9,0)
+    mappend = (Semigroup.<>)
+#else
     mappend = (><)
+#endif
 
 #if MIN_VERSION_base(4,9,0)
 -- | @since 0.5.7


### PR DESCRIPTION
Updates the definition of `Monoid (Seq a)` to use canonical definition of `mappend`, allowing https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3174 to pass