### PR TITLE
Implementation for function insertWithFun for strict and lazy maps.

### DIFF
--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -66,6 +66,7 @@ main = defaultMain
          , testCase "singleton" test_singleton
          , testCase "insert" test_insert
          , testCase "insertWith" test_insertWith
+         , testCase "insertWithFun" test_insertWithFun
          , testCase "insertWithKey" test_insertWithKey
          , testCase "insertLookupWithKey" test_insertLookupWithKey
          , testCase "delete" test_delete
@@ -464,6 +465,12 @@ test_insertWith = do
     insertWith (++) 5 "xxx" (fromList [(5,"a"), (3,"b")]) @?= fromList [(3, "b"), (5, "xxxa")]
     insertWith (++) 7 "xxx" (fromList [(5,"a"), (3,"b")]) @?= fromList [(3, "b"), (5, "a"), (7, "xxx")]
     insertWith (++) 5 "xxx" empty                         @?= singleton 5 "xxx"
+
+test_insertWithFun :: Assertion
+test_insertWithFun = do
+    insertWithFun (:) (: []) 5 "x" (fromList [(5,["a"]), (3,["b"])]) @?= fromList [(3, ["b"]), (5, ["x", "a"])]
+    insertWithFun (:) (: []) 7 "x" (fromList [(5,["a"]), (3,["b"])]) @?= fromList [(3, ["b"]), (5, ["a"]), (7, ["x"])]
+    insertWithFun (:) (: []) 5 "x" empty                             @?= singleton 5 ["x"]
 
 test_insertWithKey :: Assertion
 test_insertWithKey = do

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -9,6 +9,8 @@
 
 ### Additions
 
+* [Add `insertKeyWithFun` to `Data.Map.Strict` and `Data.Map.Lazy`]() (Thanks, Neophytos Michael)
+
 * [Add `reverseTopSort` to `Data.Graph`](https://github.com/haskell/containers/pull/638) (Thanks, James Parker)
 
 * [Expose `traverseMaybeWithKey` from `Data.IntMap.{Lazy,Strict}`](https://github.com/haskell/containers/pull/743) (Thanks, Simon

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -113,6 +113,7 @@ module Data.Map.Lazy (
     -- * Insertion
     , insert
     , insertWith
+    , insertWithFun
     , insertWithKey
     , insertLookupWithKey
 

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -129,6 +129,7 @@ module Data.Map.Strict
     -- * Insertion
     , insert
     , insertWith
+    , insertWithFun
     , insertWithKey
     , insertLookupWithKey
 

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -110,6 +110,7 @@ module Data.Map.Strict.Internal
     -- ** Insertion
     , insert
     , insertWith
+    , insertWithFun
     , insertWithKey
     , insertLookupWithKey
 
@@ -557,6 +558,37 @@ insertWith = go
 {-# INLINABLE insertWith #-}
 #else
 {-# INLINE insertWith #-}
+#endif
+
+-- | /O(log n)/. Insert with two functions: 'f' to combine a value (of type 'a')
+-- with the Map value (of type 'b') to produce a new Map value, and 'g' to inject the
+-- input value of type 'a' into type 'b' if key is not present.
+-- This version can be used to avoid unnecessary boxing when 'b' is for example
+-- some sort of container containing elements of type 'a'.
+-- @'insertWithFun' f g key value mp@
+-- will insert the pair (key, g value) into @mp@ if key does
+-- not exist in the map. If the key does exist, the function will
+-- insert the pair @(key, f new_value old_value)@.
+--
+-- > insertWithFun (:) (: []) 5 "x" (fromList [(5, ["a"]), (3, ["b"])]) == fromList [(3, ["b"]), (5, ["x", "a"])]
+-- > insertWithFun (:) (: []) 7 "x" (fromList [(5, ["a"]), (3, ["b"])]) == fromList [(3, ["b"]), (5, ["a"]), (7, ["x"])]
+-- > insertWithFun (:) (: []) 5 "x" empty                               == singleton 5 ["x"]
+
+insertWithFun :: Ord k => (a -> b -> b) -> (a -> b) -> k -> a -> Map k b -> Map k b
+insertWithFun = go
+  where
+    go :: Ord k => (a -> b -> b) -> (a -> b) -> k -> a -> Map k b -> Map k b
+    go _ g !kx x Tip = let !y' = g x in singleton kx y'
+    go f g !kx x (Bin sy ky y l r) =
+        case compare kx ky of
+            LT -> balanceL ky y (go f g kx x l) r
+            GT -> balanceR ky y l (go f g kx x r)
+            EQ -> let !y' = f x y in Bin sy kx y' l r
+
+#if __GLASGOW_HASKELL__
+{-# INLINABLE insertWithFun #-}
+#else
+{-# INLINE insertWithFun #-}
 #endif
 
 insertWithR :: Ord k => (a -> a -> a) -> k -> a -> Map k a -> Map k a


### PR DESCRIPTION
Implementation of a new variant of insertWith (called tentatively insertWithFun) that allows insertions without allocation when the value in the map is a container like object (like Map Int [Int] for example).

Discussion is here: https://github.com/haskell/containers/issues/784
