### PR TITLE
Implement Data.Graph.transposeG with STArray

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -14,6 +14,7 @@ main = do
     [ bgroup "buildG" $ forGs randGs $ \g -> nf (G.buildG (bounds (getG g))) (getEdges g)
     , bgroup "graphFromEdges" $
         forGs [randG1, randG2, randG3] $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
+    , bgroup "transposeG" $ forGs randGs $ nf G.transposeG . getG
     , bgroup "dfs" $ forGs randGs $ nf (flip G.dfs [1]) . getG
     , bgroup "dff" $ forGs randGs $ nf G.dff . getG
     , bgroup "topSort" $ forGs randGs $ nf G.topSort . getG

--- a/containers-tests/tests/graph-properties.hs
+++ b/containers-tests/tests/graph-properties.hs
@@ -17,6 +17,7 @@ main = defaultMain $ testGroup "graph-properties"
   , testCase "dfs" test_dfs
   , testCase "dff" test_dff
 
+  , testProperty "prop_transposeG" prop_transposeG
   , testProperty "prop_dfs" prop_dfs
   , testProperty "prop_dff" prop_dff
   , testProperty "prop_topSort" prop_topSort
@@ -120,6 +121,10 @@ test_dff = do
 ----------------------------------------------------------------
 -- QuickCheck
 ----------------------------------------------------------------
+
+prop_transposeG :: Graph -> Property
+prop_transposeG (Graph g) =
+  L.sort (G.edges (G.transposeG g)) === L.sort ([(v,u) | (u,v) <- G.edges g])
 
 -- Note: This tests some simple properties but not complete correctness
 prop_dfs :: Graph -> Property


### PR DESCRIPTION
Building the graph directly saves time and allocations compared to the current way of going through edge lists.

Benchmarks on GHC 9.2.5:

Before:
```
  transposeG
    n=100,m=1000:       OK (0.80s)
      19.1 μs ± 1.6 μs, 186 KB allocated, 626 B  copied, 216 MB peak memory
    n=100,m=10000:      OK (0.39s)
      271  μs ±  25 μs, 1.7 MB allocated,  64 KB copied, 216 MB peak memory
    n=10000,m=100000:   OK (1.04s)
      7.01 ms ± 596 μs,  18 MB allocated, 6.7 MB copied, 216 MB peak memory
    n=100000,m=1000000: OK (1.94s)
      123  ms ± 9.7 ms, 182 MB allocated,  73 MB copied, 227 MB peak memory
  scc
    n=100,m=1000:       OK (0.53s)
      28.0 μs ± 1.8 μs, 204 KB allocated, 648 B  copied, 227 MB peak memory
    n=100,m=10000:      OK (0.38s)
      331  μs ±  28 μs, 1.7 MB allocated,  51 KB copied, 227 MB peak memory
    n=10000,m=100000:   OK (0.42s)
      9.00 ms ± 350 μs,  21 MB allocated, 5.3 MB copied, 227 MB peak memory
    n=100000,m=1000000: OK (1.87s)
      258  ms ±  13 ms, 217 MB allocated, 113 MB copied, 227 MB peak memory
```

After:
```
  transposeG
    n=100,m=1000:       OK (0.82s)
      7.95 μs ± 701 ns,  32 KB allocated,  99 B  copied, 215 MB peak memory, 58% less than baseline
    n=100,m=10000:      OK (0.50s)
      104  μs ± 5.3 μs, 239 KB allocated, 5.7 KB copied, 215 MB peak memory, 61% less than baseline
    n=10000,m=100000:   OK (0.43s)
      2.09 ms ±  95 μs, 3.1 MB allocated, 1.1 MB copied, 215 MB peak memory, 70% less than baseline
    n=100000,m=1000000: OK (2.82s)
      88.0 ms ± 4.5 ms,  31 MB allocated,  73 MB copied, 234 MB peak memory, 28% less than baseline
  scc
    n=100,m=1000:       OK (0.44s)
      15.8 μs ± 1.4 μs,  50 KB allocated, 170 B  copied, 234 MB peak memory, 43% less than baseline
    n=100,m=10000:      OK (0.38s)
      164  μs ±  11 μs, 255 KB allocated, 7.5 KB copied, 234 MB peak memory, 50% less than baseline
    n=10000,m=100000:   OK (0.25s)
      4.91 ms ± 363 μs, 6.4 MB allocated, 1.8 MB copied, 234 MB peak memory, 45% less than baseline
    n=100000,m=1000000: OK (1.67s)
      231  ms ±  20 ms,  66 MB allocated, 117 MB copied, 234 MB peak memory, 10% less than baseline
```

Now I understand that this is a more complicated construction compared to a one-liner, so perhaps it is not desirable.
But the improvements are good enough that I consider it worthwhile.