### PR TITLE
Optimize Data.Graph.bcc

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -19,7 +19,7 @@ main = do
     , bgroup "dff" $ forGs randGs $ nf G.dff . getG
     , bgroup "topSort" $ forGs randGs $ nf G.topSort . getG
     , bgroup "scc" $ forGs randGs $ nf G.scc . getG
-    , bgroup "bcc" $ forGs [randG1, randG2] $ nf G.bcc . getG
+    , bgroup "bcc" $ forGs randGs $ nf G.bcc . getG
     , bgroup "stronglyConnCompR" $
         forGs [randG1, randG2, randG3] $ nf G.stronglyConnCompR . getAdjList
     ]


### PR DESCRIPTION
* Concat difference lists instead of lists to avoid $O(n^2)$ complexity
* Avoid the unnecessary tree labelling step
* Add explanatory comments

I've tried [a few variations](https://gist.github.com/meooow25/bf412acccbb4193d13a4b420e0af326e) and chosen the one which seems best.

Benchmarks on GHC 9.2.5:
Before:
```
  bcc
    n=100,m=1000:     OK (0.92s)
      57.0 μs ± 2.9 μs, 507 KB allocated,  29 B  copied, 216 MB peak memory
    n=100,m=10000:    OK (0.25s)
      254  μs ±  22 μs, 1.8 MB allocated,  11 KB copied, 216 MB peak memory
    n=10000,m=100000: OK (7.64s)
      2.526 s ±  96 ms, 3.8 GB allocated, 2.4 GB copied, 1.5 GB peak memory
```
After:
```
  bcc
    n=100,m=1000:       OK (0.92s)
      14.4 μs ± 961 ns,  44 KB allocated,  49 B  copied, 215 MB peak memory, 74% less than baseline
    n=100,m=10000:      OK (0.55s)
      107  μs ± 7.8 μs,  43 KB allocated,  74 B  copied, 215 MB peak memory, 58% less than baseline
    n=10000,m=100000:   OK (0.39s)
      3.79 ms ± 189 μs, 5.8 MB allocated, 584 KB copied, 215 MB peak memory, 99% less than baseline
    n=100000,m=1000000: OK (2.98s)
      193  ms ± 1.3 ms,  59 MB allocated,  59 MB copied, 215 MB peak memory
```

Fixes #900