### PR TITLE
Improve the test for powerSet

### DIFF
--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -669,16 +669,16 @@ prop_spanAntitone xs' = valid tw .&&. valid dw
     xs = fromList xs'
     (tw, dw) = spanAntitone isLeft xs
 
-prop_powerSet :: Set Int -> Property
-prop_powerSet xs = valid ps .&&. ps === ps'
-  where
-    xs' = take 10 xs
-
-    ps = powerSet xs'
-    ps' = fromList . fmap fromList $ lps (toList xs')
-
-    lps [] = [[]]
-    lps (y : ys) = fmap (y:) (lps ys) ++ lps ys
+prop_powerSet :: Property
+prop_powerSet = forAll (resize 10 arbitrary :: Gen (Set Int)) $ \xs ->
+   -- We don't actually have to check on the values directly, because the power
+   -- set is the *only* one that can be produced by a function with the type of
+   -- `powerSet` and satisfy the criteria below. In particular, the `valid ps`
+   -- test ensures that we haven't duplicated any subsets, while the size test
+   -- ensures that we haven't omitted any. Parametricity ensures that we
+   -- haven't produced any elements out of thin air.
+   let ps = powerSet xs
+   in valid ps .&&. all valid ps .&&. size ps === 2^size xs
 
 prop_cartesianProduct :: Set Int -> Set Int -> Property
 prop_cartesianProduct xs ys =


### PR DESCRIPTION
1. Check for validity of the elements of the result, not just the result.
2. Generate sets in the size range we want, rather than potentially splitting a larger one. This is more efficient and also gives us a better shape distribution.
3. Don't bother comparing to a list-based implementation. Once we've performed all the validity checks (which we should have anyway), a size test is sufficient.