### PR TITLE
Add antitone functions for IntSet and IntMap

### DIFF
--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -50,6 +50,7 @@ main = do
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
         , bench "minView" $ whnf (maybe 0 (\((k,v), m) -> k+v+M.size m) . M.minViewWithKey)
                     (M.fromList $ zip [1..10] [1..10])
+        , bench "spanAntitone" $ whnf (M.spanAntitone (<key_mid)) m
         ]
   where
     elems = elems_hits
@@ -64,6 +65,7 @@ main = do
     keys'' = fmap (* 2) [1..2^12]
     mixedKeys = interleave keys keys'
     values = [1..2^12]
+    key_mid = 2^11
     --------------------------------------------------------
     sum k v1 v2 = k + v1 + v2
     consPair k v xs = (k, v) : xs

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -19,7 +19,8 @@ main = do
     let s = IS.fromAscList elems :: IS.IntSet
         s_even = IS.fromAscList elems_even :: IS.IntSet
         s_odd = IS.fromAscList elems_odd :: IS.IntSet
-    evaluate $ rnf [s, s_even, s_odd]
+        s_sparse = IS.fromAscList elems_sparse :: IS.IntSet
+    evaluate $ rnf [s, s_even, s_odd, s_sparse]
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) IS.empty
@@ -47,11 +48,16 @@ main = do
           $ whnf (num_transitions . det 2 0) $ hard_nfa    1 16
         , bench "instanceOrd:sparse" -- many Bin, each Tip is singleton
           $ whnf (num_transitions . det 2 0) $ hard_nfa 1111 16
+        , bench "spanAntitone:dense" $ whnf (IS.spanAntitone (<key_mid)) s
+        , bench "spanAntitone:sparse" $ whnf (IS.spanAntitone (<key_sparse_mid)) s_sparse
         ]
   where
     elems = [1..2^12]
     elems_even = [2,4..2^12]
     elems_odd = [1,3..2^12]
+    key_mid = 2^11
+    elems_sparse = map (*64) elems -- when built into a map, each Tip is a singleton
+    key_sparse_mid = 64 * key_mid
 
 member :: [Int] -> IS.IntSet -> Int
 member xs s = foldl' (\n x -> if IS.member x s then n + 1 else n) 0 xs

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -48,16 +48,16 @@ main = do
           $ whnf (num_transitions . det 2 0) $ hard_nfa    1 16
         , bench "instanceOrd:sparse" -- many Bin, each Tip is singleton
           $ whnf (num_transitions . det 2 0) $ hard_nfa 1111 16
-        , bench "spanAntitone:dense" $ whnf (IS.spanAntitone (<key_mid)) s
-        , bench "spanAntitone:sparse" $ whnf (IS.spanAntitone (<key_sparse_mid)) s_sparse
+        , bench "spanAntitone:dense" $ whnf (IS.spanAntitone (<elem_mid)) s
+        , bench "spanAntitone:sparse" $ whnf (IS.spanAntitone (<elem_sparse_mid)) s_sparse
         ]
   where
     elems = [1..2^12]
     elems_even = [2,4..2^12]
     elems_odd = [1,3..2^12]
-    key_mid = 2^11
+    elem_mid = 2^11
     elems_sparse = map (*64) elems -- when built into a map, each Tip is a singleton
-    key_sparse_mid = 64 * key_mid
+    elem_sparse_mid = 64 * elem_mid
 
 member :: [Int] -> IS.IntSet -> Int
 member xs s = foldl' (\n x -> if IS.member x s then n + 1 else n) 0 xs

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -180,6 +180,9 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "deleteMax"            prop_deleteMaxModel
              , testProperty "filter"               prop_filter
              , testProperty "partition"            prop_partition
+             , testProperty "takeWhileAntitone"    prop_takeWhileAntitone
+             , testProperty "dropWhileAntitone"    prop_dropWhileAntitone
+             , testProperty "spanAntitone"         prop_spanAntitone
              , testProperty "map"                  prop_map
              , testProperty "fmap"                 prop_fmap
              , testProperty "mapkeys"              prop_mapkeys
