### PR TITLE
Add `pop` and `popWithDefault` to `Map` and `IntMap`

### DIFF
--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -65,6 +65,8 @@ main = defaultMain
              , testCase "update" test_update
              , testCase "updateWithKey" test_updateWithKey
              , testCase "updateLookupWithKey" test_updateLookupWithKey
+             , testCase "pop" test_pop
+             , testCase "popWithDefault" test_popWithDefault
              , testCase "alter" test_alter
              , testCase "union" test_union
              , testCase "mappend" test_mappend
@@ -527,6 +529,26 @@ test_updateLookupWithKey = do
     updateLookupWithKey f (-7) (fromList [(5,"a"), (-3,"b")]) @?= (Nothing,  fromList [(-3, "b"), (5, "a")])
   where
     f k x = if x == "a" then Just ((show k) ++ ":new a") else Nothing
+
+test_pop :: Assertion
+test_pop = do
+    pop 5 (fromList [(5,"a"), (7,"b")]) @?= (Just "a", fromList [(7, "b")])
+    pop 6 (fromList [(5,"a"), (7,"b")]) @?= (Nothing, fromList [(5, "a"), (7, "b")])
+    pop 7 (fromList [(5,"a"), (7,"b")]) @?= (Just "b", fromList [(5, "a")])
+
+    pop (-5) (fromList [(-5,"a"), (-7,"b")]) @?= (Just "a", fromList [(-7, "b")])
+    pop (-6) (fromList [(-5,"a"), (-7,"b")]) @?= (Nothing, fromList [(-5, "a"), (-7, "b")])
+    pop (-7) (fromList [(-5,"a"), (-7,"b")]) @?= (Just "b", fromList [(-5, "a")])
+
+test_popWithDefault :: Assertion
+test_popWithDefault = do
+    popWithDefault "c" 5 (fromList [(5,"a"), (7,"b")]) @?= ("a", fromList [(7, "b")])
+    popWithDefault "c" 6 (fromList [(5,"a"), (7,"b")]) @?= ("c", fromList [(5, "a"), (7, "b")])
+    popWithDefault "c" 7 (fromList [(5,"a"), (7,"b")]) @?= ("b", fromList [(5, "a")])
+
+    popWithDefault "c" (-5) (fromList [(-5,"a"), (-7,"b")]) @?= ("a", fromList [(-7, "b")])
+    popWithDefault "c" (-6) (fromList [(-5,"a"), (-7,"b")]) @?= ("c", fromList [(-5, "a"), (-7, "b")])
+    popWithDefault "c" (-7) (fromList [(-5,"a"), (-7,"b")]) @?= ("b", fromList [(-5, "a")])
 
 test_alter :: Assertion
 test_alter = do

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -74,6 +74,8 @@ main = defaultMain
          , testCase "update" test_update
          , testCase "updateWithKey" test_updateWithKey
          , testCase "updateLookupWithKey" test_updateLookupWithKey
+         , testCase "pop" test_pop
+         , testCase "popWithDefault" test_popWithDefault
          , testCase "alter" test_alter
          , testCase "at" test_at
          , testCase "union" test_union
@@ -528,6 +530,18 @@ test_updateLookupWithKey = do
     updateLookupWithKey f 3 (fromList [(5,"a"), (3,"b")]) @?= (Just "b", singleton 5 "a")
   where
     f k x = if x == "a" then Just ((show k) ++ ":new a") else Nothing
