### PR TITLE
Prepare for specialization of Data.List

### DIFF
--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -122,7 +122,7 @@ import Data.Array.Unboxed ( UArray )
 #else
 import qualified Data.Array as UA
 #endif
-import Data.List
+import qualified Data.List as L
 #if MIN_VERSION_base(4,9,0)
 import Data.Functor.Classes
 #endif
@@ -442,7 +442,7 @@ graphFromEdges edges0
   where
     max_v           = length edges0 - 1
     bounds0         = (0,max_v) :: (Vertex, Vertex)
-    sorted_edges    = sortBy lt edges0
+    sorted_edges    = L.sortBy lt edges0
     edges1          = zipWith (,) [0..] sorted_edges
 
     graph           = array bounds0 [(,) v (mapMaybe key_vertex ks) | (,) v (_,    _, ks) <- edges1]

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -202,7 +202,6 @@ import Prelude hiding (
     null, length, lookup, take, drop, splitAt, foldl, foldl1, foldr, foldr1,
     scanl, scanl1, scanr, scanr1, replicate, zip, zipWith, zip3, zipWith3,
     unzip, takeWhile, dropWhile, iterate, reverse, filter, mapM, sum, all)
-import qualified Data.List
 import Control.Applicative (Applicative(..), (<$>), (<**>),  Alternative,
                             liftA2, liftA3)
 import qualified Control.Applicative as Applicative
@@ -212,6 +211,11 @@ import Data.Monoid (Monoid(..))
 import Data.Functor (Functor(..))
 import Utils.Containers.Internal.State (State(..), execState)
 import Data.Foldable (Foldable(foldl, foldl1, foldr, foldr1, foldMap, foldl', foldr'), toList)
+import qualified Data.Foldable as F
+
+#if !(__GLASGOW_HASKELL__ >= 708)
+import qualified Data.List
+#endif
 
 #if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as Semigroup

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -2192,6 +2192,9 @@ instance Functor ViewL where
     fmap f (x :< xs)    = f x :< fmap f xs
 
 instance Foldable ViewL where
+    foldMap _ EmptyL = mempty
+    foldMap f (x :< xs) = f x <> foldMap f xs
+
     foldr _ z EmptyL = z
     foldr f z (x :< xs) = f x (foldr f z xs)
 


### PR DESCRIPTION
i.e. if it didn't export `Foldable` stuff.