### PR TITLE
Add missing `ys` argument to shift2Right

### DIFF
--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -297,7 +297,7 @@ onto the beginning of the second one.
 shift2Right :: Seq a -> Seq a -> (Seq a, Seq a)
 shift2Right Empty ys = (Empty, ys)
 shift2Right (Empty :|> x) ys = (Empty, x :<| ys)
-shift2Right (xs :|> x1 :|> x2) = (xs, x1 :<| x2 :<| ys)
+shift2Right (xs :|> x1 :|> x2) ys = (xs, x1 :<| x2 :<| ys)
 @
 
 @


### PR DESCRIPTION
Perhaps I'm misreading the code here, but I think there's supposed to be a `ys` argument here, right?