### PR TITLE
Make foldr' & friends more strict

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -72,8 +72,9 @@ main = do
         , bench "insertLookupWithKey' present" $ whnf (insLookupWithKey' elems_even) m_even
         , bench "mapWithKey" $ whnf (M.mapWithKey (+)) m
         , bench "foldlWithKey" $ whnf (ins elems) m
---         , bench "foldlWithKey'" $ whnf (M.foldlWithKey' sum 0) m
+        , bench "foldlWithKey'" $ whnf (M.foldlWithKey' sum 0) m
         , bench "foldrWithKey" $ whnf (M.foldrWithKey consPair []) m
+        , bench "foldrWithKey'" $ whnf (M.foldrWithKey' consPair []) m
         , bench "update absent" $ whnf (upd Just evens) m_odd
         , bench "update present" $ whnf (upd Just evens) m_even
         , bench "update delete" $ whnf (upd (const Nothing) evens) m

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -41,9 +41,13 @@ library
       array    >=0.4.0.0
     , base     >=4.6     && <5
     , deepseq  >=1.2     && <1.5
+  if impl(ghc >= 8.6.0)
+    build-depends:
+        nothunks
+      , QuickCheck
 
   include-dirs:     include
-  hs-source-dirs:   src
+  hs-source-dirs:   src, tests
   ghc-options:      -O2 -Wall
   other-extensions:
     BangPatterns
@@ -79,6 +83,9 @@ library
     Utils.Containers.Internal.BitQueue
     Utils.Containers.Internal.BitUtil
     Utils.Containers.Internal.StrictPair
+  if impl(ghc >= 8.6.0)
+    exposed-modules:
+      Utils.NoThunks
 
   other-modules:
     Utils.Containers.Internal.Coercions
@@ -331,6 +338,12 @@ test-suite set-properties
     , test-framework-quickcheck2
     , transformers
 
+  if impl(ghc >= 8.6)
+    build-depends:
+      nothunks
+    other-modules:
+      Utils.NoThunks
+
 test-suite intmap-lazy-properties
   default-language: Haskell2010
   hs-source-dirs:   tests
@@ -474,6 +487,12 @@ test-suite map-strictness-properties
   other-modules:
     Utils.IsUnit
 
+  if impl(ghc >= 8.6)
+    build-depends:
+      nothunks
+    other-modules:
+      Utils.NoThunks
+
 test-suite intmap-strictness-properties
   default-language: Haskell2010
   hs-source-dirs:   tests
@@ -500,6 +519,12 @@ test-suite intmap-strictness-properties
   other-modules:
     Utils.IsUnit
 
+  if impl(ghc >= 8.6)
+    build-depends:
+      nothunks
+    other-modules:
+      Utils.NoThunks
+
 test-suite intset-strictness-properties
   default-language: Haskell2010
   hs-source-dirs:   tests
@@ -520,6 +545,12 @@ test-suite intset-strictness-properties
     , test-framework-quickcheck2  >=0.2.9
 
   ghc-options:      -Wall
+
+  if impl(ghc >= 8.6)
+    build-depends:
+      nothunks
+    other-modules:
+      Utils.NoThunks
 
 test-suite listutils-properties
   default-language: Haskell2010

--- a/containers-tests/tests/Utils/NoThunks.hs
+++ b/containers-tests/tests/Utils/NoThunks.hs
@@ -1,0 +1,15 @@
+module Utils.NoThunks (whnfHasNoThunks) where
+
+import Data.Maybe (isNothing)
+
+import NoThunks.Class (NoThunks, noThunks)
+import Test.QuickCheck (Property, ioProperty)
+
+-- | Check that after evaluating the argument to weak head normal form there
+-- are no thunks.
+--
+whnfHasNoThunks :: NoThunks a => a -> Property
+whnfHasNoThunks a = ioProperty
+                  . fmap isNothing
+                  . noThunks []
+                 $! a

--- a/containers-tests/tests/intset-strictness.hs
+++ b/containers-tests/tests/intset-strictness.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-orphans #-}
+#endif
 module Main (main) where
 
 import Prelude hiding (foldl)
@@ -5,8 +9,25 @@ import Prelude hiding (foldl)
 import Test.ChasingBottoms.IsBottom
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.QuickCheck (Arbitrary (..))
+#if __GLASGOW_HASKELL__ >= 806
+import Test.QuickCheck (Property)
+#endif
 
 import Data.IntSet
+
+#if __GLASGOW_HASKELL__ >= 806
+import Utils.NoThunks
+#endif
+
+
+{--------------------------------------------------------------------
+  Arbitrary, reasonably balanced trees
+--------------------------------------------------------------------}
+instance Arbitrary IntSet where
+  arbitrary = do{ xs <- arbitrary
+                ; return (fromList xs)
+                }
 
 ------------------------------------------------------------------------
 -- * Properties
@@ -18,6 +39,16 @@ pFoldlAccLazy :: Int -> Bool
 pFoldlAccLazy k =
   isn'tBottom $ foldl (\_ x -> x) (bottom :: Int) (singleton k)
 
+#if __GLASGOW_HASKELL__ >= 806
+pStrictFoldr' :: IntSet -> Property
+pStrictFoldr' m = whnfHasNoThunks (foldr' (:) [] m)
+#endif
+
+#if __GLASGOW_HASKELL__ >= 806
+pStrictFoldl' :: IntSet -> Property
+pStrictFoldl' m = whnfHasNoThunks (foldl' (flip (:)) [] m)
+#endif
+
 ------------------------------------------------------------------------
 -- * Test list
 
@@ -27,6 +58,10 @@ tests =
     -- Basic interface
       testGroup "IntSet"
       [ testProperty "foldl is lazy in accumulator" pFoldlAccLazy
+#if __GLASGOW_HASKELL__ >= 806
+      , testProperty "strict foldr'" pStrictFoldr'
+      , testProperty "strict foldl'" pStrictFoldl'
+#endif
       ]
     ]
 

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -23,6 +23,10 @@ import Control.Applicative (Applicative (..), (<$>))
 #endif
 import Control.Applicative (liftA2)
 
+#if __GLASGOW_HASKELL__ >= 806
+import Utils.NoThunks (whnfHasNoThunks)
+#endif
+
 main :: IO ()
 main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testCase "lookupGT" test_lookupGT
@@ -104,6 +108,10 @@ main = defaultMain [ testCase "lookupLT" test_lookupLT
                    , testProperty "powerSet"             prop_powerSet
                    , testProperty "cartesianProduct"     prop_cartesianProduct
                    , testProperty "disjointUnion"        prop_disjointUnion
+#if __GLASGOW_HASKELL__ >= 806
+                   , testProperty "strict foldr"         prop_strictFoldr'
+                   , testProperty "strict foldr"         prop_strictFoldl'
+#endif
                    ]
 
 -- A type with a peculiar Eq instance designed to make sure keys
@@ -690,3 +698,13 @@ prop_disjointUnion xs ys =
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
 isLeft _ = False
+
+#if __GLASGOW_HASKELL__ >= 806
+prop_strictFoldr' :: Set Int -> Property
+prop_strictFoldr' m = whnfHasNoThunks (foldr' (:) [] m)
+#endif
+
+#if __GLASGOW_HASKELL__ >= 806
+prop_strictFoldl' :: Set Int -> Property
+prop_strictFoldl' m = whnfHasNoThunks (foldl' (flip (:)) [] m)
+#endif

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -3274,8 +3274,8 @@ foldr f z = go z
 foldr' :: (a -> b -> b) -> b -> Map k a -> b
 foldr' f z = go z
   where
