### PR TITLE
Prepare for liftA2 being exported from Prelude

### DIFF
--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -35,7 +35,10 @@ Library
     default-language: Haskell2010
     build-depends: base >= 4.9.1 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5, template-haskell
     hs-source-dirs: src
-    ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+    -- -fno-warn-unused-imports is turned off right now because it generates warnings which are painful to deal with
+    -- in a backwards compatible way. See https://github.com/haskell/containers/pull/841#issuecomment-1186732698
+    -- for more details
+    ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fno-warn-unused-imports
 
     other-extensions: CPP, BangPatterns
 


### PR DESCRIPTION
CLC has approved the proposal to export `liftA2` from `Prelude`
(https://github.com/haskell/core-libraries-committee/issues/50).

This is a PR to future proof for that change, while minimising warnings.