### PR TITLE
Fix for `indexInt8OffAddr#` potentially returning sized type in next GHC

### DIFF
--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -221,6 +221,9 @@ import Text.Read
 
 #if __GLASGOW_HASKELL__
 import qualified GHC.Exts
+#if !(MIN_VERSION_base(4,8,0) && (WORD_SIZE_IN_BITS==64))
+import qualified GHC.Int
+#endif
 #endif
 
 import qualified Data.Foldable as Foldable
@@ -1642,7 +1645,7 @@ highestBitSet x = WORD_SIZE_IN_BITS - 1 - countLeadingZeros x
 ----------------------------------------------------------------------}
 
 indexOfTheOnlyBit bitmask =
-  GHC.Exts.I# (lsbArray `GHC.Exts.indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset)))
+  fromIntegral (GHC.Int.I8# (lsbArray `GHC.Exts.indexInt8OffAddr#` unboxInt (intFromNat ((bitmask * magic) `shiftRL` offset))))
   where unboxInt (GHC.Exts.I# i) = i
 #if WORD_SIZE_IN_BITS==32
         magic = 0x077CB531


### PR DESCRIPTION
Here's how we fix this without CPP:

In old GHC:

```haskell
I8# :: Int# -> Int8
indexInt8OffAddr# :: Addr# -> Int# -> Int#
```

In upcoming GHC 9.2:

```haskell
I8# :: Int8# -> Int8
indexInt8OffAddr# :: Addr# -> Int# -> Int8#
```

So the "GLB" interface is:

```haskell
exists alpha.
I8# :: alpha -> Int8
indexInt8OffAddr# :: Addr# -> Int# -> alpha
```

We we write a program against that, eliminating the black-box `alpha` with `I8#` and then converting to `Int`.

See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4492