### PR TITLE
Note that adjust = alter . fmap in Haddock

### DIFF
--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -1155,6 +1155,8 @@ updateLookupWithKey f0 k0 = toPair . go f0 k0
 -- > let f _ = Just "c"
 -- > alter f 7 (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "a"), (7, "c")]
 -- > alter f 5 (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "c")]
+--
+-- Note that @'adjust' = alter . fmap@.
 
 -- See Note: Type of local 'go' function
 alter :: Ord k => (Maybe a -> Maybe a) -> k -> Map k a -> Map k a

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -795,6 +795,8 @@ updateLookupWithKey f0 k0 t0 = toPair $ go f0 k0 t0
 -- > let f _ = Just "c"
 -- > alter f 7 (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "a"), (7, "c")]
 -- > alter f 5 (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "c")]
+--
+-- Note that @'adjust' = alter . fmap@.
 
 -- See Map.Internal.Note: Type of local 'go' function
 alter :: Ord k => (Maybe a -> Maybe a) -> k -> Map k a -> Map k a


### PR DESCRIPTION
Proof:

adjust satisfies

    adjust f k m = case lookup k m of
        Nothing -> m
        Just v  -> insert k (f v) m

and alter satisfies

    lookup k (alter f k m) = f (lookup k m)

so

    lookup k (adjust f k m)
    == case lookup k m of
           Nothing -> lookup k m
           Just v  -> lookup k (insert k (f v) m)
    == case lookup k m of
           Nothing -> Nothing
           Just v  -> Just (f v)
    == fmap f (lookup k m)
    == lookup k (alter (fmap f) k m)
    == lookup k ((alter . fmap) f k m)

A function is defined by its arguments and a Map is defined by its
lookups, so this suffices to prove that `adjust == alter . fmap`.