@@ -1468,6 +1471,26 @@ prop_partition p ys = length ys > 0 ==>
       valid r .&&.
       m === let (a,b) = (List.partition (apply p . snd) xs)
             in (fromList a, fromList b)
+
+prop_takeWhileAntitone :: Int -> [(Int, Int)] -> Property
+prop_takeWhileAntitone x ys =
+  let l = takeWhileAntitone (<x) (fromList ys)
+  in  valid l .&&.
+      l === fromList (List.filter ((<x) . fst) ys)
+
+prop_dropWhileAntitone :: Int -> [(Int, Int)] -> Property
+prop_dropWhileAntitone x ys =
+  let r = dropWhileAntitone (<x) (fromList ys)
+  in  valid r .&&.
+      r === fromList (List.filter ((>=x) . fst) ys)
+
+prop_spanAntitone :: Int -> [(Int, Int)] -> Property
+prop_spanAntitone x ys =
+  let (l, r) = spanAntitone (<x) (fromList ys)
+  in  valid l .&&.
+      valid r .&&.
+      l === fromList (List.filter ((<x) . fst) ys) .&&.
+      r === fromList (List.filter ((>=x) . fst) ys)
 
 prop_map :: Fun Int Int -> [(Int, Int)] -> Property
 prop_map f ys = length ys > 0 ==>

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -70,6 +70,9 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_splitRoot" prop_splitRoot
                    , testProperty "prop_partition" prop_partition
                    , testProperty "prop_filter" prop_filter
+                   , testProperty "takeWhileAntitone" prop_takeWhileAntitone
+                   , testProperty "dropWhileAntitone" prop_dropWhileAntitone
+                   , testProperty "spanAntitone" prop_spanAntitone
                    , testProperty "prop_bitcount" prop_bitcount
                    , testProperty "prop_alterF_list" prop_alterF_list
                    , testProperty "prop_alterF_const" prop_alterF_const
@@ -419,6 +422,26 @@ prop_filter s i =
   in valid odds .&&.
      valid evens .&&.
      parts === (odds, evens)
+
+prop_takeWhileAntitone :: Int -> [Int] -> Property
+prop_takeWhileAntitone x ys =
+  let l = takeWhileAntitone (<x) (fromList ys)
+  in  valid l .&&.
+      l === fromList (List.filter (<x) ys)
+
+prop_dropWhileAntitone :: Int -> [Int] -> Property
+prop_dropWhileAntitone x ys =
+  let r = dropWhileAntitone (<x) (fromList ys)
+  in  valid r .&&.
+      r === fromList (List.filter (>=x) ys)
+
+prop_spanAntitone :: Int -> [Int] -> Property
+prop_spanAntitone x ys =
+  let (l, r) = spanAntitone (<x) (fromList ys)
+  in  valid l .&&.
+      valid r .&&.
+      l === fromList (List.filter (<x) ys) .&&.
+      r === fromList (List.filter (>=x) ys)
 
 prop_bitcount :: Int -> Word -> Bool
 prop_bitcount a w = bitcount_orig a w == bitcount_new a w

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -2631,15 +2631,15 @@ partitionWithKey predicate0 t0 = toPair $ go predicate0 t0
 takeWhileAntitone :: (Key -> Bool) -> IntMap a -> IntMap a
 takeWhileAntitone predicate t =
   case t of
-    Bin _ m l r
+    Bin p m l r
       | m < 0 ->
         if predicate 0 -- handle negative numbers.
-        then union r (go predicate l)
+        then bin p m (go predicate l) r
         else go predicate r
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = union l (go predicate' r)
+      | predicate' (p .|. m) = bin p m l (go predicate' r)
       | otherwise            = go predicate' l
     go predicate' t'@(Tip ky _)
       | predicate' ky = t'
@@ -2659,16 +2659,16 @@ takeWhileAntitone predicate t =
 dropWhileAntitone :: (Key -> Bool) -> IntMap a -> IntMap a
 dropWhileAntitone predicate t =
   case t of
