### PR TITLE
Add Lift instances

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -37,6 +37,7 @@ common deps
       array    >=0.4.0.0
     , base     >=4.9.1   && <5
     , deepseq  >=1.2     && <1.5
+    , template-haskell
 
 common test-deps
   import: deps

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -7,6 +7,11 @@
 * Bump Cabal version for tests, and use `common` clauses to reduce
   duplication.
 
+### New instances
+
+* `Data.Sequence` now offers `Lift` instances for `Seq`, `ViewL`, and `ViewR`
+  for use with Template Haskell.
+
 ## 0.6.5.1
 
 ### Bug fixes

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -9,8 +9,9 @@
 
 ### New instances
 
-* `Data.Sequence` now offers `Lift` instances for `Seq`, `ViewL`, and `ViewR`
-  for use with Template Haskell.
+* Add `Lift` instances for use with Template Haskell. Specifically:
+  `Seq`, `ViewL`, and `ViewR` (in `Data.Sequence`), `Map`, `Set`,
+  `IntMap`, `IntSet`, `Tree`, and `SCC` (in `Data.Graph`).
 
 ## 0.6.5.1
 

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -33,7 +33,7 @@ source-repository head
 
 Library
     default-language: Haskell2010
-    build-depends: base >= 4.9.1 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5
+    build-depends: base >= 4.9.1 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5, template-haskell
     hs-source-dirs: src
     ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -3,8 +3,13 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE StandaloneDeriving #-}
