### PR TITLE
Bump cabal version

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -11,7 +11,7 @@ description:
   This package contains tests and benchmarks for @containers-package
 
 build-type:         Simple
-cabal-version:      >=1.8
+cabal-version:      >=1.10
 extra-source-files:
   include/containers.h
   tests/Makefile

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -1,5 +1,5 @@
 name: containers
-version: 0.6.2.1
+version: 0.6.3.1
 license: BSD3
 license-file: LICENSE
 maintainer: libraries@haskell.org
@@ -20,7 +20,7 @@ description:
     remains valid even if structures are shared.
 
 build-type: Simple
-cabal-version:  >=1.8
+cabal-version:  >=1.10
 extra-source-files:
     include/containers.h
     changelog.md


### PR DESCRIPTION
Hackage now requires `cabal-version >= 1.10`.