-    Bin _ m l r
+    Bin p m l r
       | m < 0 ->
         if predicate 0 -- handle negative numbers.
         then go predicate l
-        else union (go predicate r) l
+        else bin p m l (go predicate r)
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
       | predicate' (p .|. m) = go predicate' r
-      | otherwise            = union (go predicate' l) r
+      | otherwise            = bin p m (go predicate' l) r
     go predicate' t'@(Tip ky _)
       | predicate' ky = Nil
       | otherwise     = t'
@@ -2689,25 +2689,25 @@ dropWhileAntitone predicate t =
 spanAntitone :: (Key -> Bool) -> IntMap a -> (IntMap a, IntMap a)
 spanAntitone predicate t =
   case t of
-    Bin _ m l r
+    Bin p m l r
       | m < 0 ->
         if predicate 0 -- handle negative numbers.
         then
           case go predicate l of
             (lt :*: gt) ->
-              let !lt' = union r lt
+              let !lt' = bin p m lt r
               in (lt', gt)
         else
           case go predicate r of
             (lt :*: gt) ->
-              let !gt' = union gt l
+              let !gt' = bin p m l gt
               in (lt, gt')
     _ -> case go predicate t of
           (lt :*: gt) -> (lt, gt)
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = case go predicate' r of (lt :*: gt) -> union l lt :*: gt
-      | otherwise            = case go predicate' l of (lt :*: gt) -> lt :*: union gt r
+      | predicate' (p .|. m) = case go predicate' r of (lt :*: gt) -> bin p m l lt :*: gt
+      | otherwise            = case go predicate' l of (lt :*: gt) -> lt :*: bin p m gt r
     go predicate' t'@(Tip ky _)
       | predicate' ky = (t' :*: Nil)
       | otherwise     = (Nil :*: t')

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -2639,8 +2639,8 @@ takeWhileAntitone predicate t =
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = bin p m l (go predicate' r)
-      | otherwise            = go predicate' l
+      | predicate' $! p+m = bin p m l (go predicate' r)
+      | otherwise         = go predicate' l
     go predicate' t'@(Tip ky _)
       | predicate' ky = t'
       | otherwise     = Nil
@@ -2667,8 +2667,8 @@ dropWhileAntitone predicate t =
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = go predicate' r
-      | otherwise            = bin p m (go predicate' l) r
+      | predicate' $! p+m = go predicate' r
+      | otherwise         = bin p m (go predicate' l) r
     go predicate' t'@(Tip ky _)
       | predicate' ky = Nil
       | otherwise     = t'
@@ -2706,8 +2706,8 @@ spanAntitone predicate t =
           (lt :*: gt) -> (lt, gt)
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = case go predicate' r of (lt :*: gt) -> bin p m l lt :*: gt
-      | otherwise            = case go predicate' l of (lt :*: gt) -> lt :*: bin p m gt r
+      | predicate' $! p+m = case go predicate' r of (lt :*: gt) -> bin p m l lt :*: gt
+      | otherwise         = case go predicate' l of (lt :*: gt) -> lt :*: bin p m gt r
     go predicate' t'@(Tip ky _)
       | predicate' ky = (t' :*: Nil)
       | otherwise     = (Nil :*: t')

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -228,6 +228,10 @@ module Data.IntMap.Internal (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -2613,6 +2617,101 @@ partitionWithKey predicate0 t0 = toPair $ go predicate0 t0
           | predicate k x -> (t :*: Nil)
           | otherwise     -> (Nil :*: t)
         Nil -> (Nil :*: Nil)
+
+-- | \(O(\min(n,W))\). Take while a predicate on the keys holds.
+-- The user is responsible for ensuring that for all @Int@s, @j \< k ==\> p j \>= p k@.
+-- See note at 'spanAntitone'.
+--
+-- @
+-- takeWhileAntitone p = 'fromDistinctAscList' . 'Data.List.takeWhile' (p . fst) . 'toList'
+-- takeWhileAntitone p = 'filterWithKey' (\\k _ -> p k)
+-- @
+--
+-- @since FIXME
+takeWhileAntitone :: (Key -> Bool) -> IntMap a -> IntMap a
+takeWhileAntitone predicate t =
+  case t of
+    Bin _ m l r
+      | m < 0 ->
+        if predicate 0 -- handle negative numbers.
+        then union r (go predicate l)
+        else go predicate r
+    _ -> go predicate t
+  where
+    go predicate' (Bin p m l r)
+      | predicate' (p .|. m) = union l (go predicate' r)
+      | otherwise            = go predicate' l
+    go predicate' t'@(Tip ky _)
+      | predicate' ky = t'
+      | otherwise     = Nil
+    go _ Nil = Nil
+
+-- | \(O(\min(n,W))\). Drop while a predicate on the keys holds.
+-- The user is responsible for ensuring that for all @Int@s, @j \< k ==\> p j \>= p k@.
+-- See note at 'spanAntitone'.
+--
+-- @
+-- dropWhileAntitone p = 'fromDistinctAscList' . 'Data.List.dropWhile' (p . fst) . 'toList'
+-- dropWhileAntitone p = 'filterWithKey' (\\k _ -> not (p k))
+-- @
+--
+-- @since FIXME
+dropWhileAntitone :: (Key -> Bool) -> IntMap a -> IntMap a
+dropWhileAntitone predicate t =
+  case t of
+    Bin _ m l r
+      | m < 0 ->
+        if predicate 0 -- handle negative numbers.
+        then go predicate l
+        else union (go predicate r) l
+    _ -> go predicate t
+  where
+    go predicate' (Bin p m l r)
+      | predicate' (p .|. m) = go predicate' r
+      | otherwise            = union (go predicate' l) r
+    go predicate' t'@(Tip ky _)
+      | predicate' ky = Nil
+      | otherwise     = t'
+    go _ Nil = Nil
+
+-- | \(O(\min(n,W))\). Divide a map at the point where a predicate on the keys stops holding.
+-- The user is responsible for ensuring that for all @Int@s, @j \< k ==\> p j \>= p k@.
+--
+-- @
+-- spanAntitone p xs = ('takeWhileAntitone' p xs, 'dropWhileAntitone' p xs)
+-- spanAntitone p xs = 'partitionWithKey' (\\k _ -> p k) xs
+-- @
+--
+-- Note: if @p@ is not actually antitone, then @spanAntitone@ will split the map
+-- at some /unspecified/ point.
+--
+-- @since FIXME
+spanAntitone :: (Key -> Bool) -> IntMap a -> (IntMap a, IntMap a)
+spanAntitone predicate t =
+  case t of
+    Bin _ m l r
+      | m < 0 ->
+        if predicate 0 -- handle negative numbers.
+        then
+          case go predicate l of
+            (lt :*: gt) ->
+              let !lt' = union r lt
+              in (lt', gt)
+        else
+          case go predicate r of
+            (lt :*: gt) ->
+              let !gt' = union gt l
+              in (lt, gt')
+    _ -> case go predicate t of
+          (lt :*: gt) -> (lt, gt)
+  where
+    go predicate' (Bin p m l r)
+      | predicate' (p .|. m) = case go predicate' r of (lt :*: gt) -> union l lt :*: gt
+      | otherwise            = case go predicate' l of (lt :*: gt) -> lt :*: union gt r
+    go predicate' t'@(Tip ky _)
+      | predicate' ky = (t' :*: Nil)
+      | otherwise     = (Nil :*: t')
+    go _ Nil = (Nil :*: Nil)
 
 -- | \(O(n)\). Map values and collect the 'Just' results.
 --

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -198,6 +198,10 @@ module Data.IntMap.Lazy (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -217,6 +217,10 @@ module Data.IntMap.Strict (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -217,6 +217,10 @@ module Data.IntMap.Strict.Internal (
     , partition
     , partitionWithKey
 
+    , takeWhileAntitone
+    , dropWhileAntitone
+    , spanAntitone
+
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -327,6 +331,9 @@ import Data.IntMap.Internal
   , null
   , partition
   , partitionWithKey
+  , takeWhileAntitone
+  , dropWhileAntitone
+  , spanAntitone
   , restrictKeys
   , size
   , split

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -111,6 +111,11 @@ module Data.IntSet (
             -- * Filter
             , IS.filter
             , partition
+
+            , takeWhileAntitone
+            , dropWhileAntitone
+            , spanAntitone
+
             , split
             , splitMember
             , splitRoot

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -805,8 +805,8 @@ takeWhileAntitone predicate t =
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = bin p m l (go predicate' r)
-      | otherwise            = go predicate' l
+      | predicate' $! p+m = bin p m l (go predicate' r)
+      | otherwise         = go predicate' l
     go predicate' (Tip kx bm) = tip kx (takeWhileAntitoneBits kx predicate' bm)
     go _ Nil = Nil
 
@@ -831,8 +831,8 @@ dropWhileAntitone predicate t =
     _ -> go predicate t
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = go predicate' r
-      | otherwise            = bin p m (go predicate' l) r
+      | predicate' $! p+m = go predicate' r
+      | otherwise         = bin p m (go predicate' l) r
     go predicate' (Tip kx bm) = tip kx (bm `xor` takeWhileAntitoneBits kx predicate' bm)
     go _ Nil = Nil
 
@@ -868,8 +868,8 @@ spanAntitone predicate t =
           (lt :*: gt) -> (lt, gt)
   where
     go predicate' (Bin p m l r)
-      | predicate' (p .|. m) = case go predicate' r of (lt :*: gt) -> bin p m l lt :*: gt
-      | otherwise            = case go predicate' l of (lt :*: gt) -> lt :*: bin p m gt r
+      | predicate' $! p+m = case go predicate' r of (lt :*: gt) -> bin p m l lt :*: gt
+      | otherwise         = case go predicate' l of (lt :*: gt) -> lt :*: bin p m gt r
     go predicate' (Tip kx bm) = let bm' = takeWhileAntitoneBits kx predicate' bm
                                 in (tip kx bm' :*: tip kx (bm `xor` bm'))
     go _ Nil = (Nil :*: Nil)

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -836,7 +836,7 @@ dropWhileAntitone predicate t =
     go predicate' (Tip kx bm) = tip kx (bm `xor` takeWhileAntitoneBits kx predicate' bm)
     go _ Nil = Nil
 
--- | \(O(\min(n,W))\). Divide a map at the point where a predicate on the elements stops holding.
+-- | \(O(\min(n,W))\). Divide a set at the point where a predicate on the elements stops holding.
 -- The user is responsible for ensuring that for all @Int@s, @j \< k ==\> p j \>= p k@.
 --
 -- @

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1648,19 +1648,18 @@ takeWhileAntitoneBits prefix predicate bitmap =
   let next d h (n',b') =
         if n' .&. h /= 0 && (predicate $! prefix+b'+d) then (n' `shiftRL` d, b'+d) else (n',b')
       {-# INLINE next #-}
-      (n,b) = next 2  0xF $
+      (_,b) = next 1  0x2 $
+              next 2  0xC $
               next 4  0xF0 $
               next 8  0xFF00 $
               next 16 0xFFFF0000 $
-#if WORD_SIZE_IN_BITS==32
-              (bitmap,0)
-#else
+#if WORD_SIZE_IN_BITS==64
               next 32 0xFFFFFFFF00000000 $
-              (bitmap,0)
 #endif
-      m | n .&. 0x2 /= 0 && (predicate $! prefix+b+1) = (4 `shiftLL` b) - 1
-        | n .&. 0x1 /= 0 && (predicate $! prefix+b)   = (2 `shiftLL` b) - 1
-        | otherwise                                   = (1 `shiftLL` b) - 1
+              (bitmap,0)
+      m = if b /= 0 || (bitmap .&. 0x1 /= 0 && predicate prefix)
+          then ((2 `shiftLL` b) - 1)
+          else ((1 `shiftLL` b) - 1)
   in bitmap .&. m
 
 #else


### PR DESCRIPTION
Add `takeWhileAntitone`, `dropWhileAntitone` and `spanAntitone` for `IntSet` and `IntMap`.

Fixes #839.