### PR TITLE
Add insertWith and fromListWith functions to handle repetitions

### DIFF
--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -76,6 +76,7 @@ module Data.Set (
             , empty
             , singleton
             , fromList
+            , fromListWith
             , fromAscList
             , fromDescList
             , fromDistinctAscList
@@ -84,6 +85,7 @@ module Data.Set (
 
             -- * Insertion
             , insert
+            , insertWith
 
             -- * Deletion
             , delete


### PR DESCRIPTION
I wanted to use `Data.Set` in my script due to its performance. However, when creating a set from a list, I wanted to control the clashes between the entries that my `Eq` instance would catch, not just replace the old one with the new one.

The following example can be extended to records, for instance:

```haskell
data MyTuple = MyTuple Int Int
  deriving Show

instance Eq MyTuple where
  (MyTuple i1 i2) == (MyTuple i3 i4) = i1 == i3

instance Ord MyTuple where
  (MyTuple i1 i2) <= (MyTuple i3 i4) = i1 <= i3

example :: IO ()
example =
  let l1 =  [MyTuple 1 1, MyTuple 1 2, MyTuple 3 3]
  in print $ fromListWith (\(MyTuple f1 s1) (MyTuple f2 s2) -> MyTuple f1 (s1 + s2)) l1
```

The idea is to allow the user to control what will happen if a conflict happens when traversing the existing list or set. So, the function `insertWith` does that for sets and `fromListWith` does that for lists that will become sets.