### PR TITLE
Enable two warnings

### DIFF
--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -35,7 +35,7 @@ Library
     default-language: Haskell2010
     build-depends: base >= 4.6 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5
     hs-source-dirs: src
-    ghc-options: -O2 -Wall
+    ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
     other-extensions: CPP, BangPatterns
 

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -13,6 +13,7 @@
 #endif
 
 {-# OPTIONS_HADDOCK not-home #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
 #include "containers.h"
 

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
 
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+
 #include "containers.h"
 
 -----------------------------------------------------------------------------

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE PatternGuards #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
because they will be part of -Wall in the future, see
https://gitlab.haskell.org/ghc/ghc/-/issues/15656

Because containers is a boot library it's important that these warnings are not triggered because otherwise GHC's test cases will fail and it will be impossible to move these warnings into -Wall!