### PR TITLE
Bump to GHC 8.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211111
+# version: 0.13.20211030
 #
-# REGENDATA ("0.13.20211111",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.13.20211030",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -24,8 +24,6 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
-    timeout-minutes:
-      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
@@ -70,21 +68,6 @@ jobs:
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
             setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
@@ -136,7 +119,7 @@ jobs:
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 70800 && HCNUMVER < 90200)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
@@ -165,10 +148,6 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
-          EOF
-          cat >> $CABAL_CONFIG <<EOF
-          program-default-options
-            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -8,9 +8,6 @@ import Control.Exception (evaluate)
 import Gauge (bench, defaultMain, whnf)
 import Data.List (foldl')
 import Data.Monoid (Sum(..))
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (foldMap)
-#endif
 import qualified Data.IntSet as IS
 -- benchmarks for "instance Ord IntSet"
 -- uses IntSet as keys of maps, and elements of sets

--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -13,9 +13,7 @@ import qualified Data.Map.Strict as MS
 import Data.Map (alterF)
 import Data.Maybe (fromMaybe)
 import Data.Functor ((<$))
-#if __GLASGOW_HASKELL__ >= 708
 import Data.Coerce
-#endif
 import Prelude hiding (lookup)
 
 main = do
@@ -134,11 +132,7 @@ atIns xs m = foldl' (\m (k, v) -> runIdentity (alterF (\_ -> Identity (Just v)) 
 
 newtype Ident a = Ident { runIdent :: a }
 instance Functor Ident where
-#if __GLASGOW_HASKELL__ >= 708
   fmap = coerce
-#else
-  fmap f (Ident a) = Ident (f a)
-#endif
 
 atInsNoRules :: [(Int, Int)] -> M.Map Int Int -> M.Map Int Int
 atInsNoRules xs m = foldl' (\m (k, v) -> runIdent (alterF (\_ -> Ident (Just v)) k m)) m xs

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -1,6 +1,7 @@
+cabal-version:      2.2
 name:               containers-tests
 version:            0
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 maintainer:         libraries@haskell.org
 bug-reports:        https://github.com/haskell/containers/issues
@@ -11,7 +12,6 @@ description:
   This package contains tests and benchmarks for @containers-package
 
 build-type:         Simple
-cabal-version:      >=1.10
 extra-source-files:
   include/containers.h
   tests/Makefile
@@ -26,21 +26,41 @@ extra-source-files:
   benchmarks/LookupGE/*.hs
 
 tested-with:
-  GHC ==7.6.3 || ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1
+  GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.1
 
 source-repository head
   type:     git
   location: http://github.com/haskell/containers.git
 
+common deps
+  build-depends:
+      array    >=0.4.0.0
+    , base     >=4.9.1   && <5
+    , deepseq  >=1.2     && <1.5
+
+common test-deps
+  import: deps
+  build-depends:
+      containers-tests
+    , QuickCheck                  >=2.7.1
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , transformers
+
+common benchmark-deps
+  import: deps
+  build-depends:
+      containers-tests
+    , deepseq           >=1.1.0.0 && <1.5
+    , gauge             >=0.2.3   && <0.3
+
 -- Copy of containers library,
 library
+  import: deps
   default-language: Haskell2010
   -- this is important for testing; may it affect benchmarks?
   cpp-options:      -DTESTING
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
   if impl(ghc >= 8.6.0)
     build-depends:
         nothunks
@@ -107,129 +127,95 @@ library
 -----------------------------
 
 benchmark intmap-benchmarks
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        IntMap.hs
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6     && <5
-    , containers-tests
-    , deepseq           >=1.1.0.0 && <1.5
-    , gauge             >=0.2.3   && <0.3
 
 benchmark intset-benchmarks
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        IntSet.hs
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6     && <5
-    , containers-tests
-    , deepseq           >=1.1.0.0 && <1.5
-    , gauge             >=0.2.3   && <0.3
 
 benchmark map-benchmarks
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        Map.hs
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6     && <5
-    , containers-tests
-    , deepseq           >=1.1.0.0 && <1.5
-    , gauge             >=0.2.3   && <0.3
-    , transformers
 
 benchmark sequence-benchmarks
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        Sequence.hs
   ghc-options:    -O2
   build-depends:
-      base              >=4.6     && <5
-    , containers-tests
-    , deepseq           >=1.1.0.0 && <1.5
-    , gauge             >=0.2.3   && <0.3
-    , random            >=0       && <1.2
+      random            >=0       && <1.2
     , transformers
 
 benchmark set-benchmarks
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        Set.hs
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6     && <5
-    , containers-tests
-    , deepseq           >=1.1.0.0 && <1.5
-    , gauge             >=0.2.3   && <0.3
 
 benchmark set-operations-intmap
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
   main-is:        SetOperations-IntMap.hs
   other-modules:  SetOperations
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6   && <5
-    , containers-tests
-    , gauge             >=0.2.3 && <0.3
 
 benchmark set-operations-intset
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
   main-is:        SetOperations-IntSet.hs
   other-modules:  SetOperations
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6   && <5
-    , containers-tests
-    , gauge             >=0.2.3 && <0.3
 
 benchmark set-operations-map
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
   main-is:        SetOperations-Map.hs
   other-modules:  SetOperations
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6   && <5
-    , containers-tests
-    , gauge             >=0.2.3 && <0.3
 
 benchmark set-operations-set
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
   main-is:        SetOperations-Set.hs
   other-modules:  SetOperations
   ghc-options:    -O2
-  build-depends:
-      base              >=4.6   && <5
-    , containers-tests
-    , gauge             >=0.2.3 && <0.3
 
 benchmark lookupge-intmap
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/LookupGE
   main-is:        IntMap.hs
   other-modules:  LookupGE_IntMap
   build-depends:  containers-tests
-  build-depends:
-      base     >=4.6     && <5
-    , deepseq  >=1.1.0.0 && <1.5
-    , gauge    >=0.2.3   && <0.3
 
 benchmark lookupge-map
+  import: benchmark-deps
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/LookupGE
@@ -237,10 +223,6 @@ benchmark lookupge-map
   other-modules:  LookupGE_Map
   build-depends:  containers-tests
   ghc-options:    -O2
-  build-depends:
-      base     >=4.6     && <5
-    , deepseq  >=1.1.0.0 && <1.5
-    , gauge    >=0.2.3   && <0.3
 
 -------------------
 -- T E S T I N G --
@@ -250,90 +232,52 @@ benchmark lookupge-map
 -- plus the testing stuff.
 
 test-suite map-lazy-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-properties.hs
   type:             exitcode-stdio-1.0
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , transformers
-
 test-suite map-strict-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-properties.hs
   type:             exitcode-stdio-1.0
   cpp-options:      -DSTRICT
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , transformers
-
 test-suite bitqueue-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          bitqueue-properties.hs
   type:             exitcode-stdio-1.0
-  build-depends:    base >=4.6 && <5
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:    containers-tests
-  build-depends:
-      tasty
-    , tasty-quickcheck
-
 test-suite set-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          set-properties.hs
   type:             exitcode-stdio-1.0
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
-
-  build-depends:    containers-tests
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-    , transformers
 
   if impl(ghc >= 8.6)
     build-depends:
@@ -342,134 +286,77 @@ test-suite set-properties
       Utils.NoThunks
 
 test-suite intmap-lazy-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-properties.hs
   type:             exitcode-stdio-1.0
   other-modules:    IntMapValidity
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-
 test-suite intmap-strict-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-properties.hs
   type:             exitcode-stdio-1.0
   cpp-options:      -DSTRICT
   other-modules:    IntMapValidity
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:    containers-tests
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-
 test-suite intset-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intset-properties.hs
   type:             exitcode-stdio-1.0
   other-modules:    IntSetValidity
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:    containers-tests
-  build-depends:
-      tasty
-    , tasty-hunit
-    , tasty-quickcheck
-
 test-suite seq-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          seq-properties.hs
   type:             exitcode-stdio-1.0
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
-    , transformers
-
 test-suite tree-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          tree-properties.hs
   type:             exitcode-stdio-1.0
-  build-depends:    containers-tests
-  build-depends:
-      array    >=0.4.0.0
-    , base     >=4.6     && <5
-    , deepseq  >=1.2     && <1.5
 
   ghc-options:      -O2
   other-extensions:
     BangPatterns
     CPP
 
-  build-depends:
-      QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
-    , transformers
-
 test-suite map-strictness-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-strictness.hs
   type:             exitcode-stdio-1.0
-  build-depends:    containers-tests
   build-depends:
-      array                       >=0.4.0.0
-    , base                        >=4.6     && <5
-    , ChasingBottoms
-    , deepseq                     >=1.2     && <1.5
-    , QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
-    , tasty-hunit
+      ChasingBottoms
 
   ghc-options:      -Wall
   other-extensions:
@@ -486,6 +373,7 @@ test-suite map-strictness-properties
       Utils.NoThunks
 
 test-suite intmap-strictness-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-strictness.hs
@@ -494,16 +382,8 @@ test-suite intmap-strictness-properties
     BangPatterns
     CPP
 
-  build-depends:    containers-tests
   build-depends:
-      array                       >=0.4.0.0
-    , base                        >=4.6     && <5
-    , ChasingBottoms
-    , deepseq                     >=1.2     && <1.5
-    , QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
-    , tasty-hunit
+      ChasingBottoms
 
   ghc-options:      -Wall
 
@@ -517,6 +397,7 @@ test-suite intmap-strictness-properties
       Utils.NoThunks
 
 test-suite intset-strictness-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intset-strictness.hs
@@ -525,15 +406,8 @@ test-suite intset-strictness-properties
     BangPatterns
     CPP
 
-  build-depends:    containers-tests
   build-depends:
-      array                       >=0.4.0.0
-    , base                        >=4.6     && <5
-    , ChasingBottoms
-    , deepseq                     >=1.2     && <1.5
-    , QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
+      ChasingBottoms
 
   ghc-options:      -Wall
 
@@ -544,17 +418,12 @@ test-suite intset-strictness-properties
       Utils.NoThunks
 
 test-suite listutils-properties
+  import: test-deps
   default-language: Haskell2010
   hs-source-dirs: tests
   main-is:        listutils-properties.hs
   type:           exitcode-stdio-1.0
-  build-depends:  containers-tests
   build-depends:
-      base                        >=4.6   && <5
-    , ChasingBottoms
-    , deepseq                     >=1.2   && <1.5
-    , QuickCheck                  >=2.7.1
-    , tasty
-    , tasty-quickcheck
+      ChasingBottoms
 
   ghc-options:    -Wall

--- a/containers-tests/tests/bitqueue-properties.hs
+++ b/containers-tests/tests/bitqueue-properties.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
 import qualified Data.List as List
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -131,10 +131,8 @@ main = defaultMain $ testGroup "intmap-properties"
              , testCase "maxView" test_maxView
              , testCase "minViewWithKey" test_minViewWithKey
              , testCase "maxViewWithKey" test_maxViewWithKey
-#if MIN_VERSION_base(4,8,0)
              , testCase "minimum" test_minimum
              , testCase "maximum" test_maximum
-#endif
              , testProperty "valid"                prop_valid
              , testProperty "empty valid"          prop_emptyValid
              , testProperty "insert to singleton"  prop_singleton
@@ -1110,8 +1108,6 @@ test_maxViewWithKey = do
     maxViewWithKey (fromList [(5,"a"), (-3,"b")]) @?= Just ((5,"a"), singleton (-3) "b")
     maxViewWithKey (empty :: SMap) @?= Nothing
 
-
-#if MIN_VERSION_base(4,8,0)
 test_minimum :: Assertion
 test_minimum = do
     getOW (minimum testOrdMap) @?= "min"
@@ -1132,8 +1128,6 @@ data OrdWith a = OrdWith String a
 
 instance Ord a => Ord (OrdWith a) where
     OrdWith _ a1 <= OrdWith _ a2 = a1 <= a2
-#endif
-
 
 ----------------------------------------------------------------
 -- Valid IntMaps

--- a/containers-tests/tests/intset-strictness.hs
+++ b/containers-tests/tests/intset-strictness.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# OPTIONS_GHC -Wno-orphans #-}
-#endif
 module Main (main) where
 
 import Prelude hiding (foldl)

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -25,9 +25,7 @@ import Data.Functor ((<$>), (<$))
 import Data.Maybe
 import Data.Function (on)
 import Data.Monoid (Monoid(..), All(..), Endo(..), Dual(..))
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (stimes, stimesMonoid)
-#endif
 import Data.Traversable (Traversable(traverse), sequenceA)
 import Prelude hiding (
   lookup, null, length, take, drop, splitAt,
@@ -144,17 +142,13 @@ main = defaultMain $ testGroup "seq-properties"
        , testProperty "intersperse" prop_intersperse
        , testProperty ">>=" prop_bind
        , testProperty "mfix" test_mfix
-#if __GLASGOW_HASKELL__ >= 800
        , testProperty "Empty pattern" prop_empty_pat
        , testProperty "Empty constructor" prop_empty_con
        , testProperty "Left view pattern" prop_viewl_pat
        , testProperty "Left view constructor" prop_viewl_con
        , testProperty "Right view pattern" prop_viewr_pat
        , testProperty "Right view constructor" prop_viewr_con
-#endif
-#if MIN_VERSION_base(4,9,0)
        , testProperty "stimes" prop_stimes
-#endif
        ]
 
 ------------------------------------------------------------------------
@@ -594,21 +588,13 @@ prop_sortOn :: Fun A OrdB -> Seq A -> Bool
 prop_sortOn (Fun _ f) xs =
     toList' (sortOn f xs) ~= listSortOn f (toList xs)
   where
-#if MIN_VERSION_base(4,8,0)
     listSortOn = Data.List.sortOn
-#else
-    listSortOn k = Data.List.sortBy (compare `on` k)
-#endif
 
 prop_sortOnStable :: Fun A UnstableOrd -> Seq A -> Bool
 prop_sortOnStable (Fun _ f) xs =
     toList' (sortOn f xs) ~= listSortOn f (toList xs)
   where
-#if MIN_VERSION_base(4,8,0)
     listSortOn = Data.List.sortOn
-#else
-    listSortOn k = Data.List.sortBy (compare `on` k)
-#endif
 
 prop_unstableSort :: Seq OrdA -> Bool
 prop_unstableSort xs =
@@ -857,7 +843,6 @@ prop_cycleTaking :: Int -> Seq A -> Property
 prop_cycleTaking n xs =
     (n <= 0 || not (null xs)) ==> toList' (cycleTaking n xs) ~= Data.List.take n (Data.List.cycle (toList xs))
 
-#if __GLASGOW_HASKELL__ >= 800
 prop_empty_pat :: Seq A -> Bool
 prop_empty_pat xs@Empty = null xs
 prop_empty_pat xs = not (null xs)
@@ -882,7 +867,6 @@ prop_viewr_pat xs = property $ null xs
 
 prop_viewr_con :: Seq A -> A -> Property
 prop_viewr_con xs x = xs :|> x === xs |> x
-#endif
 
 -- Monad operations
 
@@ -892,11 +876,9 @@ prop_bind xs (Fun _ f) =
 
 -- Semigroup operations
 
-#if MIN_VERSION_base(4,9,0)
 prop_stimes :: NonNegative Int -> Seq A -> Property
 prop_stimes (NonNegative n) s =
   stimes n s === stimesMonoid n s
-#endif
 
 -- MonadFix operation
 

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -15,9 +15,6 @@ import Control.Monad.Trans.Class
 import Control.Monad (liftM, liftM3)
 import Data.Functor.Identity
 import Data.Foldable (all)
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative (..), (<$>))
-#endif
 import Control.Applicative (liftA2)
 
 #if __GLASGOW_HASKELL__ >= 806

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -1,5 +1,12 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
 
+## FIXME
+
+* Drop support for GHC versions before 8.0.2.
+
+* Bump Cabal version for tests, and use `common` clauses to reduce
+  duplication.
+
 ## 0.6.5.1
 
 ### Bug fixes

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -25,7 +25,7 @@ extra-source-files:
     include/containers.h
     changelog.md
 
-tested-with: GHC==9.2.1, GHC==9.0.1, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3
+tested-with: GHC==9.2.1, GHC==9.0.1, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 source-repository head
     type:     git
@@ -33,7 +33,7 @@ source-repository head
 
 Library
     default-language: Haskell2010
-    build-depends: base >= 4.6 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5
+    build-depends: base >= 4.9.1 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5
     hs-source-dirs: src
     ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 

--- a/containers/include/containers.h
+++ b/containers/include/containers.h
@@ -12,24 +12,7 @@
 #include "MachDeps.h"
 #endif
 
-/*
- * Define INSTANCE_TYPEABLE[0-2]
- */
-#if __GLASGOW_HASKELL__ >= 707
-#define INSTANCE_TYPEABLE0(tycon) deriving instance Typeable tycon
-#define INSTANCE_TYPEABLE1(tycon) deriving instance Typeable tycon
-#define INSTANCE_TYPEABLE2(tycon) deriving instance Typeable tycon
-#elif defined(__GLASGOW_HASKELL__)
-#define INSTANCE_TYPEABLE0(tycon) deriving instance Typeable tycon
-#define INSTANCE_TYPEABLE1(tycon) deriving instance Typeable1 tycon
-#define INSTANCE_TYPEABLE2(tycon) deriving instance Typeable2 tycon
-#else
-#define INSTANCE_TYPEABLE0(tycon)
-#define INSTANCE_TYPEABLE1(tycon)
-#define INSTANCE_TYPEABLE2(tycon)
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800
+#ifdef __GLASGOW_HASKELL__
 #define DEFINE_PATTERN_SYNONYMS 1
 #endif
 

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -4,11 +4,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
-# if __GLASGOW_HASKELL__ >= 710
 {-# LANGUAGE Safe #-}
-# else
-{-# LANGUAGE Trustworthy #-}
-# endif
 #endif
 
 #include "containers.h"
@@ -107,12 +103,7 @@ import Data.Tree (Tree(Node), Forest)
 
 -- std interfaces
 import Control.Applicative
-#if !MIN_VERSION_base(4,8,0)
-import qualified Data.Foldable as F
-import Data.Traversable
-#else
 import Data.Foldable as F
-#endif
 import Control.DeepSeq (NFData(rnf))
 import Data.Maybe
 import Data.Array
@@ -123,16 +114,13 @@ import Data.Array.Unboxed ( UArray )
 import qualified Data.Array as UA
 #endif
 import qualified Data.List as L
-#if MIN_VERSION_base(4,9,0)
 import Data.Functor.Classes
-#endif
-#if (!MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup (..))
 #endif
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics (Generic, Generic1)
 import Data.Data (Data)
-import Data.Typeable
 #endif
 
 -- Make sure we don't use Integer by mistake.
@@ -158,8 +146,6 @@ data SCC vertex = AcyclicSCC vertex     -- ^ A single vertex that is not
   deriving (Eq, Show, Read)
 #endif
 
-INSTANCE_TYPEABLE1(SCC)
-
 #ifdef __GLASGOW_HASKELL__
 -- | @since 0.5.9
 deriving instance Data vertex => Data (SCC vertex)
@@ -171,7 +157,6 @@ deriving instance Generic1 SCC
 deriving instance Generic (SCC vertex)
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 -- | @since 0.5.9
 instance Eq1 SCC where
   liftEq eq (AcyclicSCC v1) (AcyclicSCC v2) = eq v1 v2
@@ -186,7 +171,6 @@ instance Read1 SCC where
   liftReadsPrec rp rl = readsData $
     readsUnaryWith rp "AcyclicSCC" AcyclicSCC <>
     readsUnaryWith (const rl) "CyclicSCC" CyclicSCC
-#endif
 
 -- | @since 0.5.9
 instance F.Foldable SCC where

--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -3,9 +3,8 @@
 {-# LANGUAGE Safe #-}
 #endif
 #ifdef __GLASGOW_HASKELL__
-{-# LANGUAGE DataKinds, FlexibleContexts #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 #endif
 

--- a/containers/src/Data/IntMap/Merge/Lazy.hs
+++ b/containers/src/Data/IntMap/Merge/Lazy.hs
@@ -1,19 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-#if __GLASGOW_HASKELL__
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
-#endif
 #if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Safe #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeFamilies #-}
-#define USE_MAGIC_PROXY 1
-#endif
-
-#if USE_MAGIC_PROXY
-{-# LANGUAGE MagicHash #-}
 #endif
 
 #include "containers.h"

--- a/containers/src/Data/IntMap/Merge/Strict.hs
+++ b/containers/src/Data/IntMap/Merge/Strict.hs
@@ -1,19 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
-#if __GLASGOW_HASKELL__
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
-#endif
 #if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Trustworthy #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeFamilies #-}
-#define USE_MAGIC_PROXY 1
-#endif
-
-#if USE_MAGIC_PROXY
-{-# LANGUAGE MagicHash #-}
 #endif
 
 #include "containers.h"
@@ -112,9 +100,6 @@ import Data.IntMap.Internal
   , runWhenMissing
   )
 import Data.IntMap.Strict.Internal
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative (..), (<$>))
-#endif
 import Prelude hiding (filter, map, foldl, foldr)
 
 -- | Map covariantly over a @'WhenMissing' f k x@.

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -345,14 +345,8 @@ import Data.IntMap.Internal.DeprecatedDebug (showTree, showTreeWith)
 import qualified Data.IntSet.Internal as IntSet
 import Utils.Containers.Internal.BitUtil
 import Utils.Containers.Internal.StrictPair
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor((<$>))
-#endif
 import Control.Applicative (Applicative (..), liftA2)
 import qualified Data.Foldable as Foldable
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable())
-#endif
 
 {--------------------------------------------------------------------
   Query

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
-#if __GLASGOW_HASKELL__
-{-# LANGUAGE MagicHash, DeriveDataTypeable, StandaloneDeriving #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeFamilies #-}
 #endif
 #if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Trustworthy #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE TypeFamilies #-}
 #endif
 
 {-# OPTIONS_HADDOCK not-home #-}
@@ -193,20 +191,11 @@ import Control.DeepSeq (NFData(rnf))
 import Data.Bits
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-import Data.Word (Word)
-#endif
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(stimes))
-#endif
-#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+#if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup((<>)))
 #endif
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (stimesIdempotentMonoid)
-#endif
-import Data.Typeable
 import Prelude hiding (filter, foldr, foldl, null, map)
 
 import Utils.Containers.Internal.BitUtil
@@ -220,17 +209,13 @@ import Text.Read
 
 #if __GLASGOW_HASKELL__
 import qualified GHC.Exts
-#if !(MIN_VERSION_base(4,8,0) && (WORD_SIZE_IN_BITS==64))
+#if !(WORD_SIZE_IN_BITS==64)
 import qualified GHC.Int
 #endif
 #endif
 
 import qualified Data.Foldable as Foldable
-#if MIN_VERSION_base(4,8,0)
 import Data.Functor.Identity (Identity(..))
-#else
-import Data.Foldable (Foldable())
-#endif
 
 infixl 9 \\{-This comment teaches CPP correct behaviour -}
 
@@ -286,16 +271,12 @@ type Key    = Int
 instance Monoid IntSet where
     mempty  = empty
     mconcat = unions
-#if !(MIN_VERSION_base(4,9,0))
-    mappend = union
-#else
     mappend = (<>)
 
 -- | @since 0.5.7
 instance Semigroup IntSet where
     (<>)    = union
     stimes  = stimesIdempotentMonoid
-#endif
 
 #if __GLASGOW_HASKELL__
 
@@ -541,9 +522,7 @@ alterF f k s = fmap choose (f member_)
  #-}
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 {-# SPECIALIZE alterF :: (Bool -> Identity Bool) -> Key -> IntSet -> Identity IntSet #-}
-#endif
 
 {--------------------------------------------------------------------
   Union
@@ -1055,7 +1034,8 @@ elems
 {--------------------------------------------------------------------
   Lists
 --------------------------------------------------------------------}
-#if __GLASGOW_HASKELL__ >= 708
+
+#ifdef __GLASGOW_HASKELL__
 -- | @since 0.5.6.2
 instance GHC.Exts.IsList IntSet where
   type Item IntSet = Key
@@ -1244,12 +1224,6 @@ instance Read IntSet where
 #endif
 
 {--------------------------------------------------------------------
-  Typeable
---------------------------------------------------------------------}
-
-INSTANCE_TYPEABLE0(IntSet)
-
-{--------------------------------------------------------------------
   NFData
 --------------------------------------------------------------------}
 
@@ -1375,11 +1349,7 @@ tip kx bm = Tip kx bm
 ----------------------------------------------------------------------}
 
 suffixBitMask :: Int
-#if MIN_VERSION_base(4,7,0)
 suffixBitMask = finiteBitSize (undefined::Word) - 1
-#else
-suffixBitMask = bitSize (undefined::Word) - 1
-#endif
 {-# INLINE suffixBitMask #-}
 
 prefixBitMask :: Int
@@ -1474,7 +1444,7 @@ foldr'Bits :: Int -> (Int -> a -> a) -> a -> Nat -> a
 #if defined(__GLASGOW_HASKELL__) && (WORD_SIZE_IN_BITS==32 || WORD_SIZE_IN_BITS==64)
 indexOfTheOnlyBit :: Nat -> Int
 {-# INLINE indexOfTheOnlyBit #-}
-#if MIN_VERSION_base(4,8,0) && (WORD_SIZE_IN_BITS==64)
+#if WORD_SIZE_IN_BITS==64
 indexOfTheOnlyBit bitmask = countTrailingZeros bitmask
 
 lowestBitSet x = countTrailingZeros x

--- a/containers/src/Data/Map/Merge/Lazy.hs
+++ b/containers/src/Data/Map/Merge/Lazy.hs
@@ -1,19 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-#if __GLASGOW_HASKELL__
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
-#endif
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#if defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Safe #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeFamilies #-}
-#define USE_MAGIC_PROXY 1
-#endif
-
-#if USE_MAGIC_PROXY
-{-# LANGUAGE MagicHash #-}
 #endif
 
 #include "containers.h"

--- a/containers/src/Data/Map/Merge/Strict.hs
+++ b/containers/src/Data/Map/Merge/Strict.hs
@@ -1,19 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-#if __GLASGOW_HASKELL__
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
-#endif
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#if defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Safe #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 708
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeFamilies #-}
-#define USE_MAGIC_PROXY 1
-#endif
-
-#if USE_MAGIC_PROXY
-{-# LANGUAGE MagicHash #-}
 #endif
 
 #include "containers.h"

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -299,7 +299,7 @@ module Data.Map.Strict.Internal
     , maxViewWithKey
 
     -- * Debugging
-#if defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
     , showTree
     , showTreeWith
 #endif
@@ -329,9 +329,7 @@ import Data.Map.Internal
   , (\\)
   , assocs
   , atKeyImpl
-#if MIN_VERSION_base(4,8,0)
   , atKeyPlain
-#endif
   , balance
   , balanceL
   , balanceR
@@ -415,26 +413,20 @@ import Data.Map.Internal.DeprecatedShowTree (showTree, showTreeWith)
 import Data.Map.Internal.Debug (valid)
 
 import Control.Applicative (Const (..), liftA3)
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative (..), (<$>))
-#endif
 import qualified Data.Set.Internal as Set
 import qualified Data.Map.Internal as L
 import Utils.Containers.Internal.StrictPair
 
 import Data.Bits (shiftL, shiftR)
-#if __GLASGOW_HASKELL__ >= 709
+#ifdef __GLASGOW_HASKELL__
 import Data.Coerce
 #endif
 
-#if __GLASGOW_HASKELL__ && MIN_VERSION_base(4,8,0)
+#ifdef __GLASGOW_HASKELL__
 import Data.Functor.Identity (Identity (..))
 #endif
 
 import qualified Data.Foldable as Foldable
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable())
-#endif
 
 -- $strictness
 --
@@ -872,18 +864,12 @@ alterF f k m = atKeyImpl Strict k f m
 -- `Control.Applicative.Const` and just doing a lookup.
 {-# RULES
 "alterF/Const" forall k (f :: Maybe a -> Const b (Maybe a)) . alterF f k = \m -> Const . getConst . f $ lookup k m
- #-}
-#if MIN_VERSION_base(4,8,0)
--- base 4.8 and above include Data.Functor.Identity, so we can
--- save a pretty decent amount of time by handling it specially.
-{-# RULES
 "alterF/Identity" forall k f . alterF f k = atKeyIdentity k f
  #-}
 
 atKeyIdentity :: Ord k => k -> (Maybe a -> Identity (Maybe a)) -> Map k a -> Identity (Map k a)
 atKeyIdentity k f t = Identity $ atKeyPlain Strict k (coerce f) t
 {-# INLINABLE atKeyIdentity #-}
-#endif
 #endif
 
 {--------------------------------------------------------------------

--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -67,7 +67,7 @@
 module Data.Set (
             -- * Set type
 #if !defined(TESTING)
-              Set          -- instance Eq,Ord,Show,Read,Data,Typeable
+              Set          -- instance Eq,Ord,Show,Read,Data
 #else
               Set(..)
 #endif

--- a/containers/src/Utils/Containers/Internal/BitQueue.hs
+++ b/containers/src/Utils/Containers/Internal/BitQueue.hs
@@ -44,22 +44,9 @@ module Utils.Containers.Internal.BitQueue
     , toListQ
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Word (Word)
-#endif
 import Utils.Containers.Internal.BitUtil (shiftLL, shiftRL, wordSize)
 import Data.Bits ((.|.), (.&.), testBit)
-#if MIN_VERSION_base(4,8,0)
 import Data.Bits (countTrailingZeros)
-#else
-import Data.Bits (popCount)
-#endif
-
-#if !MIN_VERSION_base(4,8,0)
-countTrailingZeros :: Word -> Int
-countTrailingZeros x = popCount ((x .&. (-x)) - 1)
-{-# INLINE countTrailingZeros #-}
-#endif
 
 -- A bit queue builder. We represent a double word using two words
 -- because we don't currently have access to proper double words.

--- a/containers/src/Utils/Containers/Internal/BitUtil.hs
+++ b/containers/src/Utils/Containers/Internal/BitUtil.hs
@@ -38,23 +38,10 @@ module Utils.Containers.Internal.BitUtil
     , wordSize
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Bits ((.|.), xor)
-#endif
 import Data.Bits (popCount, unsafeShiftL, unsafeShiftR
-#if MIN_VERSION_base(4,8,0)
-    , countLeadingZeros
-#endif
+    , countLeadingZeros, finiteBitSize
     )
-#if MIN_VERSION_base(4,7,0)
-import Data.Bits (finiteBitSize)
-#else
-import Data.Bits (bitSize)
-#endif
 
-#if !MIN_VERSION_base (4,8,0)
-import Data.Word (Word)
-#endif
 
 {----------------------------------------------------------------------
   [bitcount] as posted by David F. Place to haskell-cafe on April 11, 2006,
@@ -78,21 +65,7 @@ bitcount a x = a + popCount x
 
 -- | Return a word where only the highest bit is set.
 highestBitMask :: Word -> Word
-#if MIN_VERSION_base(4,8,0)
 highestBitMask w = shiftLL 1 (wordSize - 1 - countLeadingZeros w)
-#else
-highestBitMask x1 = let x2 = x1 .|. x1 `shiftRL` 1
-                        x3 = x2 .|. x2 `shiftRL` 2
-                        x4 = x3 .|. x3 `shiftRL` 4
-                        x5 = x4 .|. x4 `shiftRL` 8
-                        x6 = x5 .|. x5 `shiftRL` 16
-#if !(defined(__GLASGOW_HASKELL__) && WORD_SIZE_IN_BITS==32)
-                        x7 = x6 .|. x6 `shiftRL` 32
-                     in x7 `xor` (x7 `shiftRL` 1)
-#else
-                     in x6 `xor` (x6 `shiftRL` 1)
-#endif
-#endif
 {-# INLINE highestBitMask #-}
 
 -- Right and left logical shifts.
@@ -102,8 +75,4 @@ shiftLL = unsafeShiftL
 
 {-# INLINE wordSize #-}
 wordSize :: Int
-#if MIN_VERSION_base(4,7,0)
 wordSize = finiteBitSize (0 :: Word)
-#else
-wordSize = bitSize (0 :: Word)
-#endif

--- a/containers/src/Utils/Containers/Internal/Coercions.hs
+++ b/containers/src/Utils/Containers/Internal/Coercions.hs
@@ -5,12 +5,12 @@
 
 module Utils.Containers.Internal.Coercions where
 
-#if __GLASGOW_HASKELL__ >= 708
+#ifdef __GLASGOW_HASKELL__
 import Data.Coerce
 #endif
 
 infixl 8 .#
-#if __GLASGOW_HASKELL__ >= 708
+#ifdef __GLASGOW_HASKELL__
 (.#) :: Coercible b a => (b -> c) -> (a -> b) -> a -> c
 (.#) f _ = coerce f
 #else
@@ -34,7 +34,7 @@ infix 9 .^#
 -- @
 --   foldl f b . fmap g = foldl (f .^# g) b
 -- @
-#if __GLASGOW_HASKELL__ >= 708
+#ifdef __GLASGOW_HASKELL__
 (.^#) :: Coercible c b => (a -> c -> d) -> (b -> c) -> (a -> b -> d)
 (.^#) f _ = coerce f
 #else

--- a/containers/src/Utils/Containers/Internal/PtrEquality.hs
+++ b/containers/src/Utils/Containers/Internal/PtrEquality.hs
@@ -11,11 +11,7 @@ module Utils.Containers.Internal.PtrEquality (ptrEq, hetPtrEq) where
 #ifdef __GLASGOW_HASKELL__
 import GHC.Exts ( reallyUnsafePtrEquality# )
 import Unsafe.Coerce ( unsafeCoerce )
-#if __GLASGOW_HASKELL__ < 707
-import GHC.Exts ( (==#) )
-#else
 import GHC.Exts ( Int#, isTrue# )
-#endif
 #endif
 
 -- | Checks if two pointers are equal. Yes means yes;
@@ -30,13 +26,8 @@ ptrEq :: a -> a -> Bool
 hetPtrEq :: a -> b -> Bool
 
 #ifdef __GLASGOW_HASKELL__
-#if __GLASGOW_HASKELL__ < 707
-ptrEq x y = reallyUnsafePtrEquality# x y ==# 1#
-hetPtrEq x y = unsafeCoerce reallyUnsafePtrEquality# x y ==# 1#
-#else
 ptrEq x y = isTrue# (reallyUnsafePtrEquality# x y)
 hetPtrEq x y = isTrue# (unsafeCoerce (reallyUnsafePtrEquality# :: x -> x -> Int#) x y)
-#endif
 
 #else
 -- Not GHC

--- a/containers/src/Utils/Containers/Internal/State.hs
+++ b/containers/src/Utils/Containers/Internal/State.hs
@@ -5,13 +5,7 @@
 -- | A clone of Control.Monad.State.Strict.
 module Utils.Containers.Internal.State where
 
-import Prelude hiding (
-#if MIN_VERSION_base(4,8,0)
-    Applicative
-#endif
-    )
-
-import Control.Monad (ap)
+import Control.Monad (ap, liftM2)
 import Control.Applicative (Applicative(..), liftA)
 
 newtype State s a = State {runState :: s -> (s, a)}
@@ -30,6 +24,11 @@ instance Applicative (State s) where
     {-# INLINE pure #-}
     pure x = State $ \ s -> (s, x)
     (<*>) = ap
+    m *> n = State $ \s -> case runState m s of
+      (s', _) -> runState n s'
+#if MIN_VERSION_base(4,10,0)
+    liftA2 = liftM2
+#endif
 
 execState :: State s a -> s -> a
 execState m x = snd (runState m x)

--- a/containers/src/Utils/Containers/Internal/StrictMaybe.hs
+++ b/containers/src/Utils/Containers/Internal/StrictMaybe.hs
@@ -7,11 +7,6 @@
 
 module Utils.Containers.Internal.StrictMaybe (MaybeS (..), maybeS, toMaybe, toMaybeS) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable (..))
-import Data.Monoid (Monoid (..))
-#endif
-
 data MaybeS a = NothingS | JustS !a
 
 instance Foldable MaybeS where

--- a/containers/src/Utils/Containers/Internal/TypeError.hs
+++ b/containers/src/Utils/Containers/Internal/TypeError.hs
@@ -2,11 +2,7 @@
      KindSignatures, TypeFamilies, CPP #-}
 
 #if !defined(TESTING)
-# if __GLASGOW_HASKELL__ >= 710
 {-# LANGUAGE Safe #-}
-# else
-{-# LANGUAGE Trustworthy #-}
-#endif
 #endif
 
 -- | Unsatisfiable constraints for functions being removed.
@@ -14,11 +10,9 @@
 module Utils.Containers.Internal.TypeError where
 import GHC.TypeLits
 
--- | The constraint @Whoops s@ is unsatisfiable for every 'Symbol' @s@.
--- Under GHC 8.0 and above, trying to use a function with a @Whoops s@
--- constraint will lead to a pretty type error explaining how to fix
--- the problem. Under earlier GHC versions, it will produce an extremely
--- ugly type error within which the desired message is buried.
+-- | The constraint @Whoops s@ is unsatisfiable for every 'Symbol' @s@.  Trying
+-- to use a function with a @Whoops s@ constraint will lead to a pretty type
+-- error explaining how to fix the problem.
 --
 -- ==== Example
 --
@@ -28,9 +22,7 @@ import GHC.TypeLits
 -- @
 class Whoops (a :: Symbol)
 
-#if __GLASGOW_HASKELL__ >= 800
 instance TypeError ('Text a) => Whoops a
-#endif
 
 -- Why don't we just use
 --


### PR DESCRIPTION
* Raise minimum GHC version to 8.0 so we'll be able to define
  `Lift` instances, avoid certain conditional definitions, etc.

* Raise Cabal version for tests to 2.2; use `common` stanzas.