### PR TITLE
Enable TypeOperators to use (~)

### DIFF
--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE ViewPatterns #-}
 #endif
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}


### PR DESCRIPTION
[GHC Proposal #371](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0371-non-magical-eq.md) requires `TypeOperators` to use type equality `a~b`. The following lines are affected:

```
containers/src/Data/Sequence/Internal.hs
4416:instance a ~ Char => IsString (Seq a) where
```

The fix is to simply enable the extension.