### PR TITLE
Allow specialization of Data.Graph functions

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -12,16 +12,14 @@ main = do
   evaluate $ rnf randGs
   defaultMain
     [ bgroup "buildG" $ forGs randGs $ \g -> nf (G.buildG (bounds (getG g))) (getEdges g)
-    , bgroup "graphFromEdges" $
-        forGs [randG1, randG2, randG3] $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
+    , bgroup "graphFromEdges" $ forGs randGs $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
     , bgroup "transposeG" $ forGs randGs $ nf G.transposeG . getG
     , bgroup "dfs" $ forGs randGs $ nf (flip G.dfs [1]) . getG
     , bgroup "dff" $ forGs randGs $ nf G.dff . getG
     , bgroup "topSort" $ forGs randGs $ nf G.topSort . getG
     , bgroup "scc" $ forGs randGs $ nf G.scc . getG
     , bgroup "bcc" $ forGs randGs $ nf G.bcc . getG
-    , bgroup "stronglyConnCompR" $
-        forGs [randG1, randG2, randG3] $ nf G.stronglyConnCompR . getAdjList
+    , bgroup "stronglyConnCompR" $ forGs randGs $ nf G.stronglyConnCompR . getAdjList
     ]
   where
     randG1 = buildRandG 100 1000 

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -236,6 +236,7 @@ stronglyConnComp edges0
   where
     get_node (AcyclicSCC (n, _, _)) = AcyclicSCC n
     get_node (CyclicSCC triples)     = CyclicSCC [n | (n,_,_) <- triples]
+{-# INLINABLE stronglyConnComp #-}
 
 -- | The strongly connected components of a directed graph, reverse topologically
 -- sorted.  The function is the same as 'stronglyConnComp', except that
@@ -269,6 +270,7 @@ stronglyConnCompR edges0
                  where
                    dec (Node v ts) vs = vertex_fn v : foldr dec vs ts
     mentions_itself v = v `elem` (graph ! v)
+{-# INLINABLE stronglyConnCompR #-}
 
 -------------------------------------------------------------------------
 --                                                                      -
@@ -379,6 +381,7 @@ graphFromEdges'
         -> (Graph, Vertex -> (node, key, [key]))
 graphFromEdges' x = (a,b) where
     (a,b,_) = graphFromEdges x
+{-# INLINABLE graphFromEdges' #-}
 
 -- | Build a graph from a list of nodes uniquely identified by keys,
 -- with a list of keys of nodes this node should have edges to.
@@ -466,6 +469,7 @@ graphFromEdges edges0
                                    GT -> findVertex (mid+1) b
                               where
                                 mid = a + (b - a) `div` 2
+{-# INLINABLE graphFromEdges #-}
 
 -------------------------------------------------------------------------
 --                                                                      -


### PR DESCRIPTION
Mark functions in Data.Graph that have an Ord constraint as INLINABLE to allow specialization.

Benchmarks on GHC 9.2.5:
The Ord type used in benchmarks is Int.

Before:
```
  graphFromEdges
    n=100,m=1000:       OK (0.72s)
      145  μs ±  11 μs, 414 KB allocated, 1.5 KB copied, 215 MB peak memory
    n=100,m=10000:      OK (0.36s)
      1.49 ms ± 134 μs, 3.8 MB allocated, 108 KB copied, 215 MB peak memory
    n=10000,m=100000:   OK (0.30s)
      34.4 ms ± 2.3 ms,  74 MB allocated, 4.4 MB copied, 215 MB peak memory
    n=100000,m=1000000: OK (1.83s)
      589  ms ±  30 ms, 930 MB allocated,  74 MB copied, 215 MB peak memory
  stronglyConnCompR
    n=100,m=1000:       OK (0.47s)
      185  μs ±  13 μs, 467 KB allocated, 3.6 KB copied, 215 MB peak memory
    n=100,m=10000:      OK (0.70s)
      1.83 ms ±  88 μs, 4.0 MB allocated, 265 KB copied, 215 MB peak memory
    n=10000,m=100000:   OK (1.81s)
      54.6 ms ± 653 μs,  83 MB allocated,  18 MB copied, 215 MB peak memory
    n=100000,m=1000000: OK (14.92s)
      986  ms ±  41 ms, 1.0 GB allocated, 247 MB copied, 371 MB peak memory
```

After:
```
  graphFromEdges
    n=100,m=1000:       OK (0.85s)
      43.1 μs ± 2.9 μs, 111 KB allocated, 422 B  copied, 215 MB peak memory, 70% less than baseline
    n=100,m=10000:      OK (0.55s)
      530  μs ±  22 μs, 872 KB allocated,  24 KB copied, 215 MB peak memory, 64% less than baseline
    n=10000,m=100000:   OK (0.18s)
      17.6 ms ± 1.7 ms,  10 MB allocated, 4.5 MB copied, 215 MB peak memory, 48% less than baseline
    n=100000,m=1000000: OK (2.66s)
      376  ms ± 5.6 ms, 108 MB allocated,  93 MB copied, 215 MB peak memory, 36% less than baseline
  stronglyConnCompR
    n=100,m=1000:       OK (0.65s)
      78.0 μs ± 5.0 μs, 171 KB allocated, 1.3 KB copied, 215 MB peak memory, 57% less than baseline
    n=100,m=10000:      OK (0.44s)
      834  μs ±  61 μs, 1.1 MB allocated,  65 KB copied, 215 MB peak memory, 54% less than baseline
    n=10000,m=100000:   OK (1.13s)
      33.0 ms ± 1.3 ms,  18 MB allocated,  18 MB copied, 215 MB peak memory, 39% less than baseline
    n=100000,m=1000000: OK (4.93s)
      682  ms ±  56 ms, 182 MB allocated, 233 MB copied, 314 MB peak memory, 30% less than baseline
```