### PR TITLE
Remove strict `compose` versions

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -783,6 +783,10 @@ disjoint t1@(Bin p1 m1 l1 r1) t2@(Bin p2 m2 l2 r2)
 -- ('compose' bc ab '!?') = (bc '!?') <=< (ab '!?')
 -- @
 --
+-- __Note:__ Prior to UNRELEASED, "Data.IntMap.Strict" exposed a version of
+-- 'compose' that forced the values of the output 'IntMap'. This version does
+-- not force these values.
+--
 -- @since 0.6.3.1
 compose :: IntMap c -> IntMap Int -> IntMap c
 compose bc !ab

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -293,6 +293,7 @@ import Data.IntMap.Internal
   , foldrWithKey'
   , keysSet
   , mergeWithKey'
+  , compose
   , delete
   , deleteMin
   , deleteMax
@@ -717,27 +718,6 @@ intersectionWith f m1 m2
 intersectionWithKey :: (Key -> a -> b -> c) -> IntMap a -> IntMap b -> IntMap c
 intersectionWithKey f m1 m2
   = mergeWithKey' bin (\(Tip k1 x1) (Tip _k2 x2) -> Tip k1 $! f k1 x1 x2) (const Nil) (const Nil) m1 m2
-
-{--------------------------------------------------------------------
-  Compose
---------------------------------------------------------------------}
--- | Relate the keys of one map to the values of
--- the other, by using the values of the former as keys for lookups
--- in the latter.
---
--- Complexity: \( O(n * \min(m,W)) \), where \(m\) is the size of the first argument
---
--- > compose (fromList [('a', "A"), ('b', "B")]) (fromList [(1,'a'),(2,'b'),(3,'z')]) = fromList [(1,"A"),(2,"B")]
---
--- @
--- ('compose' bc ab '!?') = (bc '!?') <=< (ab '!?')
--- @
---
--- @since 0.6.3.1
-compose :: IntMap c -> IntMap Int -> IntMap c
-compose bc !ab
-  | null bc = empty
-  | otherwise = mapMaybe (bc !?) ab
 
 {--------------------------------------------------------------------
   MergeWithKey

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2106,6 +2106,10 @@ disjoint (Bin _ k _ l r) t
 -- ('compose' bc ab '!?') = (bc '!?') <=< (ab '!?')
 -- @
 --
+-- __Note:__ Prior to UNRELEASED, "Data.Map.Strict" exposed a version of
+-- 'compose' that forced the values of the output 'Map'. This version does not
+-- force these values.
+--
 -- @since 0.6.3.1
 compose :: Ord b => Map b c -> Map a b -> Map a c
 compose bc !ab

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -335,6 +335,7 @@ import Data.Map.Internal
   , balance
   , balanceL
   , balanceR
+  , compose
   , elemAt
   , elems
   , empty
@@ -1204,27 +1205,6 @@ forceMaybe :: Maybe a -> Maybe a
 forceMaybe Nothing = Nothing
 forceMaybe m@(Just !_) = m
 {-# INLINE forceMaybe #-}
-
-{--------------------------------------------------------------------
-  Compose
---------------------------------------------------------------------}
--- | Relate the keys of one map to the values of
--- the other, by using the values of the former as keys for lookups
--- in the latter.
---
--- Complexity: \( O (n * \log(m)) \), where \(m\) is the size of the first argument
---
--- > compose (fromList [('a', "A"), ('b', "B")]) (fromList [(1,'a'),(2,'b'),(3,'z')]) = fromList [(1,"A"),(2,"B")]
---
--- @
--- ('compose' bc ab '!?') = (bc '!?') <=< (ab '!?')
--- @
---
--- @since 0.6.3.1
-compose :: Ord b => Map b c -> Map a b -> Map a c
-compose bc !ab
-  | null bc = empty
-  | otherwise = mapMaybe (bc !?) ab
 
 {--------------------------------------------------------------------
   MergeWithKey


### PR DESCRIPTION
…as discussed in
https://github.com/haskell-unordered-containers/unordered-containers/pull/299#discussion_r471089295.