+
+test_pop :: Assertion
+test_pop = do
+    pop 5 (fromList [(5,"a"), (7,"b")]) @?= (Just "a", fromList [(7, "b")])
+    pop 6 (fromList [(5,"a"), (7,"b")]) @?= (Nothing, fromList [(5, "a"), (7, "b")])
+    pop 7 (fromList [(5,"a"), (7,"b")]) @?= (Just "b", fromList [(5, "a")])
+
+test_popWithDefault :: Assertion
+test_popWithDefault = do
+    popWithDefault "c" 5 (fromList [(5,"a"), (7,"b")]) @?= ("a", fromList [(7, "b")])
+    popWithDefault "c" 6 (fromList [(5,"a"), (7,"b")]) @?= ("c", fromList [(5, "a"), (7, "b")])
+    popWithDefault "c" 7 (fromList [(5,"a"), (7,"b")]) @?= ("b", fromList [(5, "a")])
 
 test_alter :: Assertion
 test_alter = do

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -1,4 +1,9 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
+## 0.6.5.0
+
+### Additions
+* [Add `pop` and `popWithDefault` to `Data.Map` and `Data.IntMap`](https://github.com/haskell/containers/pull/757)
+
 
 ## [0.6.4.1]
 

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -2,7 +2,7 @@
 ## 0.6.5.0
 
 ### Additions
-* [Add `pop` and `popWithDefault` to `Data.Map` and `Data.IntMap`](https://github.com/haskell/containers/pull/757)
+* [Add `pop` and `popWithDefault` to `Data.Map`, `Data.IntMap`, and `Data.Sequence`](https://github.com/haskell/containers/pull/757)
 
 
 ## [0.6.4.1]

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -109,6 +109,8 @@ module Data.IntMap.Internal (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 
@@ -312,6 +314,7 @@ import Data.Semigroup (stimesIdempotentMonoid)
 import Data.Functor.Classes
 #endif
 
+import Control.Arrow (first)
 import Control.DeepSeq (NFData(rnf))
 import Data.Bits
 import qualified Data.Foldable as Foldable
@@ -1010,6 +1013,23 @@ updateLookupWithKey f k t@(Tip ky y)
   | otherwise     = (Nothing,t)
 updateLookupWithKey _ _ Nil = (Nothing,Nil)
 
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, 'Nothing' is returned together with
+-- the original map.
+--
+-- @since 0.6.5
+pop :: Int -> IntMap a -> (Maybe a, IntMap a)
+pop = updateLookupWithKey (\_ _ -> Nothing)
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, a default value is returned together
+-- with the original map.
+--
+-- @since 0.6.5
+popWithDefault :: a -> Int -> IntMap a -> (a, IntMap a)
+popWithDefault a k m = first (fromMaybe a) (pop k m)
 
 
 -- | /O(min(n,W))/. The expression (@'alter' f k map@) alters the value @x@ at @k@, or absence thereof.

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -103,6 +103,8 @@ module Data.IntMap.Lazy (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -122,6 +122,8 @@ module Data.IntMap.Strict (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -120,6 +120,8 @@ module Data.IntMap.Strict.Internal (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 
@@ -352,6 +354,8 @@ import qualified Data.Foldable as Foldable
 #if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable())
 #endif
+import Control.Arrow (first)
+import Data.Maybe (fromMaybe)
 
 {--------------------------------------------------------------------
   Query
@@ -579,6 +583,23 @@ updateLookupWithKey f0 !k0 t0 = toPair $ go f0 k0 t0
           | otherwise     -> (Nothing :*: t)
         Nil -> (Nothing :*: Nil)
 
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, 'Nothing' is returned together with
+-- the original map.
+--
+-- @since 0.6.5
+pop :: Int -> IntMap a -> (Maybe a, IntMap a)
+pop = updateLookupWithKey (\_ _ -> Nothing)
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, a default value is returned together
+-- with the original map.
+--
+-- @since 0.6.5
+popWithDefault :: a -> Int -> IntMap a -> (a, IntMap a)
+popWithDefault a k m = first (fromMaybe a) (pop k m)
 
 
 -- | /O(min(n,W))/. The expression (@'alter' f k map@) alters the value @x@ at @k@, or absence thereof.

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -167,6 +167,8 @@ module Data.Map.Internal (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 
@@ -388,6 +390,7 @@ import Data.Semigroup (Semigroup(stimes))
 import Data.Semigroup (Semigroup((<>)))
 #endif
 import Control.Applicative (Const (..))
+import Control.Arrow (first)
 import Control.DeepSeq (NFData(rnf))
 import Data.Bits (shiftL, shiftR)
 import qualified Data.Foldable as Foldable
@@ -398,6 +401,7 @@ import Data.Foldable (Foldable())
 import Data.Bifoldable
 #endif
 import Data.Typeable
+import Data.Maybe (fromMaybe)
 import Prelude hiding (lookup, map, filter, foldr, foldl, null, splitAt, take, drop)
 
 import qualified Data.Set.Internal as Set
@@ -1143,6 +1147,24 @@ updateLookupWithKey f0 k0 = toPair . go f0 k0
 #else
 {-# INLINE updateLookupWithKey #-}
 #endif
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, 'Nothing' is returned together with
+-- the original map.
+--
+-- @since 0.6.5
+pop :: Ord k => k -> Map k a -> (Maybe a, Map k a)
+pop = updateLookupWithKey (\_ _ -> Nothing)
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, a default value is returned together
+-- with the original map.
+--
+-- @since 0.6.5
+popWithDefault :: Ord k => a -> k -> Map k a -> (a, Map k a)
+popWithDefault a k m = first (fromMaybe a) (pop k m)
 
 -- | /O(log n)/. The expression (@'alter' f k map@) alters the value @x@ at @k@, or absence thereof.
 -- 'alter' can be used to insert, delete, or update a value in a 'Map'.

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -123,6 +123,8 @@ module Data.Map.Lazy (
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -139,6 +139,8 @@ module Data.Map.Strict
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -120,6 +120,8 @@ module Data.Map.Strict.Internal
     , update
     , updateWithKey
     , updateLookupWithKey
+    , pop
+    , popWithDefault
     , alter
     , alterF
 
@@ -426,6 +428,9 @@ import Data.Bits (shiftL, shiftR)
 #if __GLASGOW_HASKELL__ >= 709
 import Data.Coerce
 #endif
+
+import Control.Arrow (first)
+import Data.Maybe (fromMaybe)
 
 #if __GLASGOW_HASKELL__ && MIN_VERSION_base(4,8,0)
 import Data.Functor.Identity (Identity (..))
@@ -783,6 +788,24 @@ updateLookupWithKey f0 k0 t0 = toPair $ go f0 k0 t0
 #else
 {-# INLINE updateLookupWithKey #-}
 #endif
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, 'Nothing' is returned together with
+-- the original map.
+--
+-- @since 0.6.5
+pop :: Ord k => k -> Map k a -> (Maybe a, Map k a)
+pop = updateLookupWithKey (\_ _ -> Nothing)
+
+-- | /O(log n)/. Lookup and delete.
+-- If the key is found, the value corresponding to it is returned and removed
+-- from the map. If the key is not found, a default value is returned together
+-- with the original map.
+--
+-- @since 0.6.5
+popWithDefault :: Ord k => a -> k -> Map k a -> (a, Map k a)
+popWithDefault a k m = first (fromMaybe a) (pop k m)
 
 -- | /O(log n)/. The expression (@'alter' f k map@) alters the value @x@ at @k@, or absence thereof.
 -- 'alter' can be used to insert, delete, or update a value in a 'Map'.

--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -206,6 +206,8 @@ module Data.Sequence (
     adjust,         -- :: (a -> a) -> Int -> Seq a -> Seq a
     adjust',        -- :: (a -> a) -> Int -> Seq a -> Seq a
     update,         -- :: Int -> a -> Seq a -> Seq a
+    pop,            -- :: Int -> Seq a -> (Maybe a, Seq a)
+    popWithDefault, -- :: a -> Int -> Seq a -> (a, Seq a)
     take,           -- :: Int -> Seq a -> Seq a
     drop,           -- :: Int -> Seq a -> Seq a
     insertAt,       -- :: Int -> a -> Seq a -> Seq a


### PR DESCRIPTION
Proposal:

* Add `pop` and `popWithDefault` to `Data.Map` and `Data.IntMap`.

Why:

* They're useful functions I expected to be in `Data.Map` and `Data.IntMap`. (This might be influenced by the fact that they're defined on Python's `dict`.)
* Their implementations (~ `updateLookupWithKey (\_ _ -> Nothing)`) is harder to parse than a simple `pop`, which should help Haskell codebases become a bit cleaner :). 
* Their implementations are a bit non-obvious. My first instinct was to write `(Map.lookup ..., Map.delete ...)`, which would have done two traversals. Having "properly" implemented functions in the lib would prevent people from writing their own suboptimal ones.

Mailing list discussion:

* https://mail.haskell.org/pipermail/libraries/2020-December/030954.html
* Reservations on name `pop`. Proposed alternatives: `extract`, `lookupRemove`. I'll leave it `pop` for now, until we've settled on a name.