### PR TITLE
Use `S.replicate` in sequence-benchmarks

### DIFF
--- a/containers-tests/benchmarks/Sequence.hs
+++ b/containers-tests/benchmarks/Sequence.hs
@@ -126,15 +126,15 @@ main = do
               nf (\s -> ((+) <$> s <*> s) `S.index` (S.length s * S.length s `div` 2))
                  (S.fromFunction (floor (sqrt $ fromIntegral (maxBound::Int))-10) (+1))
          , bench "nf100/2500/rep" $
-              nf (\(s,t) -> (,) <$> replicate s () <*> replicate t ()) (100,2500)
+              nf (\(s,t) -> (,) <$> S.replicate s () <*> S.replicate t ()) (100,2500)
          , bench "nf100/2500/ff" $
               nf (\(s,t) -> (,) <$> S.fromFunction s (+1) <*> S.fromFunction t (*2)) (100,2500)
          , bench "nf500/500/rep" $
-              nf (\(s,t) -> (,) <$> replicate s () <*> replicate t ()) (500,500)
+              nf (\(s,t) -> (,) <$> S.replicate s () <*> S.replicate t ()) (500,500)
          , bench "nf500/500/ff" $
               nf (\(s,t) -> (,) <$> S.fromFunction s (+1) <*> S.fromFunction t (*2)) (500,500)
          , bench "nf2500/100/rep" $
-              nf (\(s,t) -> (,) <$> replicate s () <*> replicate t ()) (2500,100)
+              nf (\(s,t) -> (,) <$> S.replicate s () <*> S.replicate t ()) (2500,100)
          , bench "nf2500/100/ff" $
               nf (\(s,t) -> (,) <$> S.fromFunction s (+1) <*> S.fromFunction t (*2)) (2500,100)
          ]


### PR DESCRIPTION
Fixes #703.