### PR TITLE
Implement 'intersections', and add an 'Intersection' newtype along with a 'Semigroup' instance

### DIFF
--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -906,7 +906,7 @@ intersection t1@(Bin _ x l1 r1) t2
 #endif
 
 #if (MIN_VERSION_base(4,9,0))
--- | The intersection of a series of sets.
+-- | The intersection of a series of sets. Intersections are performed left-to-right.
 intersections :: Ord a => NonEmpty (Set a) -> Set a
 intersections (s :| ss) = Foldable.foldl' intersection s ss
 

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -908,7 +908,11 @@ intersection t1@(Bin _ x l1 r1) t2
 #if (MIN_VERSION_base(4,9,0))
 -- | The intersection of a series of sets. Intersections are performed left-to-right.
 intersections :: Ord a => NonEmpty (Set a) -> Set a
-intersections (s :| ss) = Foldable.foldl' intersection s ss
+intersections (s0 :| ss) = List.foldr go id ss s0
+    where
+      go s r acc
+          | null acc = empty
+          | otherwise = r (intersection acc s)
 
 -- | Sets form a 'Semigroup' under 'intersection'.
 newtype Intersection a = Intersection { getIntersection :: Set a }

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -156,9 +156,15 @@ module Data.Set.Internal (
             , unions
             , difference
             , intersection
+#if (MIN_VERSION_base(4,9,0))
             , intersections
+#endif
             , cartesianProduct
             , disjointUnion
+#if (MIN_VERSION_base(4,9,0))
+            , Intersection(..)
+#endif
+
 
             -- * Filter
             , filter

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -156,6 +156,7 @@ module Data.Set.Internal (
             , unions
             , difference
             , intersection
+            , intersections
             , cartesianProduct
             , disjointUnion
 
@@ -239,12 +240,13 @@ import Data.Monoid (Monoid(..))
 #endif
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(stimes))
+import Data.List.NonEmpty (NonEmpty(..))
 #endif
 #if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup((<>)))
 #endif
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (stimesIdempotentMonoid)
+import Data.Semigroup (stimesIdempotentMonoid, stimesIdempotent)
 import Data.Functor.Classes
 #endif
 #if MIN_VERSION_base(4,8,0)
@@ -895,6 +897,20 @@ intersection t1@(Bin _ x l1 r1) t2
     !r1r2 = intersection r1 r2
 #if __GLASGOW_HASKELL__
 {-# INLINABLE intersection #-}
+#endif
+
+#if (MIN_VERSION_base(4,9,0))
+-- | The intersection of a series of sets.
+intersections :: Ord a => NonEmpty (Set a) -> Set a
+intersections (s :| ss) = Foldable.foldl' intersection s ss
+
+-- | Sets form a 'Semigroup' under 'intersection'.
+newtype Intersection a = Intersection { getIntersection :: Set a }
+    deriving (Show, Eq, Ord)
+
+instance (Ord a) => Semigroup (Intersection a) where
+    (Intersection a) <> (Intersection b) = Intersection $ intersection a b
+    stimes = stimesIdempotent
 #endif
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
## Patch Description

This PR adds the following function for computing the intersection of a series of sets:
```
intersections :: Ord a => NonEmpty (Set a) -> Set a
intersections (s :| ss) = Foldable.foldl' intersection s ss
```

It also adds a newtype around `Set` dubbed `Intersection`, which provides a `Semigroup` instance that uses `intersections`.

Mailing list discussion can be found here: https://mail.haskell.org/pipermail/libraries/2020-December/030951.html