### PR TITLE
Prepare for liftA2 being exposed in the Prelude

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.0.20220523
+            compilerKind: ghc
+            compilerVersion: 9.4.0.20220523
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.2.2
             compilerKind: ghc
             compilerVersion: 9.2.2
@@ -82,6 +87,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -122,7 +128,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -151,6 +157,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -208,6 +226,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(binary|containers|containers-tests|ghc-heap|text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -109,6 +109,7 @@ library
       Utils.NoThunks
 
   other-modules:
+    Prelude
     Utils.Containers.Internal.Coercions
     Utils.Containers.Internal.PtrEquality
     Utils.Containers.Internal.State

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -26,7 +26,7 @@ extra-source-files:
   benchmarks/LookupGE/*.hs
 
 tested-with:
-  GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.2
+  GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.2 || ==9.4.1
 
 source-repository head
   type:     git

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -71,6 +71,7 @@ Library
         Utils.Containers.Internal.StrictPair
 
     other-modules:
+        Prelude
         Utils.Containers.Internal.State
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -25,7 +25,7 @@ extra-source-files:
     include/containers.h
     changelog.md
 
-tested-with: GHC==9.2.2, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
+tested-with: GHC==9.4.1, GHC==9.2.2, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 source-repository head
     type:     git

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -107,7 +107,6 @@ import qualified Data.IntSet as Set
 import Data.Tree (Tree(Node), Forest)
 
 -- std interfaces
-import Control.Applicative
 import Data.Foldable as F
 import Control.DeepSeq (NFData(rnf))
 import Data.Maybe

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -294,7 +294,6 @@ module Data.IntMap.Internal (
     ) where
 
 import Data.Functor.Identity (Identity (..))
-import Control.Applicative (liftA2)
 import Data.Semigroup (Semigroup(stimes))
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup((<>)))

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -345,7 +345,6 @@ import Data.IntMap.Internal.DeprecatedDebug (showTree, showTreeWith)
 import qualified Data.IntSet.Internal as IntSet
 import Utils.Containers.Internal.BitUtil
 import Utils.Containers.Internal.StrictPair
-import Control.Applicative (Applicative (..), liftA2)
 import qualified Data.Foldable as Foldable
 
 {--------------------------------------------------------------------

--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -250,7 +250,6 @@ import Data.Sequence.Internal.Sorting
 import Prelude ()
 #ifdef __HADDOCK_VERSION__
 import Control.Monad (Monad (..))
-import Control.Applicative (Applicative (..))
 import Data.Functor (Functor (..))
 #endif
 

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -199,12 +199,12 @@ import Prelude hiding (
 #if MIN_VERSION_base(4,11,0)
     (<>),
 #endif
-    Applicative, (<$>), foldMap, Monoid,
+    (<$>), foldMap, Monoid,
     null, length, lookup, take, drop, splitAt, foldl, foldl1, foldr, foldr1,
     scanl, scanl1, scanr, scanr1, replicate, zip, zipWith, zip3, zipWith3,
     unzip, takeWhile, dropWhile, iterate, reverse, filter, mapM, sum, all)
-import Control.Applicative (Applicative(..), (<$>), (<**>),  Alternative,
-                            liftA2, liftA3)
+import Control.Applicative ((<$>), (<**>),  Alternative,
+                            liftA3)
 import qualified Control.Applicative as Applicative
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad (MonadPlus(..))

--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -53,7 +53,6 @@ module Data.Tree(
     ) where
 
 import Data.Foldable (toList)
-import Control.Applicative (Applicative(..), liftA2)
 import Control.Monad (liftM)
 import Control.Monad.Fix (MonadFix (..), fix)
 import Data.Sequence (Seq, empty, singleton, (<|), (|>), fromList,

--- a/containers/src/Prelude.hs
+++ b/containers/src/Prelude.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
+-- | This hideous module lets us avoid dealing with the fact that
+-- @liftA2@ wasn't previously exported from the standard prelude.
+module Prelude
+  ( module Prel
+  , Applicative (..)
+#if !MIN_VERSION_base(4,10,0)
+  , liftA2
+#endif
+  )
+  where
+
+import "base" Prelude as Prel
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative(Applicative(..))
+#endif
+
+#if !MIN_VERSION_base(4,10,0)
+import Control.Applicative(liftA2)
+#endif

--- a/containers/src/Utils/Containers/Internal/State.hs
+++ b/containers/src/Utils/Containers/Internal/State.hs
@@ -6,7 +6,7 @@
 module Utils.Containers.Internal.State where
 
 import Control.Monad (ap, liftM2)
-import Control.Applicative (Applicative(..), liftA)
+import Control.Applicative (liftA)
 
 newtype State s a = State {runState :: s -> (s, a)}
 


### PR DESCRIPTION
*  Use a private `Prelude` temporarily to deal with warnings arising
   from the fact that `liftA2` hasn't always been exposed in the
   `Prelude`. Other approaches seemed to involve too much CPP or
   required disabling redundant import warnings, which we really don't
   want.

* Update CI to test with GHC 9.4 and head.

* Hopefully fix strict fold tests.