### PR TITLE
Faster Tree folds

### DIFF
--- a/containers-tests/benchmarks/Tree.hs
+++ b/containers-tests/benchmarks/Tree.hs
@@ -1,0 +1,53 @@
+module Main where
+
+import Control.DeepSeq (NFData, rnf)
+import Control.Exception (evaluate)
+import Data.Coerce (coerce)
+import Data.Foldable (fold, foldl', toList)
+import Data.Monoid (All(..))
+import Test.Tasty.Bench (Benchmark, Benchmarkable, bench, bgroup, defaultMain, whnf, nf)
+import qualified Data.Tree as T
+
+main :: IO ()
+main = do
+  evaluate $ rnf ts `seq` rnf tsBool
+  defaultMain
+    [ bgroup "fold" $ forTs tsBool $ whnf fold . (coerce :: T.Tree Bool -> T.Tree All)
+    , bgroup "foldMap" $ forTs tsBool $ whnf (foldMap All)
+    , bgroup "foldr_1" $ forTs tsBool $ whnf (foldr (&&) True)
+    , bgroup "foldr_2" $ forTs ts $ whnf (length . foldr (:) [])
+    , bgroup "foldr_3" $ forTs ts $ whnf (\t -> foldr (\x k acc -> if acc < 0 then acc else k $! acc + x) id t 0)
+    , bgroup "foldl'" $ forTs ts $ whnf (foldl' (+) 0)
+    , bgroup "foldr1" $ forTs tsBool $ whnf (foldr1 (&&))
+    , bgroup "foldl1" $ forTs ts $ whnf (foldl1 (+))
+    , bgroup "toList" $ forTs ts $ nf toList
+    , bgroup "elem" $ forTs ts $ whnf (elem 0)
+    , bgroup "maximum" $ forTs ts $ whnf maximum
+    , bgroup "sum" $ forTs ts $ whnf sum
+    ]
+  where
+    ts = [binaryTree, lineTree] <*> [1000, 1000000]
+    tsBool = [t { getT = True <$ getT t } | t <- ts]
+
+forTs :: [Tree a] -> (T.Tree a -> Benchmarkable) -> [Benchmark]
+forTs ts f = [bench label (f t) | Tree label t <- ts]
+
+data Tree a = Tree
+  { getLabel :: String
+  , getT :: T.Tree a
+  }
+
+instance NFData a => NFData (Tree a) where
+  rnf (Tree label t) = rnf label `seq` rnf t
+
+binaryTree :: Int -> Tree Int
+binaryTree n = Tree label t
+  where
+    label = "bin,n=" ++ show n
+    t = T.unfoldTree (\x -> (x, takeWhile (<=n) [2*x, 2*x+1])) 1
+
+lineTree :: Int -> Tree Int
+lineTree n = Tree label t
+  where
+    label = "line,n=" ++ show n
+    t = T.unfoldTree (\x -> (x, [x+1 | x+1 <= n])) 1

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -152,6 +152,14 @@ benchmark map-benchmarks
   main-is:        Map.hs
   ghc-options:    -O2
 
+benchmark tree-benchmarks
+  import: benchmark-deps
+  default-language: Haskell2010
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is:        Tree.hs
+  ghc-options:    -O2
+
 benchmark sequence-benchmarks
   import: benchmark-deps
   default-language: Haskell2010

--- a/containers-tests/tests/tree-properties.hs
+++ b/containers-tests/tests/tree-properties.hs
@@ -5,23 +5,37 @@ import Data.Tree as T
 import Control.Applicative (Const(Const, getConst), pure, (<$>), (<*>), liftA2)
 
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import Test.QuickCheck.Function (apply)
-import Test.QuickCheck.Poly (A, B, C)
+import Test.QuickCheck.Poly (A, B, C, OrdA)
 import Control.Monad.Fix (MonadFix (..))
 import Control.Monad (ap)
+import Data.Foldable (foldl', toList)
+import Data.Traversable (foldMapDefault)
 
 default (Int)
 
 main :: IO ()
 main = defaultMain $ testGroup "tree-properties"
          [
-           testProperty "monad_id1"                prop_monad_id1
+           testCase     "foldr"                    test_foldr
+         , testProperty "monad_id1"                prop_monad_id1
          , testProperty "monad_id2"                prop_monad_id2
          , testProperty "monad_assoc"              prop_monad_assoc
          , testProperty "ap_ap"                    prop_ap_ap
          , testProperty "ap_liftA2"                prop_ap_liftA2
          , testProperty "monadFix_ls"              prop_monadFix_ls
+         , testProperty "toList"                   prop_toList
+         , testProperty "foldMap"                  prop_foldMap
+         , testProperty "foldl'"                   prop_foldl'
+         , testProperty "foldr1"                   prop_foldr1
+         , testProperty "foldl1"                   prop_foldl1
+         , testProperty "foldr_infinite"           prop_foldr_infinite
+         , testProperty "maximum"                  prop_maximum
+         , testProperty "minimum"                  prop_minimum
+         , testProperty "sum"                      prop_sum
+         , testProperty "product"                  prop_product
          ]
 
 {--------------------------------------------------------------------
@@ -53,8 +67,23 @@ instance Arbitrary a => Arbitrary (Tree a) where
 #endif
 
 ----------------------------------------------------------------
+-- Utilities
+----------------------------------------------------------------
+
+data Magma a
+  = Inj a
+  | Magma a :* Magma a
+  deriving (Eq, Show)
+
+----------------------------------------------------------------
 -- Unit tests
 ----------------------------------------------------------------
+
+test_foldr :: Assertion
+test_foldr = do
+  foldr (:) [] (Node 1 []) @?= [1]
+  foldr (:) [] (Node 1 [Node 2 [Node 3 []]]) @?= [1..3]
+  foldr (:) [] (Node 1 [Node 2 [Node 3 [], Node 4 []], Node 5 [Node 6 [], Node 7 []]]) @?= [1..7]
 
 ----------------------------------------------------------------
 -- QuickCheck
@@ -101,3 +130,39 @@ prop_monadFix_ls val ta ti =
     f :: (Int -> Int) -> Int -> Tree (Int -> Int)
     f q y = let t = apply ti y
             in fmap (\w -> fact w q) t
+
+prop_toList :: Tree A -> Property
+prop_toList t = toList t === foldr (:) [] t
+
+prop_foldMap :: Tree A -> Property
+prop_foldMap t =
+  foldMap (:[]) t === toList t .&&.
+  foldMap (:[]) t === foldMapDefault (:[]) t
+
+prop_foldl' :: Tree A -> Property
+prop_foldl' t = foldl' (flip (:)) [] t === reverse (toList t)
+
+prop_foldr1 :: Tree A -> Property
+prop_foldr1 t = foldr1 (:*) (fmap Inj t) === foldr1 (:*) (map Inj (toList t))
+
+prop_foldl1 :: Tree A -> Property
+prop_foldl1 t = foldl1 (:*) (fmap Inj t) === foldl1 (:*) (map Inj (toList t))
+
+prop_foldr_infinite :: NonNegative Int -> Property
+prop_foldr_infinite (NonNegative n) =
+    forAllShow genInf (const "<possibly infinite tree>") $
+        \t -> length (take n (foldr (:) [] t)) <= n
+  where
+    genInf = Node () <$> oneof [listOf genInf, infiniteListOf genInf]
+
+prop_maximum :: Tree OrdA -> Property
+prop_maximum t = maximum t === maximum (toList t)
+
+prop_minimum :: Tree OrdA -> Property
+prop_minimum t = minimum t === minimum (toList t)
+
+prop_sum :: Tree OrdA -> Property
+prop_sum t = sum t === sum (toList t)
+
+prop_product :: Tree OrdA -> Property
+prop_product t = product t === product (toList t)


### PR DESCRIPTION
Add some `Foldable` functions for `Data.Tree.Tree`.

* `foldMap`, `null`: Already exist
* `foldr`, `foldl'`: Added, basic functions
* `fold`, `elem`: Added, default definitions but `INLINABLE` helps
* `foldr1`, `foldl1`, `maximum`, `minimum`: Added, default definitions introduce `Maybe`s since these can be partial, we can avoid all that since trees are non-empty.
* `foldMap'`, `toList`, `length`, `sum`, `product`: Not added, defaults work well enough
* `foldr'`, `foldl`: Not added or benchmarked, unlikely to be used(?)

Benchmarks:

```
  fold:    OK (0.25s)
    15.5 μs ± 962 ns, 85% less than baseline
  foldMap: OK (0.14s)
    18.0 μs ± 1.7 μs, 82% less than baseline
  foldr:   OK (0.18s)
    21.8 μs ± 1.5 μs, 93% less than baseline
  foldl':  OK (0.30s)
    18.1 μs ± 878 ns, 95% less than baseline
  foldr1:  OK (0.16s)
    19.6 μs ± 1.5 μs, 94% less than baseline
  foldl1:  OK (0.30s)
    18.0 μs ± 1.2 μs, 95% less than baseline
  toList:  OK (0.17s)
    39.9 μs ± 2.9 μs, 31% less than baseline
  elem:    OK (0.27s)
    16.3 μs ± 777 ns, 47% less than baseline
  maximum: OK (0.16s)
    19.6 μs ± 1.5 μs, 94% less than baseline
  sum:     OK (0.30s)
    17.9 μs ± 671 ns, 95% less than baseline
```

Fixes #878.