### PR TITLE
Inline simple functions in Data.Graph

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -14,6 +14,7 @@ main = do
     [ bgroup "buildG" $ forGs randGs $ \g -> nf (G.buildG (bounds (getG g))) (getEdges g)
     , bgroup "graphFromEdges" $
         forGs [randG1, randG2, randG3] $ nf ((\(g, _, _) -> g) . G.graphFromEdges) . getAdjList
+    , bgroup "transposeG" $ forGs randGs $ nf G.transposeG . getG
     , bgroup "dfs" $ forGs randGs $ nf (flip G.dfs [1]) . getG
     , bgroup "dff" $ forGs randGs $ nf G.dff . getG
     , bgroup "topSort" $ forGs randGs $ nf G.topSort . getG


### PR DESCRIPTION
Mark `vertices`, `edges`, `buildG`, and `reverseE` as `INLINE`. These are functions with simple definitions that produce or consume lists. Inlining them allows fusion and other optimizations.

<details>
<summary>Benchmarks on GHC 9.2.5</summary>
Before:
<pre>
  buildG
    n=100,m=1000:       OK (1.33s)
      8.14 μs ± 461 ns,  31 KB allocated, 116 B  copied, 216 MB peak memory
    n=100,m=10000:      OK (0.87s)
      78.3 μs ± 6.2 μs, 239 KB allocated, 6.6 KB copied, 216 MB peak memory
    n=10000,m=100000:   OK (0.54s)
      1.29 ms ±  99 μs, 2.9 MB allocated, 942 KB copied, 218 MB peak memory
    n=100000,m=1000000: OK (0.45s)
      34.5 ms ± 2.4 ms,  29 MB allocated,  44 MB copied, 249 MB peak memory
  graphFromEdges
    n=100,m=1000:       OK (0.71s)
      143  μs ±  14 μs, 414 KB allocated, 1.6 KB copied, 299 MB peak memory
    n=100,m=10000:      OK (0.61s)
      1.33 ms ± 116 μs, 3.8 MB allocated, 109 KB copied, 299 MB peak memory
    n=10000,m=100000:   OK (0.35s)
      31.1 ms ± 1.7 ms,  74 MB allocated, 4.4 MB copied, 299 MB peak memory
  transposeG
    n=100,m=1000:       OK (1.00s)
      20.0 μs ± 1.6 μs, 186 KB allocated, 643 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (0.73s)
      284  μs ±  26 μs, 1.7 MB allocated,  64 KB copied, 299 MB peak memory
    n=10000,m=100000:   OK (0.87s)
      7.48 ms ± 181 μs,  18 MB allocated, 4.6 MB copied, 299 MB peak memory
    n=100000,m=1000000: OK (0.47s)
      108  ms ± 8.9 ms, 181 MB allocated,  49 MB copied, 299 MB peak memory
  dfs
    n=100,m=1000:       OK (1.14s)
      4.90 μs ± 328 ns, 4.7 KB allocated,   0 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (0.88s)
      47.2 μs ± 3.4 μs, 4.0 KB allocated,   1 B  copied, 299 MB peak memory
    n=10000,m=100000:   OK (0.48s)
      2.50 ms ± 205 μs, 1.3 MB allocated,  12 KB copied, 299 MB peak memory
    n=100000,m=1000000: OK (0.33s)
      91.9 ms ± 5.5 ms,  13 MB allocated, 5.9 MB copied, 299 MB peak memory
  dff
    n=100,m=1000:       OK (1.15s)
      5.78 μs ± 362 ns,  12 KB allocated,   8 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (0.95s)
      45.8 μs ± 3.3 μs, 9.5 KB allocated,   9 B  copied, 299 MB peak memory
    n=10000,m=100000:   OK (1.22s)
      2.72 ms ± 208 μs, 2.1 MB allocated, 110 KB copied, 299 MB peak memory
    n=100000,m=1000000: OK (0.33s)
      94.7 ms ± 7.5 ms,  18 MB allocated,  11 MB copied, 299 MB peak memory
  topSort
    n=100,m=1000:       OK (1.08s)
      6.22 μs ± 341 ns,  20 KB allocated,  14 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (1.68s)
      47.5 μs ± 1.6 μs,  19 KB allocated,  22 B  copied, 299 MB peak memory
    n=10000,m=100000:   OK (0.75s)
      3.01 ms ± 142 μs, 2.6 MB allocated, 187 KB copied, 299 MB peak memory
    n=100000,m=1000000: OK (0.43s)
      102  ms ± 9.7 ms,  25 MB allocated,  18 MB copied, 299 MB peak memory
  scc
    n=100,m=1000:       OK (0.82s)
      28.2 μs ± 2.7 μs, 203 KB allocated, 659 B  copied, 299 MB peak memory
    n=100,m=10000:      OK (0.74s)
      329  μs ±  24 μs, 1.7 MB allocated,  51 KB copied, 299 MB peak memory
    n=10000,m=100000:   OK (0.45s)
      12.7 ms ± 1.0 ms,  21 MB allocated, 5.4 MB copied, 299 MB peak memory
    n=100000,m=1000000: OK (0.89s)
      251  ms ±  22 ms, 217 MB allocated,  76 MB copied, 299 MB peak memory
  bcc
    n=100,m=1000:       OK (0.95s)
      58.3 μs ± 3.4 μs, 507 KB allocated,  62 B  copied, 305 MB peak memory
    n=100,m=10000:      OK (0.81s)
      241  μs ±  12 μs, 1.8 MB allocated,  11 KB copied, 305 MB peak memory
  stronglyConnCompR
    n=100,m=1000:       OK (0.76s)
      194  μs ±  11 μs, 626 KB allocated, 5.0 KB copied, 305 MB peak memory
    n=100,m=10000:      OK (0.68s)
      1.86 ms ±  85 μs, 5.5 MB allocated, 426 KB copied, 305 MB peak memory
    n=10000,m=100000:   OK (0.21s)
      47.9 ms ± 4.5 ms,  97 MB allocated,  11 MB copied, 305 MB peak memory
</pre>

After:
<pre>
  buildG
    n=100,m=1000:       OK (1.98s)
      7.39 μs ± 412 ns,  31 KB allocated,  92 B  copied, 216 MB peak memory,  9% less than baseline
    n=100,m=10000:      OK (0.73s)
      72.8 μs ± 5.6 μs, 239 KB allocated, 7.0 KB copied, 216 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.59s)
      1.25 ms ± 118 μs, 2.9 MB allocated, 942 KB copied, 218 MB peak memory,       same as baseline
    n=100000,m=1000000: OK (0.45s)
      34.0 ms ± 1.9 ms,  29 MB allocated,  44 MB copied, 263 MB peak memory,       same as baseline
  graphFromEdges
    n=100,m=1000:       OK (0.73s)
      143  μs ±  13 μs, 414 KB allocated, 1.6 KB copied, 313 MB peak memory,       same as baseline
    n=100,m=10000:      OK (0.89s)
      1.39 ms ±  65 μs, 3.8 MB allocated, 111 KB copied, 313 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.43s)
      32.2 ms ± 1.8 ms,  74 MB allocated, 4.4 MB copied, 313 MB peak memory,       same as baseline
  transposeG
    n=100,m=1000:       OK (1.01s)
      7.64 μs ± 657 ns,  32 KB allocated, 102 B  copied, 313 MB peak memory, 61% less than baseline
    n=100,m=10000:      OK (0.84s)
      105  μs ± 5.4 μs, 239 KB allocated, 5.7 KB copied, 313 MB peak memory, 63% less than baseline
    n=10000,m=100000:   OK (0.59s)
      3.69 ms ± 247 μs, 3.1 MB allocated, 1.1 MB copied, 313 MB peak memory, 50% less than baseline
    n=100000,m=1000000: OK (0.74s)
      77.1 ms ± 2.1 ms,  31 MB allocated,  47 MB copied, 313 MB peak memory, 28% less than baseline
  dfs
    n=100,m=1000:       OK (1.12s)
      5.00 μs ± 380 ns, 4.7 KB allocated,   0 B  copied, 320 MB peak memory,       same as baseline
    n=100,m=10000:      OK (0.87s)
      46.4 μs ± 2.7 μs, 4.0 KB allocated,   1 B  copied, 320 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.47s)
      2.51 ms ± 177 μs, 1.3 MB allocated,  12 KB copied, 320 MB peak memory,       same as baseline
    n=100000,m=1000000: OK (1.57s)
      91.9 ms ± 7.5 ms,  14 MB allocated, 7.9 MB copied, 320 MB peak memory,       same as baseline
  dff
    n=100,m=1000:       OK (1.18s)
      5.71 μs ± 339 ns,  12 KB allocated,   8 B  copied, 320 MB peak memory,       same as baseline
    n=100,m=10000:      OK (0.98s)
      44.8 μs ± 4.0 μs, 9.5 KB allocated,   9 B  copied, 320 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.83s)
      2.77 ms ± 244 μs, 2.1 MB allocated, 108 KB copied, 320 MB peak memory,       same as baseline
    n=100000,m=1000000: OK (0.42s)
      93.4 ms ± 4.4 ms,  18 MB allocated,  11 MB copied, 320 MB peak memory,       same as baseline
  topSort
    n=100,m=1000:       OK (1.12s)
      6.32 μs ± 376 ns,  20 KB allocated,  14 B  copied, 320 MB peak memory,       same as baseline
    n=100,m=10000:      OK (0.99s)
      47.2 μs ± 3.1 μs,  17 KB allocated,  22 B  copied, 320 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.59s)
      2.98 ms ± 211 μs, 2.6 MB allocated, 179 KB copied, 320 MB peak memory,       same as baseline
    n=100000,m=1000000: OK (0.44s)
      101  ms ± 7.3 ms,  25 MB allocated,  18 MB copied, 320 MB peak memory,       same as baseline
  scc
    n=100,m=1000:       OK (0.92s)
      16.4 μs ± 1.4 μs,  50 KB allocated, 173 B  copied, 320 MB peak memory, 41% less than baseline
    n=100,m=10000:      OK (0.75s)
      155  μs ±  11 μs, 255 KB allocated, 7.5 KB copied, 320 MB peak memory, 52% less than baseline
    n=10000,m=100000:   OK (0.32s)
      8.26 ms ± 765 μs, 5.9 MB allocated, 1.9 MB copied, 320 MB peak memory, 34% less than baseline
    n=100000,m=1000000: OK (0.81s)
      221  ms ± 9.8 ms,  66 MB allocated,  76 MB copied, 320 MB peak memory, 11% less than baseline
  bcc
    n=100,m=1000:       OK (0.94s)
      56.8 μs ± 3.0 μs, 507 KB allocated,  62 B  copied, 320 MB peak memory,       same as baseline
    n=100,m=10000:      OK (0.66s)
      253  μs ±  22 μs, 1.8 MB allocated,  11 KB copied, 320 MB peak memory,       same as baseline
  stronglyConnCompR
    n=100,m=1000:       OK (0.85s)
      178  μs ±  11 μs, 467 KB allocated, 3.6 KB copied, 320 MB peak memory,  8% less than baseline
    n=100,m=10000:      OK (0.68s)
      1.78 ms ± 106 μs, 4.0 MB allocated, 295 KB copied, 320 MB peak memory,       same as baseline
    n=10000,m=100000:   OK (0.52s)
      45.2 ms ± 1.7 ms,  82 MB allocated,  11 MB copied, 320 MB peak memory,       same as baseline
</pre>
</details>

`transposeG` and `scc` (which uses `transposeG`) show a decrease in time and allocations, everything else seems unaffected.

This PR follows from @treeowl's suggestion in #912.
From benchmarks I didn't see a need to mark `transposeG` as `NOINLINE`, but I can do so if you wish.

