### PR TITLE
Rename the custom prelude

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -109,7 +109,7 @@ library
       Utils.NoThunks
 
   other-modules:
-    Prelude
+    Utils.Containers.Internal.Prelude
     Utils.Containers.Internal.Coercions
     Utils.Containers.Internal.PtrEquality
     Utils.Containers.Internal.State

--- a/containers-tests/tests/tree-properties.hs
+++ b/containers-tests/tests/tree-properties.hs
@@ -130,9 +130,9 @@ prop_monad_assoc ta atb btc =
 -- sensitive to the Monad instance.
 prop_monadFix_ls :: Int -> Tree Int -> Fun Int (Tree Int) -> Property
 prop_monadFix_ls val ta ti =
-  fmap ($val) (mfix (\x -> ta >>= \y -> f x y))
+  fmap ($ val) (mfix (\x -> ta >>= \y -> f x y))
   ===
-  fmap ($val) (ta >>= \y -> mfix (\x -> f x y))
+  fmap ($ val) (ta >>= \y -> mfix (\x -> f x y))
   where
     fact :: Int -> (Int -> Int) -> Int -> Int
     fact x _ 0 = x + 1

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -71,7 +71,7 @@ Library
         Utils.Containers.Internal.StrictPair
 
     other-modules:
-        Prelude
+        Utils.Containers.Internal.Prelude
         Utils.Containers.Internal.State
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -93,6 +93,8 @@ module Data.Graph (
 
     ) where
 
+import Utils.Containers.Internal.Prelude
+import Prelude ()
 #if USE_ST_MONAD
 import Control.Monad.ST
 import Data.Array.ST.Safe (newArray, readArray, writeArray)

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -310,7 +310,9 @@ import Control.DeepSeq (NFData(rnf))
 import Data.Bits
 import qualified Data.Foldable as Foldable
 import Data.Maybe (fromMaybe)
-import Prelude hiding (lookup, map, filter, foldr, foldl, null)
+import Utils.Containers.Internal.Prelude hiding
+  (lookup, map, filter, foldr, foldl, null)
+import Prelude ()
 
 import Data.IntSet.Internal (Key)
 import qualified Data.IntSet.Internal as IntSet

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -259,7 +259,9 @@ module Data.IntMap.Strict.Internal (
 #endif
     ) where
 
-import Prelude hiding (lookup,map,filter,foldr,foldl,null)
+import Utils.Containers.Internal.Prelude hiding
+  (lookup,map,filter,foldr,foldl,null)
+import Prelude ()
 
 import Data.Bits
 import qualified Data.IntMap.Internal as L

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -203,7 +203,9 @@ import Data.Semigroup (Semigroup(stimes))
 import Data.Semigroup (Semigroup((<>)))
 #endif
 import Data.Semigroup (stimesIdempotentMonoid)
-import Prelude hiding (filter, foldr, foldl, null, map)
+import Utils.Containers.Internal.Prelude hiding
+  (filter, foldr, foldl, null, map)
+import Prelude ()
 
 import Utils.Containers.Internal.BitUtil
 import Utils.Containers.Internal.StrictPair

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -383,7 +383,9 @@ import qualified Data.Foldable as Foldable
 #if MIN_VERSION_base(4,10,0)
 import Data.Bifoldable
 #endif
-import Prelude hiding (lookup, map, filter, foldr, foldl, null, splitAt, take, drop)
+import Utils.Containers.Internal.Prelude hiding
+  (lookup, map, filter, foldr, foldl, null, splitAt, take, drop)
+import Prelude ()
 
 import qualified Data.Set.Internal as Set
 import Data.Set.Internal (Set)

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -194,7 +194,7 @@ module Data.Sequence.Internal (
 #endif
     ) where
 
-import Prelude hiding (
+import Utils.Containers.Internal.Prelude hiding (
     Functor(..),
 #if MIN_VERSION_base(4,11,0)
     (<>),
@@ -203,6 +203,7 @@ import Prelude hiding (
     null, length, lookup, take, drop, splitAt, foldl, foldl1, foldr, foldr1,
     scanl, scanl1, scanr, scanr1, replicate, zip, zipWith, zip3, zipWith3,
     unzip, takeWhile, dropWhile, iterate, reverse, filter, mapM, sum, all)
+import Prelude ()
 import Control.Applicative ((<$>), (<**>),  Alternative,
                             liftA3)
 import qualified Control.Applicative as Applicative

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -232,7 +232,9 @@ module Data.Set.Internal (
             , merge
             ) where
 
-import Prelude hiding (filter,foldl,foldr,null,map,take,drop,splitAt)
+import Utils.Containers.Internal.Prelude hiding
+  (filter,foldl,foldr,null,map,take,drop,splitAt)
+import Prelude ()
 import Control.Applicative (Const(..))
 import qualified Data.List as List
 import Data.Bits (shiftL, shiftR)

--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -53,6 +53,8 @@ module Data.Tree(
 
     ) where
 
+import Utils.Containers.Internal.Prelude as Prelude
+import Prelude ()
 import Data.Foldable (fold, foldl', toList)
 import Data.Traversable (foldMapDefault)
 import Control.Monad (liftM)

--- a/containers/src/Utils/Containers/Internal/Prelude.hs
+++ b/containers/src/Utils/Containers/Internal/Prelude.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PackageImports #-}
 -- | This hideous module lets us avoid dealing with the fact that
 -- @liftA2@ wasn't previously exported from the standard prelude.
-module Prelude
-  ( module Prel
+module Utils.Containers.Internal.Prelude
+  ( module Prelude
   , Applicative (..)
 #if !MIN_VERSION_base(4,10,0)
   , liftA2
@@ -11,7 +10,7 @@ module Prelude
   )
   where
 
-import "base" Prelude as Prel hiding (Applicative(..))
+import Prelude hiding (Applicative(..))
 import Control.Applicative(Applicative(..))
 
 #if !MIN_VERSION_base(4,10,0)

--- a/containers/src/Utils/Containers/Internal/State.hs
+++ b/containers/src/Utils/Containers/Internal/State.hs
@@ -7,6 +7,8 @@ module Utils.Containers.Internal.State where
 
 import Control.Monad (ap, liftM2)
 import Control.Applicative (liftA)
+import Utils.Containers.Internal.Prelude
+import Prelude ()
 
 newtype State s a = State {runState :: s -> (s, a)}
 


### PR DESCRIPTION
* Using a custom prelude named `Prelude` breaks `cabal repl`.  Just rename it, and change imports all over the place.

* Squash a warning about dollar sign use in the test suite.

Fixes #898 