### PR TITLE
Add `Ord (Tree a)` instance.

### DIFF
--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -97,6 +97,7 @@ data Tree a = Node {
     }
 #ifdef __GLASGOW_HASKELL__
   deriving ( Eq
+           , Ord -- ^ @since 0.6.5
            , Read
            , Show
            , Data
@@ -104,7 +105,7 @@ data Tree a = Node {
            , Generic1 -- ^ @since 0.5.8
            )
 #else
-  deriving (Eq, Read, Show)
+  deriving (Eq, Ord, Read, Show)
 #endif
 
 -- | This type synonym exists primarily for historical


### PR DESCRIPTION
I assume this is an oversight because we do have `Ord1 Tree`.

Some of you may be interested in knowing that I caught this due to trying out the the changes discusssed in the thread that began in https://mail.haskell.org/pipermail/libraries/2020-March/030306.html.