### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -3504,7 +3504,7 @@ showsBars :: [String] -> ShowS
 showsBars bars
   = case bars of
       [] -> id
-      _  -> showString (concat (reverse (tail bars))) . showString node
+      _ : tl -> showString (concat (reverse tl)) . showString node
 
 node :: String
 node = "+--"

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1299,7 +1299,7 @@ showWide wide bars
 
 showsBars :: [String] -> ShowS
 showsBars [] = id
-showsBars bars = showString (concat (reverse (tail bars))) . showString node
+showsBars (_ : tl) = showString (concat (reverse tl)) . showString node
 
 showsBitMap :: Word -> ShowS
 showsBitMap = showString . showBitMap

--- a/containers/src/Data/Map/Internal/Debug.hs
+++ b/containers/src/Data/Map/Internal/Debug.hs
@@ -91,7 +91,7 @@ showsBars :: [String] -> ShowS
 showsBars bars
   = case bars of
       [] -> id
-      _  -> showString (concat (reverse (tail bars))) . showString node
+      _ : tl -> showString (concat (reverse tl)) . showString node
 
 node :: String
 node           = "+--"

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1977,7 +1977,7 @@ showsBars :: [String] -> ShowS
 showsBars bars
   = case bars of
       [] -> id
-      _  -> showString (concat (reverse (tail bars))) . showString node
+      _ : tl -> showString (concat (reverse tl)) . showString node
 
 node :: String
 node           = "+--"


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates all usages of `head` and `tail` in `containers`. They are confined to a couple of debug functions, so should not have any effect on performance or semantics.