### PR TITLE
Fix `stack test`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,10 @@
 flags: {}
 packages:
-- containers
 - containers-tests
+### containers is disabled by default in order to avoid dependency resolution
+### problems with test dependencies that incur circular dependencies on
+### containers itself.
+# - containers
 
 ### Uncoment the resolver you want to use and re-run `stack build/test/bench`.
 # resolver: lts-10.0


### PR DESCRIPTION
Previously this command would fail due to circular dependency issues.

Fixes #607, fixes #671.