### PR TITLE
Use less cpp and don't rely on base version for liftA2 comaptibility

### DIFF
--- a/containers/src/Prelude.hs
+++ b/containers/src/Prelude.hs
@@ -4,19 +4,15 @@
 -- @liftA2@ wasn't previously exported from the standard prelude.
 module Prelude
   ( module Prel
-#if !MIN_VERSION_base(4,18,0)
   , Applicative (..)
-#endif
 #if !MIN_VERSION_base(4,10,0)
   , liftA2
 #endif
   )
   where
 
-import "base" Prelude as Prel
-#if !MIN_VERSION_base(4,18,0)
+import "base" Prelude as Prel hiding (Applicative(..))
 import Control.Applicative(Applicative(..))
-#endif
 
 #if !MIN_VERSION_base(4,10,0)
 import Control.Applicative(liftA2)


### PR DESCRIPTION
Relying on base version should work fine, once `base` is bumped. But it currently isn't, causing warnings (again) when compiling ghc. To this end, we can employ this solution, which both avoids this issue, as well as uses less CPP. 