-    go !z' Tip             = z'
-    go z' (Bin _ _ x l r) = go (f x (go z' r)) l
+    go !z' Tip            = z'
+    go z' (Bin _ _ x l r) = go (f x $! go z' r) l
 {-# INLINE foldr' #-}
 
 -- | /O(n)/. Fold the values in the map using the given left-associative
@@ -3300,8 +3300,10 @@ foldl f z = go z
 foldl' :: (a -> b -> a) -> a -> Map k b -> a
 foldl' f z = go z
   where
-    go !z' Tip             = z'
-    go z' (Bin _ _ x l r) = go (f (go z' l) x) r
+    go !z' Tip            = z'
+    go z' (Bin _ _ x l r) =
+      let !z'' = go z' l
+      in go (f z'' x) r
 {-# INLINE foldl' #-}
 
 -- | /O(n)/. Fold the keys and values in the map using the given right-associative
@@ -3328,7 +3330,7 @@ foldrWithKey' :: (k -> a -> b -> b) -> b -> Map k a -> b
 foldrWithKey' f z = go z
   where
     go !z' Tip              = z'
-    go z' (Bin _ kx x l r) = go (f kx x (go z' r)) l
+    go z' (Bin _ kx x l r) = go (f kx x $! go z' r) l
 {-# INLINE foldrWithKey' #-}
 
 -- | /O(n)/. Fold the keys and values in the map using the given left-associative
@@ -3354,8 +3356,10 @@ foldlWithKey f z = go z
 foldlWithKey' :: (a -> k -> b -> a) -> a -> Map k b -> a
 foldlWithKey' f z = go z
   where
-    go !z' Tip              = z'
-    go z' (Bin _ kx x l r) = go (f (go z' l) kx x) r
+    go !z' Tip             = z'
+    go z' (Bin _ kx x l r) =
+      let !z'' = go z' l
+      in go (f z'' kx x) r
 {-# INLINE foldlWithKey' #-}
 
 -- | /O(n)/. Fold the keys and values in the map using the given monoid, such that

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -987,7 +987,7 @@ foldr' :: (a -> b -> b) -> b -> Set a -> b
 foldr' f z = go z
   where
     go !z' Tip           = z'
-    go z' (Bin _ x l r) = go (f x (go z' r)) l
+    go z' (Bin _ x l r) = go (f x $! go z' r) l
 {-# INLINE foldr' #-}
 
 -- | /O(n)/. Fold the elements in the set using the given left-associative
@@ -1010,7 +1010,9 @@ foldl' :: (a -> b -> a) -> a -> Set b -> a
 foldl' f z = go z
   where
     go !z' Tip           = z'
-    go z' (Bin _ x l r) = go (f (go z' l) x) r
+    go z' (Bin _ x l r) =
+      let !z'' = go z' l
+      in go (f z'' x) r
 {-# INLINE foldl' #-}
 
 {--------------------------------------------------------------------

--- a/containers/src/Utils/NoThunks.hs
+++ b/containers/src/Utils/NoThunks.hs
@@ -1,0 +1,15 @@
+module Utils.NoThunks (whnfHasNoThunks) where
+
+import Data.Maybe (isNothing)
+
+import NoThunks.Class (NoThunks, noThunks)
+import Test.QuickCheck (Property, ioProperty)
+
+-- | Check that after evaluating the argument to weak head normal form there
+-- are no thunks.
+--
+whnfHasNoThunks :: NoThunks a => a -> Property
+whnfHasNoThunks a = ioProperty
+                  . fmap isNothing
+                  . noThunks []
+                 $! a


### PR DESCRIPTION
Fixes #749

There are no tests that checks that `foldr'` or `foldl'` are strict.  The
[nothunks](https://hackage.haskell.org/package/nothunks) library could be used to test it.

- Make Data.Map.foldr' and Data.Map.foldl' more strict
- Make foldrWithKey' and foldlWithKey' more strict
