### PR TITLE
Fix build paths in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 *.swo
 *.tix
 .hpc/
-/dist/*
-/dist-newstyle/*
+**/dist/*
+**/dist-newstyle/*
 GNUmakefile
 dist-install
 ghc.mk


### PR DESCRIPTION
Current .gitignore isn't matching these dirs
```
containers-tests/dist-newstyle/
containers-tests/dist/
containers/dist-newstyle/
containers/dist/
```