### PR TITLE
Optimize Data.Graph.dfs

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -12,19 +12,22 @@ main = do
   evaluate $ rnf randGs
   defaultMain
     [ bgroup "buildG" $ forGs randGs $ \g -> nf (G.buildG (bounds (getG g))) (getEdges g)
-    , bgroup "graphFromEdges" $ forGs randGs $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
+    , bgroup "graphFromEdges" $
+        forGs [randG1, randG2, randG3] $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
     , bgroup "dfs" $ forGs randGs $ nf (flip G.dfs [1]) . getG
     , bgroup "dff" $ forGs randGs $ nf G.dff . getG
     , bgroup "topSort" $ forGs randGs $ nf G.topSort . getG
     , bgroup "scc" $ forGs randGs $ nf G.scc . getG
     , bgroup "bcc" $ forGs [randG1, randG2] $ nf G.bcc . getG
-    , bgroup "stronglyConnCompR" $ forGs randGs $ nf G.stronglyConnCompR . getAdjList
+    , bgroup "stronglyConnCompR" $
+        forGs [randG1, randG2, randG3] $ nf G.stronglyConnCompR . getAdjList
     ]
   where
     randG1 = buildRandG 100 1000 
     randG2 = buildRandG 100 10000
     randG3 = buildRandG 10000 100000
-    randGs = [randG1, randG2, randG3]
+    randG4 = buildRandG 100000 1000000
+    randGs = [randG1, randG2, randG3, randG4]
 
 -- Note: In practice it does not make sense to run topSort or bcc on a random
 -- graph. For topSort the graph should be acyclic and for bcc the graph should


### PR DESCRIPTION
From #882.

Bundle together `generate`, `prune`, and `chop` into `dfs`.
This eliminates the trees generated by `generate` which significantly reduces time and memory usage.

<details>
<summary>Benchmarks</summary>
On GHC 9.2.5

Before:
<pre>
  dfs
    n=100,m=1000:       OK (1.19s)
      16.7 μs ± 949 ns, 173 KB allocated, 259 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (1.00s)
      141  μs ± 5.7 μs, 1.6 MB allocated, 2.6 KB copied, 299 MB peak memory
    n=10000,m=100000:   OK (3.70s)
      12.5 ms ± 136 μs,  17 MB allocated,  13 MB copied, 303 MB peak memory
    n=100000,m=1000000: OK (1.67s)
      217  ms ± 4.4 ms, 174 MB allocated, 164 MB copied, 325 MB peak memory
  dff
    n=100,m=1000:       OK (1.20s)
      18.5 μs ± 834 ns, 196 KB allocated, 288 B  copied, 325 MB peak memory
    n=100,m=10000:      OK (0.79s)
      143  μs ±  12 μs, 1.6 MB allocated, 2.6 KB copied, 325 MB peak memory
    n=10000,m=100000:   OK (3.78s)
      13.2 ms ± 504 μs,  20 MB allocated,  16 MB copied, 325 MB peak memory
    n=100000,m=1000000: OK (3.58s)
      226  ms ±  16 ms, 198 MB allocated, 189 MB copied, 325 MB peak memory
  topSort
    n=100,m=1000:       OK (1.15s)
      19.4 μs ± 865 ns, 204 KB allocated, 301 B  copied, 325 MB peak memory
    n=100,m=10000:      OK (0.71s)
      143  μs ±  11 μs, 1.6 MB allocated, 2.6 KB copied, 325 MB peak memory
    n=10000,m=100000:   OK (0.43s)
      10.4 ms ± 740 μs,  20 MB allocated, 9.1 MB copied, 325 MB peak memory
    n=100000,m=1000000: OK (1.86s)
      234  ms ±  14 ms, 204 MB allocated, 211 MB copied, 325 MB peak memory
  scc
    n=100,m=1000:       OK (1.02s)
      58.8 μs ± 5.8 μs, 572 KB allocated, 2.4 KB copied, 325 MB peak memory
    n=100,m=10000:      OK (0.80s)
      539  μs ±  26 μs, 4.9 MB allocated, 154 KB copied, 325 MB peak memory
    n=10000,m=100000:   OK (0.31s)
      24.0 ms ± 2.3 ms,  57 MB allocated,  20 MB copied, 325 MB peak memory
    n=100000,m=1000000: OK (1.58s)
      511  ms ±  38 ms, 570 MB allocated, 409 MB copied, 384 MB peak memory
  bcc
    n=100,m=1000:       OK (0.88s)
      79.5 μs ± 5.8 μs, 690 KB allocated, 6.0 KB copied, 384 MB peak memory
    n=100,m=10000:      OK (0.80s)
      377  μs ±  26 μs, 3.4 MB allocated,  14 KB copied, 384 MB peak memory
  stronglyConnCompR
    n=100,m=1000:       OK (0.90s)
      228  μs ±  12 μs, 991 KB allocated, 9.2 KB copied, 384 MB peak memory
    n=100,m=10000:      OK (0.74s)
      2.22 ms ± 135 μs, 8.7 MB allocated, 694 KB copied, 384 MB peak memory
    n=10000,m=100000:   OK (0.32s)
      59.3 ms ± 3.7 ms, 133 MB allocated,  27 MB copied, 384 MB peak memory
