### PR TITLE
Make the internal prelude conditional

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -109,7 +109,6 @@ library
       Utils.NoThunks
 
   other-modules:
-    Prelude
     Utils.Containers.Internal.Coercions
     Utils.Containers.Internal.PtrEquality
     Utils.Containers.Internal.State
@@ -120,6 +119,10 @@ library
       Data.IntMap.Internal.DeprecatedDebug
       Data.Map.Internal.DeprecatedShowTree
       Utils.Containers.Internal.TypeError
+
+  if impl(ghc < 7.10)
+    other-modules:
+      Prelude
 
   if impl(ghc >= 8.6)
     ghc-options: -Werror

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -71,7 +71,6 @@ Library
         Utils.Containers.Internal.StrictPair
 
     other-modules:
-        Prelude
         Utils.Containers.Internal.State
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality
@@ -81,5 +80,8 @@ Library
         Utils.Containers.Internal.TypeError
         Data.Map.Internal.DeprecatedShowTree
         Data.IntMap.Internal.DeprecatedDebug
+    if impl(ghc < 7.10)
+      other-modules:
+        Prelude
 
     include-dirs: include


### PR DESCRIPTION
The internal prelude mucks with cabal repl. Let's only use it when we need it.