### PR TITLE
Implemement foldr, foldl', sum and product in Foldable Tree

### DIFF
--- a/containers-tests/benchmarks/Tree.hs
+++ b/containers-tests/benchmarks/Tree.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE BangPatterns #-}
+import Control.DeepSeq (rnf)
+import Control.Exception (evaluate)
+
+import Data.Foldable
+import Data.Monoid
+import Test.Tasty.Bench
+
+import Data.Tree
+
+main :: IO ()
+main = do
+    let lim = 1000 * 1000
+        t :: Tree Int
+        t = unfoldTree (\x -> (x, filter (<=lim) [2*x, 2*x+1])) 1
+
+    evaluate $ rnf [t]
+    defaultMain
+        [ bench "foldMap'Tree Sum" $ whnf (foldMap'Tree Sum) t
+        , bench "sum"              $ whnf sum t
+        ]
+
+foldMap'Tree :: Monoid m => (a -> m) -> Tree a -> m
+foldMap'Tree f = go mempty
+  where go !z (Node x ts) = foldl' go (z <> f x) ts

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -163,6 +163,14 @@ benchmark sequence-benchmarks
       random            >=0       && <1.2
     , transformers
 
+benchmark tree-benchmarks
+  import: benchmark-deps
+  default-language: Haskell2010
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: benchmarks
+  main-is:        Tree.hs
+  ghc-options:    -O1
+
 benchmark set-benchmarks
   import: benchmark-deps
   default-language: Haskell2010

--- a/containers-tests/tests/tree-properties.hs
+++ b/containers-tests/tests/tree-properties.hs
@@ -10,6 +10,7 @@ import Test.QuickCheck.Function (apply)
 import Test.QuickCheck.Poly (A, B, C)
 import Control.Monad.Fix (MonadFix (..))
 import Control.Monad (ap)
+import Data.Foldable (toList)
 
 default (Int)
 
@@ -22,6 +23,7 @@ main = defaultMain $ testGroup "tree-properties"
          , testProperty "ap_ap"                    prop_ap_ap
          , testProperty "ap_liftA2"                prop_ap_liftA2
          , testProperty "monadFix_ls"              prop_monadFix_ls
+         , testProperty "foldr"                    prop_foldr
          ]
 
 {--------------------------------------------------------------------
@@ -101,3 +103,6 @@ prop_monadFix_ls val ta ti =
     f :: (Int -> Int) -> Int -> Tree (Int -> Int)
     f q y = let t = apply ti y
             in fmap (\w -> fact w q) t
+
+prop_foldr :: Fun (A,B) B -> B -> Tree A -> Property
+prop_foldr f z t = foldr (apply2 f) z t === foldr (apply2 f) z (toList t)


### PR DESCRIPTION
Addresses #878

With this patch on my machine:

```
All
  foldMap'Tree Sum: OK (0.31s)
    18.8 ms ± 1.9 ms
  sum:              OK (1.42s)
    18.0 ms ± 761 μs
```

This patch "changes" the strictness of `sum` and `product`, but it has already been *different* depending on which GHC/base version `containers` is compiled with. So this change makes it consistent.