### PR TITLE
Faster disjoint/isSubsetOf for Set via unbalanced splitting.

### DIFF
--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -36,6 +36,8 @@ main = do
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even
         , bench "disjoint:true" $ whnf (S.disjoint s_odd) s_even
+        , bench "isSubsetOf:true" $ whnf (s_even `S.isSubsetOf`) s
+        , bench "isSubsetOf:false" $ whnf (s_even `S.isSubsetOf`) s_odd
         , bench "null.intersection:false" $ whnf (S.null. S.intersection s) s_even
         , bench "null.intersection:true" $ whnf (S.null. S.intersection s_odd) s_even
         , bench "alterF:member" $ whnf (alterF_member elems) s


### PR DESCRIPTION
Unlike, say, `union`/`intersection`, `disjoint` doesn't return a new structure. It can avoid the re-balancing work because it immediately inspects and forgets the produced tree. This allows significant constant factor speedups.

```All
  member:                    OK (0.14s)
    133  μs ±  12 μs,   0 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  insert:                    OK (0.18s)
    678  μs ±  47 μs, 2.6 MB allocated,  55 KB copied, 8.0 MB peak memory,       same as baseline
  map:                       OK (0.22s)
    106  μs ± 6.0 μs, 557 KB allocated,  16 KB copied, 8.0 MB peak memory,       same as baseline
  filter:                    OK (0.17s)
    80.2 μs ± 6.4 μs,  80 KB allocated, 1.2 KB copied, 8.0 MB peak memory,       same as baseline
  partition:                 OK (0.16s)
    148  μs ±  15 μs, 239 KB allocated, 4.0 KB copied, 8.0 MB peak memory,       same as baseline
  fold:                      OK (0.31s)
    34.9 ns ± 1.5 ns, 695 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  delete:                    OK (0.12s)
    454  μs ±  44 μs, 1.3 MB allocated, 372 B  copied, 8.0 MB peak memory,       same as baseline
  findMin:                   OK (0.27s)
    15.7 ns ± 784 ps,  31 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  findMax:                   OK (0.30s)
    17.1 ns ± 842 ps,  31 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  deleteMin:                 OK (0.25s)
    114  ns ± 7.0 ns, 471 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  deleteMax:                 OK (0.25s)
    117  ns ± 7.0 ns, 511 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  unions:                    OK (0.31s)
    147  μs ± 7.2 μs, 472 KB allocated,  10 KB copied, 8.0 MB peak memory,       same as baseline
  union:                     OK (0.16s)
    148  μs ±  11 μs, 467 KB allocated,  10 KB copied, 8.0 MB peak memory,       same as baseline
  difference:                OK (0.21s)
    102  μs ± 7.2 μs, 239 KB allocated, 2.4 KB copied, 8.0 MB peak memory,       same as baseline
  intersection:              OK (0.20s)
    49.8 μs ± 3.5 μs,  80 KB allocated, 835 B  copied, 8.0 MB peak memory,       same as baseline
  fromList:                  OK (0.28s)
    67.4 μs ± 4.2 μs, 271 KB allocated, 6.9 KB copied, 8.0 MB peak memory,       same as baseline
  fromList-desc:             OK (0.30s)
    600  μs ±  25 μs, 2.6 MB allocated,  56 KB copied, 8.0 MB peak memory,       same as baseline
  fromAscList:               OK (0.27s)
    127  μs ± 8.9 μs, 414 KB allocated, 8.3 KB copied, 8.0 MB peak memory,       same as baseline
  fromDistinctAscList:       OK (0.21s)
    50.2 μs ± 2.9 μs, 159 KB allocated, 3.2 KB copied, 8.0 MB peak memory,       same as baseline
  disjoint:false:            OK (0.22s)
    24.9 ns ± 1.7 ns,  31 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  disjoint:true:             OK (0.12s)
    111  μs ±  10 μs, 153 KB allocated,  61 B  copied, 8.0 MB peak memory, 23% less than baseline
  isSubsetOf:true:           OK (0.16s)
    18.6 μs ± 1.6 μs,   0 B  allocated,   0 B  copied, 8.0 MB peak memory,       same as baseline
  isSubsetOf:false:          OK (0.43s)
    100  ns ± 4.6 ns, 463 B  allocated,   0 B  copied, 8.0 MB peak memory, 63% less than baseline
  null.intersection:false:   OK (0.21s)
    49.5 μs ± 3.6 μs,  80 KB allocated, 834 B  copied, 8.0 MB peak memory,       same as baseline
  null.intersection:true:    OK (0.15s)
    154  μs ±  13 μs, 293 KB allocated, 174 B  copied, 8.0 MB peak memory,       same as baseline
  alterF:member:             OK (0.21s)
    801  μs ±  48 μs, 2.4 MB allocated, 402 B  copied, 8.0 MB peak memory,       same as baseline
  alterF:insert:             OK (0.23s)
    864  μs ±  52 μs, 3.6 MB allocated, 106 KB copied, 8.0 MB peak memory,       same as baseline
  alterF:delete:             OK (0.14s)
    536  μs ±  46 μs, 1.9 MB allocated, 432 B  copied, 8.0 MB peak memory,       same as baseline
  alterF:four:               OK (0.20s)
    813  μs ±  74 μs, 2.4 MB allocated, 388 B  copied, 8.0 MB peak memory,       same as baseline
  alterF:four:strings:       OK (0.22s)
    1.68 ms ± 120 μs, 2.5 MB allocated, 413 B  copied, 8.0 MB peak memory,       same as baseline
  alterF_naive:four:         OK (0.17s)
    1.39 ms ±  88 μs, 2.0 MB allocated, 327 B  copied, 8.0 MB peak memory,       same as baseline
  alterF_naive:four:strings: OK (0.27s)
    4.16 ms ± 351 μs, 2.1 MB allocated, 397 B  copied, 8.0 MB peak memory,       same as baseline

All 32 tests passed (7.14s)
Benchmark set-benchmarks: FINISH
```