### PR TITLE
Add whitespace in: fmap ($x)

### DIFF
--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -523,7 +523,7 @@ apSeq fs xs@(Seq xsFT) = case viewl fs of
     EmptyR -> fmap firstf xs
     Seq fs''FT :> lastf -> case rigidify xsFT of
          RigidEmpty -> empty
-         RigidOne (Elem x) -> fmap ($x) fs
+         RigidOne (Elem x) -> fmap ($ x) fs
          RigidTwo (Elem x1) (Elem x2) ->
             Seq $ ap2FT firstf fs''FT lastf (x1, x2)
          RigidThree (Elem x1) (Elem x2) (Elem x3) ->


### PR DESCRIPTION
This fixes a warning generated by `-Woperator-whitespace-ext-conflict`.

Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4277