### PR TITLE
Faster IntSet and IntMap split functions

### DIFF
--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -51,6 +51,8 @@ main = do
         , bench "minView" $ whnf (maybe 0 (\((k,v), m) -> k+v+M.size m) . M.minViewWithKey)
                     (M.fromList $ zip [1..10] [1..10])
         , bench "spanAntitone" $ whnf (M.spanAntitone (<key_mid)) m
+        , bench "split" $ whnf (M.split key_mid) m
+        , bench "splitLookup" $ whnf (M.splitLookup key_mid) m
         ]
   where
     elems = elems_hits

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -50,14 +50,18 @@ main = do
           $ whnf (num_transitions . det 2 0) $ hard_nfa 1111 16
         , bench "spanAntitone:dense" $ whnf (IS.spanAntitone (<elem_mid)) s
         , bench "spanAntitone:sparse" $ whnf (IS.spanAntitone (<elem_sparse_mid)) s_sparse
+        , bench "split:dense" $ whnf (IS.split elem_mid) s
+        , bench "split:sparse" $ whnf (IS.split elem_sparse_mid) s_sparse
+        , bench "splitMember:dense" $ whnf ((\(!l, !x, !r) -> ()) . IS.splitMember elem_mid) s
+        , bench "splitMember:sparse" $ whnf ((\(!l, !x, !r) -> ()) . IS.splitMember elem_sparse_mid) s_sparse
         ]
   where
     elems = [1..2^12]
     elems_even = [2,4..2^12]
     elems_odd = [1,3..2^12]
-    elem_mid = 2^11
+    elem_mid = 2^11 + 31 -- falls in the middle of a packed Tip bitmask (assuming 64-bit words)
     elems_sparse = map (*64) elems -- when built into a map, each Tip is a singleton
-    elem_sparse_mid = 64 * elem_mid
+    elem_sparse_mid = 2^11 * 64
 
 member :: [Int] -> IS.IntSet -> Int
 member xs s = foldl' (\n x -> if IS.member x s then n + 1 else n) 0 xs

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -52,8 +52,8 @@ main = do
         , bench "spanAntitone:sparse" $ whnf (IS.spanAntitone (<elem_sparse_mid)) s_sparse
         , bench "split:dense" $ whnf (IS.split elem_mid) s
         , bench "split:sparse" $ whnf (IS.split elem_sparse_mid) s_sparse
-        , bench "splitMember:dense" $ whnf ((\(!l, !x, !r) -> ()) . IS.splitMember elem_mid) s
-        , bench "splitMember:sparse" $ whnf ((\(!l, !x, !r) -> ()) . IS.splitMember elem_sparse_mid) s_sparse
+        , bench "splitMember:dense" $ whnf (IS.splitMember elem_mid) s
+        , bench "splitMember:sparse" $ whnf (IS.splitMember elem_sparse_mid) s_sparse
         ]
   where
     elems = [1..2^12]

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -187,6 +187,7 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "fmap"                 prop_fmap
              , testProperty "mapkeys"              prop_mapkeys
              , testProperty "split"                prop_splitModel
+             , testProperty "splitLookup"          prop_splitLookup
              , testProperty "splitRoot"            prop_splitRoot
              , testProperty "foldr"                prop_foldr
              , testProperty "foldr'"               prop_foldr'
@@ -1518,6 +1519,16 @@ prop_splitModel n ys = length ys > 0 ==>
       valid r .&&.
       toAscList l === sort [(k, v) | (k,v) <- xs, k < n] .&&.
       toAscList r === sort [(k, v) | (k,v) <- xs, k > n]
+
+prop_splitLookup :: Int -> [(Int, Int)] -> Property
+prop_splitLookup n ys =
+    let xs = List.nubBy ((==) `on` fst) ys
+        (l, x, r) = splitLookup n (fromList xs)
+    in  valid l .&&.
+        valid r .&&.
+        x === List.lookup n xs .&&.
+        toAscList l === sort [(k, v) | (k,v) <- xs, k < n] .&&.
+        toAscList r === sort [(k, v) | (k,v) <- xs, k > n]
 
 prop_splitRoot :: IMap -> Bool
 prop_splitRoot s = loop ls && (s == unions ls)

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -933,8 +933,16 @@ splitMember x t =
   where
     go x' t'@(Bin p m l r)
         | nomatch x' p m = if x' < p then (Nil, False, t') else (t', False, Nil)
