### PR TITLE
Use a relative src dir path in containers-tests instead of a symlink.

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -86,8 +86,8 @@ library
   -- this is important for testing; may it affect benchmarks?
   cpp-options:      -DTESTING
 
-  include-dirs:     include
-  hs-source-dirs:   src
+  include-dirs:     ../containers/include
+  hs-source-dirs:   ../containers/src
 
   ghc-options:      -O2 -Wall
   if impl(ghc >= 8.6)

--- a/containers-tests/include
+++ b/containers-tests/include
@@ -1,1 +1,0 @@
-../containers/include

--- a/containers-tests/src
+++ b/containers-tests/src
@@ -1,1 +1,0 @@
-../containers/src


### PR DESCRIPTION
This should make working on containers easier when on windows.

Fixes #885