### PR TITLE
Avoid a redundant export

### DIFF
--- a/containers/src/Prelude.hs
+++ b/containers/src/Prelude.hs
@@ -4,7 +4,9 @@
 -- @liftA2@ wasn't previously exported from the standard prelude.
 module Prelude
   ( module Prel
+#if !MIN_VERSION_base(4,18,0)
   , Applicative (..)
+#endif
 #if !MIN_VERSION_base(4,10,0)
   , liftA2
 #endif


### PR DESCRIPTION
Avoid a redundant export

I don't see a warning, but it seems a bit silly to export
`Applicative (..)` explicitly from the custom prelude when
`base >= 4.18.0`. Let's not.