-        | zero x' m      = case go x' l of (lt, fnd, gt) -> (lt, fnd, bin p m gt r)
-        | otherwise      = case go x' r of (lt, fnd, gt) -> (bin p m l lt, fnd, gt)
+        | zero x' m =
+          case go x' l of
+            (lt, fnd, gt) ->
+              let !gt' = bin p m gt r
+              in (lt, fnd, gt')
+        | otherwise =
+          case go x' r of
+            (lt, fnd, gt) ->
+              let !lt' = bin p m l lt
+              in (lt', fnd, gt)
     go x' t'@(Tip kx' bm)
         | kx' > x'          = (Nil, False, t')
           -- equivalent to kx' > prefixOf x'

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -882,11 +882,11 @@ spanAntitone predicate t =
 split :: Key -> IntSet -> (IntSet,IntSet)
 split x t =
   case t of
-      Bin _ m l r
+      Bin p m l r
           | m < 0 -> if x >= 0  -- handle negative numbers.
-                     then case go x l of (lt :*: gt) -> let !lt' = union lt r
+                     then case go x l of (lt :*: gt) -> let !lt' = bin p m lt r
                                                         in (lt', gt)
-                     else case go x r of (lt :*: gt) -> let !gt' = union gt l
+                     else case go x r of (lt :*: gt) -> let !gt' = bin p m l gt
                                                         in (lt, gt')
       _ -> case go x t of
           (lt :*: gt) -> (lt, gt)
@@ -894,9 +894,9 @@ split x t =
     go !x' t'@(Bin p m l r)
         | match x' p m = if zero x' m
                          then case go x' l of
-                             (lt :*: gt) -> lt :*: union gt r
+                             (lt :*: gt) -> lt :*: bin p m gt r
                          else case go x' r of
-                             (lt :*: gt) -> union lt l :*: gt
+                             (lt :*: gt) -> bin p m l lt :*: gt
         | otherwise   = if x' < p then (Nil :*: t')
                         else (t' :*: Nil)
     go x' t'@(Tip kx' bm)
@@ -913,21 +913,21 @@ split x t =
 splitMember :: Key -> IntSet -> (IntSet,Bool,IntSet)
 splitMember x t =
   case t of
-      Bin _ m l r | m < 0 -> if x >= 0
+      Bin p m l r | m < 0 -> if x >= 0
                              then case go x l of
-                                 (lt, fnd, gt) -> let !lt' = union lt r
+                                 (lt, fnd, gt) -> let !lt' = bin p m lt r
                                                   in (lt', fnd, gt)
                              else case go x r of
-                                 (lt, fnd, gt) -> let !gt' = union gt l
+                                 (lt, fnd, gt) -> let !gt' = bin p m l gt
                                                   in (lt, fnd, gt')
       _ -> go x t
   where
     go x' t'@(Bin p m l r)
         | match x' p m = if zero x' m
                          then case go x' l of
-                             (lt, fnd, gt) -> (lt, fnd, union gt r)
+                             (lt, fnd, gt) -> (lt, fnd, bin p m gt r)
                          else case go x' r of
-                             (lt, fnd, gt) -> (union lt l, fnd, gt)
+                             (lt, fnd, gt) -> (bin p m l lt, fnd, gt)
         | otherwise   = if x' < p then (Nil, False, t') else (t', False, Nil)
     go x' t'@(Tip kx' bm)
         | kx' > x'          = (Nil, False, t')

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -882,23 +882,26 @@ spanAntitone predicate t =
 split :: Key -> IntSet -> (IntSet,IntSet)
 split x t =
   case t of
-      Bin p m l r
-          | m < 0 -> if x >= 0  -- handle negative numbers.
-                     then case go x l of (lt :*: gt) -> let !lt' = bin p m lt r
-                                                        in (lt', gt)
-                     else case go x r of (lt :*: gt) -> let !gt' = bin p m l gt
-                                                        in (lt, gt')
-      _ -> case go x t of
+    Bin p m l r
+      | m < 0 ->
+        if x >= 0  -- handle negative numbers.
+        then
+          case go x l of
+            (lt :*: gt) ->
+              let !lt' = bin p m lt r
+              in (lt', gt)
+        else
+          case go x r of
+            (lt :*: gt) ->
+              let !gt' = bin p m l gt
+              in (lt, gt')
+    _ -> case go x t of
           (lt :*: gt) -> (lt, gt)
   where
     go !x' t'@(Bin p m l r)
-        | match x' p m = if zero x' m
-                         then case go x' l of
-                             (lt :*: gt) -> lt :*: bin p m gt r
-                         else case go x' r of
-                             (lt :*: gt) -> bin p m l lt :*: gt
-        | otherwise   = if x' < p then (Nil :*: t')
-                        else (t' :*: Nil)
+        | nomatch x' p m = if x' < p then (Nil :*: t') else (t' :*: Nil)
+        | zero x' m      = case go x' l of (lt :*: gt) -> lt :*: bin p m gt r
+        | otherwise      = case go x' r of (lt :*: gt) -> bin p m l lt :*: gt
     go x' t'@(Tip kx' bm)
         | kx' > x'          = (Nil :*: t')
           -- equivalent to kx' > prefixOf x'
@@ -913,22 +916,25 @@ split x t =
 splitMember :: Key -> IntSet -> (IntSet,Bool,IntSet)
 splitMember x t =
   case t of
-      Bin p m l r | m < 0 -> if x >= 0
-                             then case go x l of
-                                 (lt, fnd, gt) -> let !lt' = bin p m lt r
-                                                  in (lt', fnd, gt)
-                             else case go x r of
-                                 (lt, fnd, gt) -> let !gt' = bin p m l gt
-                                                  in (lt, fnd, gt')
-      _ -> go x t
+    Bin p m l r
+      | m < 0 ->
+        if x >= 0 -- handle negative numbers.
+        then
+          case go x l of
+            (lt, fnd, gt) ->
+              let !lt' = bin p m lt r
+              in (lt', fnd, gt)
+        else
+          case go x r of
+            (lt, fnd, gt) ->
+              let !gt' = bin p m l gt
+              in (lt, fnd, gt')
+    _ -> go x t
   where
     go x' t'@(Bin p m l r)
-        | match x' p m = if zero x' m
-                         then case go x' l of
-                             (lt, fnd, gt) -> (lt, fnd, bin p m gt r)
-                         else case go x' r of
-                             (lt, fnd, gt) -> (bin p m l lt, fnd, gt)
-        | otherwise   = if x' < p then (Nil, False, t') else (t', False, Nil)
+        | nomatch x' p m = if x' < p then (Nil, False, t') else (t', False, Nil)
+        | zero x' m      = case go x' l of (lt, fnd, gt) -> (lt, fnd, bin p m gt r)
+        | otherwise      = case go x' r of (lt, fnd, gt) -> (bin p m l lt, fnd, gt)
     go x' t'@(Tip kx' bm)
         | kx' > x'          = (Nil, False, t')
           -- equivalent to kx' > prefixOf x'


### PR DESCRIPTION
Following up from [#874](https://github.com/haskell/containers/pull/874#discussion_r1027248480).

The main changes are using `bin` everywhere and being strict in `IntSet.splitMember`. Also added one missing property test , and benchmarks to measure the change.

IntSet:
```
  split:dense:        OK (0.20s)
    46.4 ns ± 2.7 ns, 49% less than baseline
  split:sparse:       OK (0.18s)
    84.2 ns ± 5.5 ns, 41% less than baseline
  splitMember:dense:  OK (0.20s)
    46.3 ns ± 3.6 ns, 47% less than baseline
  splitMember:sparse: OK (0.17s)
    82.1 ns ± 5.4 ns, 45% less than baseline
```

IntMap:
```
  split:       OK (0.19s)
    82.3 ns ± 6.4 ns, 43% less than baseline
  splitLookup: OK (0.17s)
    84.5 ns ± 5.9 ns, 43% less than baseline
```