</pre>

After:
<pre>
  dfs
    n=100,m=1000:       OK (1.12s)
      4.93 μs ± 401 ns, 4.7 KB allocated,   0 B  copied, 298 MB peak memory, 70% less than baseline
    n=100,m=10000:      OK (0.89s)
      50.7 μs ± 4.0 μs, 4.0 KB allocated,   1 B  copied, 298 MB peak memory, 63% less than baseline
    n=10000,m=100000:   OK (0.55s)
      1.58 ms ± 127 μs, 1.4 MB allocated,  21 KB copied, 298 MB peak memory, 87% less than baseline
    n=100000,m=1000000: OK (0.78s)
      85.2 ms ± 2.5 ms,  14 MB allocated, 7.2 MB copied, 298 MB peak memory, 60% less than baseline
  dff
    n=100,m=1000:       OK (1.15s)
      5.75 μs ± 346 ns,  12 KB allocated,   8 B  copied, 298 MB peak memory, 68% less than baseline
    n=100,m=10000:      OK (0.98s)
      50.8 μs ± 3.7 μs, 9.5 KB allocated,   9 B  copied, 298 MB peak memory, 64% less than baseline
    n=10000,m=100000:   OK (0.63s)
      1.74 ms ±  95 μs, 2.1 MB allocated, 108 KB copied, 298 MB peak memory, 86% less than baseline
    n=100000,m=1000000: OK (0.80s)
      88.3 ms ± 5.3 ms,  20 MB allocated,  12 MB copied, 298 MB peak memory, 60% less than baseline
  topSort
    n=100,m=1000:       OK (1.11s)
      6.27 μs ± 363 ns,  20 KB allocated,  14 B  copied, 298 MB peak memory, 67% less than baseline
    n=100,m=10000:      OK (0.94s)
      49.3 μs ± 3.0 μs,  17 KB allocated,  22 B  copied, 298 MB peak memory, 65% less than baseline
    n=10000,m=100000:   OK (0.91s)
      1.77 ms ± 102 μs, 2.7 MB allocated, 196 KB copied, 298 MB peak memory, 82% less than baseline
    n=100000,m=1000000: OK (0.36s)
      103  ms ± 4.3 ms,  25 MB allocated,  18 MB copied, 298 MB peak memory, 56% less than baseline
  scc
    n=100,m=1000:       OK (0.82s)
      28.6 μs ± 2.7 μs, 203 KB allocated, 656 B  copied, 298 MB peak memory, 51% less than baseline
    n=100,m=10000:      OK (0.75s)
      333  μs ±  24 μs, 1.7 MB allocated,  51 KB copied, 298 MB peak memory, 38% less than baseline
    n=10000,m=100000:   OK (0.46s)
      12.9 ms ± 1.2 ms,  21 MB allocated, 5.4 MB copied, 298 MB peak memory, 46% less than baseline
    n=100000,m=1000000: OK (0.91s)
      256  ms ± 4.9 ms, 217 MB allocated,  76 MB copied, 298 MB peak memory, 49% less than baseline
  bcc
    n=100,m=1000:       OK (0.95s)
      59.1 μs ± 2.7 μs, 507 KB allocated,  55 B  copied, 304 MB peak memory, 25% less than baseline
    n=100,m=10000:      OK (0.83s)
      253  μs ±  14 μs, 1.8 MB allocated,  11 KB copied, 304 MB peak memory, 32% less than baseline
  stronglyConnCompR
    n=100,m=1000:       OK (0.79s)
      202  μs ±  12 μs, 626 KB allocated, 5.0 KB copied, 304 MB peak memory, 11% less than baseline
    n=100,m=10000:      OK (0.50s)
      1.88 ms ± 170 μs, 5.5 MB allocated, 427 KB copied, 304 MB peak memory, 15% less than baseline
    n=10000,m=100000:   OK (0.21s)
      48.3 ms ± 2.7 ms,  97 MB allocated,  11 MB copied, 304 MB peak memory, 18% less than baseline
</pre>
</details>

You may notice that the improvement here is more than what I saw in #882, that's because I had written the `go` function as a fold which did not optimize very well.

There are a few dfs-unrelated smaller improvements I can think of, I'll round those up into another PR.
