### PR TITLE
Implement Foldable1 for Data.Tree.Tree

### DIFF
--- a/containers-tests/benchmarks/Tree.hs
+++ b/containers-tests/benchmarks/Tree.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import Control.DeepSeq (NFData, rnf)
@@ -5,6 +6,10 @@ import Control.Exception (evaluate)
 import Data.Coerce (coerce)
 import Data.Foldable (fold, foldl', toList)
 import Data.Monoid (All(..))
+#if MIN_VERSION_base(4,18,0)
+import Data.Monoid (Sum(..))
+import qualified Data.Foldable1 as Foldable1
+#endif
 import Test.Tasty.Bench (Benchmark, Benchmarkable, bench, bgroup, defaultMain, whnf, nf)
 import qualified Data.Tree as T
 
@@ -12,18 +17,34 @@ main :: IO ()
 main = do
   evaluate $ rnf ts `seq` rnf tsBool
   defaultMain
-    [ bgroup "fold" $ forTs tsBool $ whnf fold . (coerce :: T.Tree Bool -> T.Tree All)
-    , bgroup "foldMap" $ forTs tsBool $ whnf (foldMap All)
-    , bgroup "foldr_1" $ forTs tsBool $ whnf (foldr (&&) True)
-    , bgroup "foldr_2" $ forTs ts $ whnf (length . foldr (:) [])
-    , bgroup "foldr_3" $ forTs ts $ whnf (\t -> foldr (\x k acc -> if acc < 0 then acc else k $! acc + x) id t 0)
-    , bgroup "foldl'" $ forTs ts $ whnf (foldl' (+) 0)
-    , bgroup "foldr1" $ forTs tsBool $ whnf (foldr1 (&&))
-    , bgroup "foldl1" $ forTs ts $ whnf (foldl1 (+))
-    , bgroup "toList" $ forTs ts $ nf toList
-    , bgroup "elem" $ forTs ts $ whnf (elem 0)
-    , bgroup "maximum" $ forTs ts $ whnf maximum
-    , bgroup "sum" $ forTs ts $ whnf sum
+    [ bgroup "Foldable"
+      [ bgroup "fold" $ forTs tsBool $ whnf fold . (coerce :: T.Tree Bool -> T.Tree All)
+      , bgroup "foldMap" $ forTs tsBool $ whnf (foldMap All)
+      , bgroup "foldr_1" $ forTs tsBool $ whnf (foldr (&&) True)
+      , bgroup "foldr_2" $ forTs ts $ whnf (length . foldr (:) [])
+      , bgroup "foldr_3" $ forTs ts $ whnf (\t -> foldr (\x k acc -> if acc < 0 then acc else k $! acc + x) id t 0)
+      , bgroup "foldl'" $ forTs ts $ whnf (foldl' (+) 0)
+      , bgroup "foldr1" $ forTs tsBool $ whnf (foldr1 (&&))
+      , bgroup "foldl1" $ forTs ts $ whnf (foldl1 (+))
+      , bgroup "toList" $ forTs ts $ nf toList
+      , bgroup "elem" $ forTs ts $ whnf (elem 0)
+      , bgroup "maximum" $ forTs ts $ whnf maximum
+      , bgroup "sum" $ forTs ts $ whnf sum
+      ]
+#if MIN_VERSION_base(4,18,0)
+    , bgroup "Foldable1"
+      [ bgroup "fold1" $ forTs tsBool $ whnf Foldable1.fold1 . (coerce :: T.Tree Bool -> T.Tree All)
+      , bgroup "foldMap1" $ forTs tsBool $ whnf (Foldable1.foldMap1 All)
+      , bgroup "foldMap1'" $ forTs ts $ whnf (Foldable1.foldMap1' Sum)
+      , bgroup "toNonEmpty" $ forTs ts $ nf Foldable1.toNonEmpty
+      , bgroup "maximum" $ forTs ts $ whnf Foldable1.maximum
+      , bgroup "last" $ forTs ts $ whnf Foldable1.last
+      , bgroup "foldrMap1_1" $ forTs tsBool $ whnf (Foldable1.foldrMap1 id (&&))
+      , bgroup "foldrMap1_2" $ forTs ts $ whnf (length . Foldable1.foldrMap1 (:[]) (:))
+      , bgroup "foldlMap1'" $ forTs ts $ whnf (Foldable1.foldlMap1' id (+))
+      , bgroup "foldlMap1" $ forTs ts $ whnf (Foldable1.foldlMap1 id (+))
+      ]
+#endif
     ]
   where
     ts = [binaryTree, lineTree] <*> [1000, 1000000]


### PR DESCRIPTION
Resolves #906.

<details>
<summary>Benchmarks (GHC 9.2.5)</summary>
Updated some Foldable definitions so it makes sense to check it's not worse.
<pre>
Foldable
    fold
      bin,n=1000:     OK (1.15s)
        3.68 μs ± 225 ns, 13% less than baseline
      bin,n=1000000:  OK (0.55s)
        8.24 ms ± 694 μs,       same as baseline
      line,n=1000:    OK (1.67s)
        4.91 μs ± 388 ns,  8% less than baseline
      line,n=1000000: OK (0.54s)
        14.3 ms ± 886 μs,       same as baseline
    foldMap
      bin,n=1000:     OK (1.65s)
        3.74 μs ± 356 ns, 15% less than baseline
      bin,n=1000000:  OK (0.43s)
        8.27 ms ± 757 μs,       same as baseline
      line,n=1000:    OK (1.67s)
        4.96 μs ± 358 ns, 10% less than baseline
      line,n=1000000: OK (0.54s)
        14.4 ms ± 883 μs, 28% less than baseline
    foldr_1
      bin,n=1000:     OK (1.70s)
        5.24 μs ± 368 ns,       same as baseline
      bin,n=1000000:  OK (0.58s)
        10.3 ms ± 882 μs,       same as baseline
      line,n=1000:    OK (1.77s)
        7.07 μs ± 337 ns,       same as baseline
      line,n=1000000: OK (0.55s)
        30.8 ms ± 2.1 ms,       same as baseline
    foldr_2
      bin,n=1000:     OK (1.59s)
        8.13 μs ± 732 ns,       same as baseline
      bin,n=1000000:  OK (0.68s)
        16.4 ms ± 752 μs,       same as baseline
      line,n=1000:    OK (1.43s)
        8.97 μs ± 743 ns,       same as baseline
      line,n=1000000: OK (0.58s)
        32.4 ms ± 1.5 ms, 34% less than baseline
    foldr_3
      bin,n=1000:     OK (1.60s)
        7.51 μs ± 660 ns,       same as baseline
      bin,n=1000000:  OK (0.65s)
        14.6 ms ± 674 μs,       same as baseline
      line,n=1000:    OK (1.53s)
        6.93 μs ± 661 ns,       same as baseline
      line,n=1000000: OK (0.53s)
        27.3 ms ± 2.0 ms,       same as baseline
    foldl'
      bin,n=1000:     OK (1.06s)
        4.54 μs ± 366 ns,       same as baseline
      bin,n=1000000:  OK (0.86s)
        10.3 ms ± 367 μs,       same as baseline
      line,n=1000:    OK (1.13s)
        6.11 μs ± 406 ns,       same as baseline
      line,n=1000000: OK (0.79s)
        23.4 ms ± 1.0 ms, 15% more than baseline
    foldr1
      bin,n=1000:     OK (1.74s)
        5.30 μs ± 373 ns, 11% less than baseline
      bin,n=1000000:  OK (0.59s)
        10.4 ms ± 722 μs, 14% less than baseline
      line,n=1000:    OK (1.74s)
        5.84 μs ± 395 ns, 21% less than baseline
      line,n=1000000: OK (0.67s)
        8.44 ms ± 778 μs, 67% less than baseline
    foldl1
      bin,n=1000:     OK (1.07s)
        4.46 μs ± 392 ns,       same as baseline
      bin,n=1000000:  OK (0.59s)
        10.3 ms ± 837 μs,       same as baseline
      line,n=1000:    OK (1.13s)
        5.83 μs ± 338 ns,       same as baseline
      line,n=1000000: OK (0.77s)
        20.6 ms ± 843 μs,       same as baseline
    toList
      bin,n=1000:     OK (1.44s)
        8.66 μs ± 675 ns,       same as baseline
      bin,n=1000000:  OK (0.33s)
        28.5 ms ± 1.4 ms,       same as baseline
      line,n=1000:    OK (0.99s)
        9.28 μs ± 673 ns,       same as baseline
      line,n=1000000: OK (5.06s)
        76.5 ms ± 1.3 ms,       same as baseline
    elem
      bin,n=1000:     OK (1.70s)
        4.01 μs ± 365 ns,  8% less than baseline
      bin,n=1000000:  OK (0.47s)
        10.0 ms ± 851 μs,       same as baseline
      line,n=1000:    OK (1.72s)
        5.28 μs ± 375 ns,       same as baseline
      line,n=1000000: OK (0.65s)
        20.1 ms ± 1.1 ms,       same as baseline
    maximum
      bin,n=1000:     OK (2.00s)
        4.96 μs ± 408 ns, 14% more than baseline
      bin,n=1000000:  OK (0.89s)
        11.0 ms ± 411 μs,  8% more than baseline
      line,n=1000:    OK (1.12s)
        5.82 μs ± 386 ns,       same as baseline
      line,n=1000000: OK (0.78s)
        20.8 ms ± 732 μs,       same as baseline
    sum
      bin,n=1000:     OK (1.98s)
        4.56 μs ± 293 ns,       same as baseline
      bin,n=1000000:  OK (0.86s)
        10.4 ms ± 424 μs,       same as baseline
      line,n=1000:    OK (1.12s)
        5.95 μs ± 391 ns,       same as baseline
      line,n=1000000: OK (0.78s)
        20.7 ms ± 1.2 ms,       same as baseline
</pre>
</details>

<details>
<summary>Benchmarks (GHC 9.6.0.20230111)</summary>
<pre>
  Foldable
    fold
      bin,n=1000:     OK (1.71s)
        4.60 μs ± 398 ns, 17% more than baseline
      bin,n=1000000:  OK (0.57s)
        8.86 ms ± 749 μs,       same as baseline
      line,n=1000:    OK (1.74s)
        5.76 μs ± 488 ns, 13% more than baseline
      line,n=1000000: OK (0.69s)
        14.8 ms ± 762 μs,       same as baseline
    foldMap
      bin,n=1000:     OK (1.95s)
        3.97 μs ± 211 ns, 10% less than baseline
      bin,n=1000000:  OK (0.57s)
        8.39 ms ± 745 μs,       same as baseline
      line,n=1000:    OK (1.73s)
        5.16 μs ± 388 ns,  8% less than baseline
      line,n=1000000: OK (0.67s)
        14.2 ms ± 785 μs,       same as baseline
    foldr_1
      bin,n=1000:     OK (1.77s)
        5.31 μs ± 363 ns,       same as baseline
      bin,n=1000000:  OK (0.59s)
        10.4 ms ± 819 μs,       same as baseline
      line,n=1000:    OK (1.60s)
        7.27 μs ± 672 ns,       same as baseline
      line,n=1000000: OK (0.31s)
        31.0 ms ± 3.1 ms, 29% less than baseline
    foldr_2
      bin,n=1000:     OK (1.64s)
        33.9 μs ± 2.5 μs,       same as baseline
      bin,n=1000000:  OK (0.39s)
        59.6 ms ± 5.7 ms,       same as baseline
      line,n=1000:    OK (1.59s)
        34.3 μs ± 2.2 μs,       same as baseline
      line,n=1000000: OK (0.49s)
        88.3 ms ± 7.7 ms,       same as baseline
    foldr_3
      bin,n=1000:     OK (1.43s)
        42.2 μs ± 2.7 μs,       same as baseline
      bin,n=1000000:  OK (0.30s)
        66.4 ms ± 5.6 ms,       same as baseline
      line,n=1000:    OK (1.27s)
        41.3 μs ± 3.4 μs,       same as baseline
      line,n=1000000: OK (0.41s)
        97.5 ms ± 5.0 ms,       same as baseline
    foldl'
      bin,n=1000:     OK (1.57s)
        7.31 μs ± 330 ns,       same as baseline
      bin,n=1000000:  OK (0.62s)
        12.7 ms ± 1.2 ms,       same as baseline
      line,n=1000:    OK (1.55s)
        7.45 μs ± 687 ns,       same as baseline
      line,n=1000000: OK (0.46s)
        19.5 ms ± 1.4 ms,       same as baseline
    foldr1
      bin,n=1000:     OK (1.72s)
        5.28 μs ± 371 ns, 91% less than baseline
      bin,n=1000000:  OK (0.58s)
        10.3 ms ± 725 μs, 82% less than baseline
      line,n=1000:    OK (1.73s)
        5.84 μs ± 405 ns, 88% less than baseline
      line,n=1000000: OK (0.73s)
        6.06 ms ± 352 μs, 91% less than baseline
    foldl1
      bin,n=1000:     OK (1.75s)
        5.61 μs ± 459 ns,       same as baseline
      bin,n=1000000:  OK (0.60s)
        11.2 ms ± 1.0 ms,       same as baseline
      line,n=1000:    OK (2.01s)
        6.31 μs ± 557 ns,       same as baseline
      line,n=1000000: OK (0.71s)
        18.9 ms ± 1.2 ms,       same as baseline
    toList
      bin,n=1000:     OK (1.64s)
        34.1 μs ± 2.2 μs,       same as baseline
      bin,n=1000000:  OK (0.82s)
        70.6 ms ± 2.6 ms,       same as baseline
      line,n=1000:    OK (1.64s)
        35.1 μs ± 2.7 μs,       same as baseline
      line,n=1000000: OK (0.55s)
        107  ms ± 6.5 ms,       same as baseline
    elem
      bin,n=1000:     OK (1.98s)
        4.53 μs ± 171 ns, 11% more than baseline
      bin,n=1000000:  OK (0.60s)
        10.3 ms ± 688 μs,       same as baseline
      line,n=1000:    OK (1.76s)
        5.84 μs ± 358 ns, 14% more than baseline
      line,n=1000000: OK (0.75s)
        19.7 ms ± 1.8 ms,       same as baseline
    maximum
      bin,n=1000:     OK (1.73s)
        4.61 μs ± 342 ns, 12% less than baseline
      bin,n=1000000:  OK (0.86s)
        10.7 ms ± 473 μs,       same as baseline
      line,n=1000:    OK (1.79s)
        5.96 μs ± 359 ns,       same as baseline
      line,n=1000000: OK (0.73s)
        19.3 ms ± 891 μs,  7% more than baseline
    sum
      bin,n=1000:     OK (1.60s)
        7.34 μs ± 707 ns,       same as baseline
      bin,n=1000000:  OK (0.62s)
        12.7 ms ± 764 μs,       same as baseline
      line,n=1000:    OK (1.57s)
        7.48 μs ± 725 ns,       same as baseline
      line,n=1000000: OK (0.72s)
        17.5 ms ± 878 μs, 13% less than baseline
  Foldable1
    fold1
      bin,n=1000:     OK (1.60s)
        8.24 μs ± 758 ns
      bin,n=1000000:  OK (0.63s)
        13.2 ms ± 765 μs
      line,n=1000:    OK (1.76s)
        5.88 μs ± 354 ns
      line,n=1000000: OK (0.73s)
        6.26 ms ± 423 μs
    foldMap1
      bin,n=1000:     OK (1.58s)
        7.82 μs ± 683 ns
      bin,n=1000000:  OK (0.63s)
        13.1 ms ± 963 μs
      line,n=1000:    OK (1.75s)
        6.00 μs ± 367 ns
      line,n=1000000: OK (0.74s)
        6.28 ms ± 358 μs
    foldMap1'
      bin,n=1000:     OK (1.76s)
        6.31 μs ± 362 ns
      bin,n=1000000:  OK (0.64s)
        12.7 ms ± 769 μs
      line,n=1000:    OK (1.72s)
        5.87 μs ± 344 ns
      line,n=1000000: OK (0.52s)
        24.5 ms ± 2.4 ms
    toNonEmpty
      bin,n=1000:     OK (1.67s)
        34.6 μs ± 2.2 μs
      bin,n=1000000:  OK (0.44s)
        72.1 ms ± 6.2 ms
      line,n=1000:    OK (1.65s)
        35.0 μs ± 2.3 μs
      line,n=1000000: OK (4.55s)
        130  ms ± 3.0 ms
    maximum
      bin,n=1000:     OK (1.68s)
        4.59 μs ± 375 ns
      bin,n=1000000:  OK (0.87s)
        10.8 ms ± 566 μs
      line,n=1000:    OK (1.73s)
        5.91 μs ± 332 ns
      line,n=1000000: OK (0.73s)
        17.3 ms ± 1.0 ms
    last
      bin,n=1000:     OK (2.60s)
        64.5 ns ± 5.3 ns
      bin,n=1000000:  OK (2.06s)
        118  ns ±  11 ns
      line,n=1000:    OK (1.64s)
        3.83 μs ± 343 ns
      line,n=1000000: OK (1.07s)
        7.56 ms ± 301 μs
    foldrMap1_1
      bin,n=1000:     OK (1.68s)
        5.30 μs ± 329 ns
      bin,n=1000000:  OK (0.58s)
        10.3 ms ± 681 μs
      line,n=1000:    OK (1.72s)
        6.46 μs ± 397 ns
      line,n=1000000: OK (1.23s)
        10.1 ms ± 911 μs
    foldrMap1_2
      bin,n=1000:     OK (1.42s)
        34.5 μs ± 3.3 μs
      bin,n=1000000:  OK (0.73s)
        58.6 ms ± 1.7 ms
      line,n=1000:    OK (1.56s)
        30.7 μs ± 2.2 μs
      line,n=1000000: OK (0.80s)
        66.8 ms ± 1.7 ms
    foldlMap1'
      bin,n=1000:     OK (1.53s)
        7.21 μs ± 703 ns
      bin,n=1000000:  OK (0.61s)
        12.8 ms ± 907 μs
      line,n=1000:    OK (1.58s)
        7.43 μs ± 728 ns
      line,n=1000000: OK (0.71s)
        19.4 ms ± 1.1 ms
    foldlMap1
      bin,n=1000:     OK (1.73s)
        5.58 μs ± 378 ns
      bin,n=1000000:  OK (0.88s)
        11.2 ms ± 778 μs
      line,n=1000:    OK (1.76s)
        5.53 μs ± 371 ns
      line,n=1000000: OK (0.71s)
        16.6 ms ± 910 μs
</pre>
</details>

The CI won't help in testing the new functions. In case someone wants to test it, on my machine I got 9.6 through ghcup's prerelease channel. I set `allow-newer` `splitmix` in `cabal.project`, and removed all the targets using `nothunks` because it still complained. Tests and benchmarks work after that.

Also, not related to this PR, but it seems that `foldr_2`, `foldr_3`, `toList` are noticeably worse in 9.6 vs 9.2. It might be worth checking what goes wrong.