### PR TITLE
Larger keys for intmap and intset

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 2000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests 1000"  --test-options="--quickcheck-max-size 100"  --test-options="--timeout 10s"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 2000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 1000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests 1000"  --test-options="--quickcheck-max-size 100"  --test-options="--timeout 10s"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests 1000"  --test-options="--quickcheck-max-size 100"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,10 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests 1000"  --test-options="--quickcheck-max-size 100"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=1000   --quickcheck-max-size=100"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=10     --quickcheck-max-size=1000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -251,12 +251,12 @@ jobs:
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
-	  for pat in intmap intset
-	  do
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=10000"
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=1000   --quickcheck-max-size=100"
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=10     --quickcheck-max-size=1000"
-	  done
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intset --quickcheck-tests=10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intset --quickcheck-tests=1000   --quickcheck-max-size=100"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intset --quickcheck-tests=10     --quickcheck-max-size=1000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intmap --quickcheck-tests=10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intmap --quickcheck-tests=1000   --quickcheck-max-size=100"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=intmap --quickcheck-tests=10     --quickcheck-max-size=1000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 1000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 10000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -251,9 +251,12 @@ jobs:
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=10000"
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=1000   --quickcheck-max-size=100"
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--quickcheck-tests=10     --quickcheck-max-size=1000"
+	  for pat in intmap intset
+	  do
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=10000"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=1000   --quickcheck-max-size=100"
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-options="--pattern=$pat --quickcheck-tests=10     --quickcheck-max-size=1000"
+	  done
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -250,7 +250,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct --test-option="-a 10000"
       - name: haddock
         run: |
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -219,16 +219,16 @@ apply3 f a b c = apply f (a, b, c)
 
 
 {--------------------------------------------------------------------
-  Arbitrary, reasonably balanced trees
+  Arbitrary IntMaps, including those with large keys
 --------------------------------------------------------------------}
 
 instance Arbitrary a => Arbitrary (IntMap a) where
-  arbitrary = fmap fromList arbitrary
+  arbitrary = fmap (fromList . fmap (\(k,v) -> (getLarge k, v))) arbitrary
 
 newtype NonEmptyIntMap a = NonEmptyIntMap {getNonEmptyIntMap :: IntMap a} deriving (Eq, Show)
 
 instance Arbitrary a => Arbitrary (NonEmptyIntMap a) where
-  arbitrary = fmap (NonEmptyIntMap . fromList . getNonEmpty) arbitrary
+  arbitrary = fmap (NonEmptyIntMap . fromList  . fmap (\(k,v) -> (getLarge k, v)) . getNonEmpty) arbitrary
 
 
 ------------------------------------------------------------------------

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -109,11 +109,11 @@ test_split = do
    split 3 (fromList [1..5]) @?= (fromList [1,2], fromList [4,5])
 
 {--------------------------------------------------------------------
-  Arbitrary, reasonably balanced trees
+  Arbitrary IntSets, including those with large elements
 --------------------------------------------------------------------}
 instance Arbitrary IntSet where
   arbitrary = do{ xs <- arbitrary
-                ; return (fromList xs)
+                ; return (fromList (fmap getLarge xs))
                 }
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
as discussed in https://github.com/haskell/containers/issues/788 .

I have no idea on how to best pass the "-a N" option for testing. Does it go in haskell-ci.yml, or in cabal.haskell-ci? or in containers.cabal? 

or in the source? That seems easiest to do, and most stable (independent from build/CI tooling) but it would ignore command-line options, which is bad? https://hackage.haskell.org/package/test-framework-0.8.2.0/docs/Test-Framework-Runners-Console.html#v:defaultMainWithArgs

Adding `--test-option="-a 10000"` does seem to increase CI build times - quite drastically. Or, they weren't very stable to begin with.