+#  if __GLASGOW_HASKELL__ >= 802
 {-# LANGUAGE Safe #-}
+#  else
+{-# LANGUAGE Trustworthy #-}
+#  endif
 #endif
 
 #include "containers.h"
@@ -121,6 +126,7 @@ import Data.Semigroup (Semigroup (..))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics (Generic, Generic1)
 import Data.Data (Data)
+import Language.Haskell.TH.Syntax (Lift)
 #endif
 
 -- Make sure we don't use Integer by mistake.
@@ -155,6 +161,9 @@ deriving instance Generic1 SCC
 
 -- | @since 0.5.9
 deriving instance Generic (SCC vertex)
+
+-- | @since FIXME
+deriving instance Lift vertex => Lift (SCC vertex)
 #endif
 
 -- | @since 0.5.9

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
 #ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -319,6 +320,7 @@ import Data.Data (Data(..), Constr, mkConstr, constrIndex, Fixity(Prefix),
 import GHC.Exts (build)
 import qualified GHC.Exts as GHCExts
 import Text.Read
+import Language.Haskell.TH.Syntax (Lift)
 #endif
 import qualified Control.Category as Category
 
@@ -368,6 +370,9 @@ type Mask   = Int
 -- 'withoutKeys' to use.
 type IntSetPrefix = Int
 type IntSetBitMap = Word
+
+-- | @since FIXME
+deriving instance Lift a => Lift (IntMap a)
 
 bitmapOf :: Int -> IntSetBitMap
 bitmapOf x = shiftLL 1 (x .&. IntSet.suffixBitMask)

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
 #ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 #endif
 #if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
@@ -209,9 +211,10 @@ import Text.Read
 
 #if __GLASGOW_HASKELL__
 import qualified GHC.Exts
-#if !(WORD_SIZE_IN_BITS==64)
+#  if !(WORD_SIZE_IN_BITS==64)
 import qualified GHC.Int
-#endif
+#  endif
+import Language.Haskell.TH.Syntax (Lift)
 #endif
 
 import qualified Data.Foldable as Foldable
@@ -267,6 +270,11 @@ type Prefix = Int
 type Mask   = Int
 type BitMap = Word
 type Key    = Int
+
+#ifdef __GLASGOW_HASKELL__
+-- | @since FIXME
+deriving instance Lift IntSet
+#endif
 
 instance Monoid IntSet where
     mempty  = empty

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
 #if defined(__GLASGOW_HASKELL__)
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 #endif
@@ -393,6 +395,7 @@ import Utils.Containers.Internal.BitUtil (wordSize)
 
 #if __GLASGOW_HASKELL__
 import GHC.Exts (build, lazy)
+import Language.Haskell.TH.Syntax (Lift)
 #  ifdef USE_MAGIC_PROXY
 import GHC.Exts (Proxy#, proxy# )
 #  endif
@@ -460,6 +463,11 @@ type Size     = Int
 
 #ifdef __GLASGOW_HASKELL__
 type role Map nominal representational
+#endif
+
+#ifdef __GLASGOW_HASKELL__
+-- | @since FIXME
+deriving instance (Lift k, Lift a) => Lift (Map k a)
 #endif
 
 instance (Ord k) => Monoid (Map k v) where

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -4,18 +4,20 @@
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 #endif
 #ifdef DEFINE_PATTERN_SYNONYMS
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 #endif
 {-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
@@ -223,8 +225,7 @@ import Text.Read (Lexeme(Ident), lexP, parens, prec,
     readPrec, readListPrec, readListPrecDefault)
 import Data.Data
 import Data.String (IsString(..))
-#endif
-#if __GLASGOW_HASKELL__
+import qualified Language.Haskell.TH.Syntax as TH
 import GHC.Generics (Generic, Generic1)
 #endif
 
@@ -338,6 +339,41 @@ instance Sized (ForceBox a) where
 
 -- | General-purpose finite sequences.
 newtype Seq a = Seq (FingerTree (Elem a))
+
+#ifdef __GLASGOW_HASKELL__
+-- | @since 0.7
+instance TH.Lift a => TH.Lift (Seq a) where
+#  if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped t = [|| coerceFT z ||]
+#  else
+  lift t = [| coerceFT z |]
+#  endif
+    where
+      -- We rebalance the sequence to use only 3-nodes before lifting its
+      -- underlying finger tree. This should minimize the size and depth of the
+      -- tree generated at run-time. It also reduces the size of the splice,
+      -- but I don't know how that affects the size of the resulting Core once
+      -- all the types are added.
+      Seq ft = zipWith (flip const) (replicate (length t) ()) t
+
+      -- We remove the 'Elem' constructors to reduce the size of the splice
+      -- and the number of types and coercions in the generated Core. Instead
+      -- of, say,
+      --
+      --   Seq (Deep 3 (Two (Elem 1) (Elem 2)) EmptyT (One (Elem 3)))
+      --
+      -- we generate
+      --
+      --   coerceFT (Deep 3 (Two 1 2)) EmptyT (One 3)
+      z :: FingerTree a
+      z = coerce ft
+
+-- | We use this to help the types work out for splices in the
+-- Lift instance. Things get a bit yucky otherwise.
+coerceFT :: FingerTree a -> Seq a
+coerceFT = coerce
+
+#endif
 
 instance Functor Seq where
     fmap = fmapSeq
@@ -974,6 +1010,8 @@ deriving instance Generic1 FingerTree
 
 -- | @since 0.6.1
 deriving instance Generic (FingerTree a)
+
+deriving instance TH.Lift a => TH.Lift (FingerTree a)
 #endif
 
 instance Sized a => Sized (FingerTree a) where
@@ -1165,6 +1203,8 @@ deriving instance Generic1 Digit
 
 -- | @since 0.6.1
 deriving instance Generic (Digit a)
+
+deriving instance TH.Lift a => TH.Lift (Digit a)
 #endif
 
 foldDigit :: (b -> b -> b) -> (a -> b) -> Digit a -> b
@@ -1266,6 +1306,8 @@ deriving instance Generic1 Node
 
 -- | @since 0.6.1
 deriving instance Generic (Node a)
+
+deriving instance TH.Lift a => TH.Lift (Node a)
 #endif
 
 foldNode :: (b -> b -> b) -> (a -> b) -> Node a -> b
@@ -2131,6 +2173,9 @@ deriving instance Generic1 ViewL
 
 -- | @since 0.5.8
 deriving instance Generic (ViewL a)
+
+-- | @since 0.7
+deriving instance TH.Lift a => TH.Lift (ViewL a)
 #endif
 
 instance Functor ViewL where
@@ -2195,6 +2240,9 @@ deriving instance Generic1 ViewR
 
 -- | @since 0.5.8
 deriving instance Generic (ViewR a)
+
+-- | @since 0.7
+deriving instance TH.Lift a => TH.Lift (ViewR a)
 #endif
 
 instance Functor ViewR where

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -341,7 +341,7 @@ instance Sized (ForceBox a) where
 newtype Seq a = Seq (FingerTree (Elem a))
 
 #ifdef __GLASGOW_HASKELL__
--- | @since 0.7
+-- | @since FIXME
 instance TH.Lift a => TH.Lift (Seq a) where
 #  if MIN_VERSION_template_haskell(2,16,0)
   liftTyped t = [|| coerceFT z ||]
@@ -2174,7 +2174,7 @@ deriving instance Generic1 ViewL
 -- | @since 0.5.8
 deriving instance Generic (ViewL a)
 
--- | @since 0.7
+-- | @since FIXME
 deriving instance TH.Lift a => TH.Lift (ViewL a)
 #endif
 
@@ -2241,7 +2241,7 @@ deriving instance Generic1 ViewR
 -- | @since 0.5.8
 deriving instance Generic (ViewR a)
 
--- | @since 0.7
+-- | @since FIXME
 deriving instance TH.Lift a => TH.Lift (ViewR a)
 #endif
 

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 #ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 #endif
 
@@ -250,6 +252,7 @@ import qualified GHC.Exts as GHCExts
 import Text.Read ( readPrec, Read (..), Lexeme (..), parens, prec
                  , lexP, readListPrecDefault )
 import Data.Data
+import Language.Haskell.TH.Syntax (Lift)
 #endif
 
 
@@ -279,6 +282,9 @@ type Size     = Int
 #ifdef __GLASGOW_HASKELL__
 type role Set nominal
 #endif
+
+-- | @since FIXME
+deriving instance Lift a => Lift (Set a)
 
 instance Ord a => Monoid (Set a) where
     mempty  = empty

--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -3,6 +3,7 @@
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE Trustworthy #-}
 #endif
 
@@ -62,6 +63,7 @@ import Control.DeepSeq (NFData(rnf))
 #ifdef __GLASGOW_HASKELL__
 import Data.Data (Data)
 import GHC.Generics (Generic, Generic1)
+import Language.Haskell.TH.Syntax (Lift)
 #endif
 
 import Control.Monad.Zip (MonadZip (..))
@@ -88,6 +90,7 @@ data Tree a = Node {
            , Data
            , Generic  -- ^ @since 0.5.8
            , Generic1 -- ^ @since 0.5.8
+           , Lift -- ^ @since FIXME
            )
 #else
   deriving (Eq, Ord, Read, Show)


### PR DESCRIPTION
* `Data.Sequence`: Add `Lift` instances for `Seq`, `ViewL`, and `ViewR`. The `Seq` instance
tries to be a bit clever about the shape of the resulting tree and the
size of the splice; everything else is straightforward.
* Others: Add `Lift` instances for `Data.IntMap.IntMap`, `Data.IntSet.IntSet`, `Data.Map.Map`, `Data.Set.Set`,
`Data.Tree.Tree`, and `Data.Graph.SCC`.