### PR TITLE
Disable unboxed arrays on big-endian

### DIFF
--- a/containers/include/containers.h
+++ b/containers/include/containers.h
@@ -35,7 +35,13 @@
 
 #ifdef __GLASGOW_HASKELL__
 # define USE_ST_MONAD 1
+#ifndef WORDS_BIGENDIAN
+/*
+ * Unboxed arrays are broken on big-endian architectures.
+ * See https://gitlab.haskell.org/ghc/ghc/-/issues/16998
+ */
 # define USE_UNBOXED_ARRAYS 1
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
Unboxed arrays are broken on big-endian architectures, see
https://gitlab.haskell.org/ghc/ghc/-/issues/16998 for details.
This patch makes the use of unboxed arrays conditional on
little-endian architecture.

Fixes #673