### PR TITLE
Fix mention of `foldl'` in Haddocks of `unions`/`unionsWith`

### DIFF
--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -1773,7 +1773,7 @@ maxView t = case maxViewWithKey t of
   Union.
 --------------------------------------------------------------------}
 -- | The union of a list of maps:
---   (@'unions' == 'Prelude.foldl' 'union' 'empty'@).
+--   (@'unions' == 'Foldable.foldl'' 'union' 'empty'@).
 --
 -- > unions [(fromList [(5, "a"), (3, "b")]), (fromList [(5, "A"), (7, "C")]), (fromList [(5, "A3"), (3, "B3")])]
 -- >     == fromList [(3, "b"), (5, "a"), (7, "C")]
@@ -1788,7 +1788,7 @@ unions ts
 #endif
 
 -- | The union of a list of maps, with a combining operation:
---   (@'unionsWith' f == 'Prelude.foldl' ('unionWith' f) 'empty'@).
+--   (@'unionsWith' f == 'Foldable.foldl'' ('unionWith' f) 'empty'@).
 --
 -- > unionsWith (++) [(fromList [(5, "a"), (3, "b")]), (fromList [(5, "A"), (7, "C")]), (fromList [(5, "A3"), (3, "B3")])]
 -- >     == fromList [(3, "bB3"), (5, "aAA3"), (7, "C")]

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -953,7 +953,7 @@ updateMaxWithKey f (Bin _ kx x l r)    = balanceL kx x l (updateMaxWithKey f r)
 --------------------------------------------------------------------}
 
 -- | The union of a list of maps, with a combining operation:
---   (@'unionsWith' f == 'Prelude.foldl' ('unionWith' f) 'empty'@).
+--   (@'unionsWith' f == 'Foldable.foldl'' ('unionWith' f) 'empty'@).
 --
 -- > unionsWith (++) [(fromList [(5, "a"), (3, "b")]), (fromList [(5, "A"), (7, "C")]), (fromList [(5, "A3"), (3, "B3")])]
 -- >     == fromList [(3, "bB3"), (5, "aAA3"), (7, "C")]

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -800,7 +800,7 @@ deleteMax Tip             = Tip
 {--------------------------------------------------------------------
   Union.
 --------------------------------------------------------------------}
--- | The union of the sets in a Foldable structure : (@'unions' == 'foldl' 'union' 'empty'@).
+-- | The union of the sets in a Foldable structure : (@'unions' == 'Foldable.foldl'' 'union' 'empty'@).
 unions :: (Foldable f, Ord a) => f (Set a) -> Set a
 unions = Foldable.foldl' union empty
 #if __GLASGOW_HASKELL__


### PR DESCRIPTION
Tiny documentation fix, was confused by this for a split second today 😆 

Before:
![2022-04-25_21-50](https://user-images.githubusercontent.com/15369874/165163958-0b0a4416-deab-47ef-9b10-a2dd86ea5295.png)
After:
![2022-04-25_21-50_1](https://user-images.githubusercontent.com/15369874/165163961-49865b34-546f-4017-92c0-e200d736fc4f.png)
