### PR TITLE
Add a maximal DAG in Graph benchmarks

### DIFF
--- a/containers-tests/benchmarks/Graph.hs
+++ b/containers-tests/benchmarks/Graph.hs
@@ -22,10 +22,11 @@ main = do
     , bgroup "stronglyConnCompR" $ forGs allGs $ nf G.stronglyConnCompR . getAdjList
     ]
   where
-    allGs = randGs ++ starGs ++ lineGs
+    allGs = randGs ++ starGs ++ lineGs ++ maxDAGs
     randGs = map (uncurry buildRandG) [(100, 1000), (100, 10000), (10000, 100000), (100000, 1000000)]
     starGs = map buildStarG [100, 1000000]
     lineGs = map buildLineG [100, 1000000]
+    maxDAGs = map buildMaxDAG [15, 1500]
 
 -- Note: In practice it does not make sense to run topSort or bcc on a random
 -- graph. For topSort the graph should be acyclic and for bcc the graph should
@@ -74,3 +75,10 @@ buildLineG :: Int -> Graph
 buildLineG n = makeG label (1, n) (zip [1..n-1] [2..])
   where
     label = "line,n=" ++ show n
+
+-- A maximal DAG. There is an edge from vertex i to j for every i, j when i < j.
+-- The number of edges is n * (n - 1) / 2.
+buildMaxDAG :: Int -> Graph
+buildMaxDAG n = makeG label (1, n) [(i, j) | i <- [1 .. n-1], j <- [i+1 .. n]]
+  where
+    label = "maxDAG,n=" ++ show n


### PR DESCRIPTION
Add a maximal DAG in Graph benchmarks. From https://github.com/haskell/containers/pull/931#issuecomment-1427134981.

<details>
<summary>Benchmarks on GHC 9.2.5</summary>
<pre>
  buildG
    rand,n=100,m=1000:       OK (6.18s)
      7.23 μs ± 529 ns,  30 KB allocated, 101 B  copied, 1.1 GB peak memory
    rand,n=100,m=10000:      OK (4.66s)
      102  μs ± 7.2 μs, 239 KB allocated, 7.1 KB copied, 1.1 GB peak memory
    rand,n=10000,m=100000:   OK (2.23s)
      5.10 ms ± 486 μs, 2.8 MB allocated, 883 KB copied, 1.1 GB peak memory
    rand,n=100000,m=1000000: OK (1.88s)
      82.4 ms ± 1.5 ms,  29 MB allocated,  44 MB copied, 1.1 GB peak memory
    star,n=100:              OK (6.87s)
      1.33 μs ± 109 ns, 9.4 KB allocated,   7 B  copied, 1.2 GB peak memory
    star,n=1000000:          OK (1.74s)
      59.2 ms ± 1.9 ms,  92 MB allocated,  43 MB copied, 1.2 GB peak memory
    line,n=100:              OK (7.55s)
      1.19 μs ±  89 ns, 9.4 KB allocated,   7 B  copied, 1.2 GB peak memory
    line,n=1000000:          OK (1.20s)
      64.8 ms ± 1.4 ms,  92 MB allocated,  43 MB copied, 1.2 GB peak memory
    maxDAG,n=15:             OK (6.54s)
      837  ns ±  43 ns, 3.6 KB allocated,   1 B  copied, 1.2 GB peak memory
    maxDAG,n=1500:           OK (0.60s)
      72.3 ms ± 4.5 ms,  24 MB allocated,  45 MB copied, 1.2 GB peak memory
  graphFromEdges
    rand,n=100,m=1000:       OK (4.02s)
      44.8 μs ± 2.8 μs, 111 KB allocated, 457 B  copied, 1.2 GB peak memory
    rand,n=100,m=10000:      OK (3.05s)
      545  μs ±  43 μs, 853 KB allocated,  23 KB copied, 1.2 GB peak memory
    rand,n=10000,m=100000:   OK (1.37s)
      16.9 ms ± 1.1 ms,  11 MB allocated, 4.6 MB copied, 1.2 GB peak memory
    rand,n=100000,m=1000000: OK (3.71s)
      401  ms ± 2.3 ms, 108 MB allocated,  54 MB copied, 1.2 GB peak memory
    star,n=100:              OK (6.18s)
      6.67 μs ± 329 ns,  34 KB allocated,  59 B  copied, 1.3 GB peak memory
    star,n=1000000:          OK (14.74s)
      419  ms ±  36 ms, 328 MB allocated, 444 MB copied, 1.8 GB peak memory
    line,n=100:              OK (5.27s)
      6.84 μs ± 496 ns,  34 KB allocated,  55 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (1.33s)
      311  ms ±  24 ms, 327 MB allocated, 246 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (5.65s)
      3.06 μs ± 216 ns,  13 KB allocated,  10 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (0.67s)
      85.4 ms ± 6.1 ms,  93 MB allocated,  42 MB copied, 1.8 GB peak memory
  transposeG
    rand,n=100,m=1000:       OK (5.43s)
      7.80 μs ± 481 ns,  32 KB allocated, 107 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (3.09s)
      117  μs ±  11 μs, 239 KB allocated, 5.7 KB copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (2.89s)
      2.70 ms ± 105 μs, 3.1 MB allocated, 1.1 MB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (1.35s)
      76.8 ms ± 2.2 ms,  31 MB allocated,  47 MB copied, 1.8 GB peak memory
    star,n=100:              OK (6.89s)
      1.40 μs ±  47 ns,  11 KB allocated,   3 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (1.10s)
      44.5 ms ± 4.2 ms, 106 MB allocated,  46 MB copied, 1.8 GB peak memory
    line,n=100:              OK (6.61s)
      1.40 μs ±  97 ns,  11 KB allocated,   3 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (1.40s)
      73.9 ms ± 1.7 ms, 106 MB allocated,  75 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (7.19s)
      737  ns ±  58 ns, 3.9 KB allocated,   1 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (0.95s)
      62.7 ms ± 2.9 ms,  24 MB allocated,  45 MB copied, 1.8 GB peak memory
  dfs
    rand,n=100,m=1000:       OK (5.45s)
      4.96 μs ± 367 ns, 4.7 KB allocated,   1 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (4.23s)
      47.2 μs ± 2.7 μs, 4.0 KB allocated,   2 B  copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (2.22s)
      1.63 ms ± 160 μs, 1.4 MB allocated,  21 KB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (1.77s)
      87.8 ms ± 4.7 ms,  14 MB allocated, 7.2 MB copied, 1.8 GB peak memory
    star,n=100:              OK (6.34s)
      1.63 μs ±  89 ns, 4.8 KB allocated,   1 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (1.69s)
      78.4 ms ± 7.0 ms, 101 MB allocated,  88 MB copied, 1.8 GB peak memory
    line,n=100:              OK (5.60s)
      1.66 μs ± 165 ns, 4.7 KB allocated,   1 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (8.74s)
      224  ms ± 5.3 ms, 164 MB allocated, 230 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (7.63s)
      591  ns ±  38 ns, 838 B  allocated,   0 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (1.30s)
      17.7 ms ± 1.8 ms,   0 B  allocated,   0 B  copied, 1.8 GB peak memory
  dff
    rand,n=100,m=1000:       OK (5.39s)
      5.82 μs ± 329 ns,  12 KB allocated,  11 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (4.70s)
      54.8 μs ± 2.7 μs, 9.5 KB allocated,  11 B  copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (2.79s)
      1.75 ms ± 112 μs, 2.1 MB allocated, 108 KB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (1.77s)
      90.1 ms ± 1.5 ms,  20 MB allocated,  12 MB copied, 1.8 GB peak memory
    star,n=100:              OK (6.21s)
      2.38 μs ± 205 ns,  12 KB allocated,  10 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (27.20s)
      201  ms ±  12 ms, 170 MB allocated, 255 MB copied, 1.8 GB peak memory
    line,n=100:              OK (6.21s)
      2.42 μs ± 206 ns,  12 KB allocated,  10 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (5.13s)
      248  ms ±  23 ms, 233 MB allocated, 271 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (6.72s)
      683  ns ±  42 ns, 1.9 KB allocated,   0 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (2.45s)
      15.8 ms ± 930 μs,   0 B  allocated,   0 B  copied, 1.8 GB peak memory
  topSort
    rand,n=100,m=1000:       OK (5.65s)
      6.48 μs ± 353 ns,  20 KB allocated,  17 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (4.68s)
      50.3 μs ± 3.5 μs,  17 KB allocated,  25 B  copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (4.17s)
      1.82 ms ±  62 μs, 2.7 MB allocated, 199 KB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (4.98s)
      96.7 ms ± 1.0 ms,  27 MB allocated,  20 MB copied, 1.8 GB peak memory
    star,n=100:              OK (5.18s)
      2.90 μs ± 171 ns,  20 KB allocated,  22 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (8.66s)
      225  ms ± 2.5 ms, 246 MB allocated, 311 MB copied, 1.8 GB peak memory
    line,n=100:              OK (5.67s)
      3.08 μs ± 177 ns,  20 KB allocated,  25 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (12.77s)
      379  ms ± 3.0 ms, 286 MB allocated, 478 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (5.76s)
      761  ns ±  42 ns, 3.0 KB allocated,   0 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (2.28s)
      17.4 ms ± 1.1 ms, 248 KB allocated, 2.6 KB copied, 1.8 GB peak memory
  scc
    rand,n=100,m=1000:       OK (4.64s)
      16.6 μs ± 1.4 μs,  50 KB allocated, 181 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (3.56s)
      173  μs ±  13 μs, 255 KB allocated, 7.5 KB copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (2.10s)
      5.16 ms ± 181 μs, 6.5 MB allocated, 1.8 MB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (2.82s)
      226  ms ± 2.3 ms,  66 MB allocated,  77 MB copied, 1.8 GB peak memory
    star,n=100:              OK (5.36s)
      5.66 μs ± 341 ns,  29 KB allocated,  28 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (27.87s)
      428  ms ± 1.2 ms, 393 MB allocated, 545 MB copied, 1.8 GB peak memory
    line,n=100:              OK (4.57s)
      5.25 μs ± 348 ns,  29 KB allocated,  29 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (26.96s)
      414  ms ±  20 ms, 393 MB allocated, 572 MB copied, 1.8 GB peak memory
    maxDAG,n=15:             OK (6.88s)
      1.84 μs ±  92 ns, 6.7 KB allocated,   2 B  copied, 1.8 GB peak memory
    maxDAG,n=1500:           OK (2.89s)
      76.7 ms ± 1.4 ms,  26 MB allocated,  49 MB copied, 1.8 GB peak memory
  bcc
    rand,n=100,m=1000:       OK (4.33s)
      14.4 μs ± 1.3 μs,  44 KB allocated,  59 B  copied, 1.8 GB peak memory
    rand,n=100,m=10000:      OK (4.91s)
      112  μs ± 3.8 μs,  43 KB allocated,  74 B  copied, 1.8 GB peak memory
    rand,n=10000,m=100000:   OK (1.98s)
      4.25 ms ± 369 μs, 5.8 MB allocated, 581 KB copied, 1.8 GB peak memory
    rand,n=100000,m=1000000: OK (2.17s)
      196  ms ± 5.7 ms,  58 MB allocated,  35 MB copied, 1.8 GB peak memory
    star,n=100:              OK (5.67s)
      6.95 μs ± 335 ns,  39 KB allocated,  38 B  copied, 1.8 GB peak memory
    star,n=1000000:          OK (13.42s)
      389  ms ±  10 ms, 437 MB allocated, 435 MB copied, 1.8 GB peak memory
    line,n=100:              OK (6.21s)
      7.82 μs ± 371 ns,  48 KB allocated,  69 B  copied, 1.8 GB peak memory
    line,n=1000000:          OK (25.73s)
      799  ms ±  50 ms, 687 MB allocated, 1.0 GB copied, 2.0 GB peak memory
    maxDAG,n=15:             OK (7.58s)
      1.70 μs ± 130 ns, 6.2 KB allocated,   1 B  copied, 2.0 GB peak memory
    maxDAG,n=1500:           OK (1.00s)
      42.3 ms ± 3.3 ms,   0 B  allocated,   0 B  copied, 2.0 GB peak memory
  stronglyConnCompR
    rand,n=100,m=1000:       OK (4.87s)
      78.0 μs ± 5.3 μs, 170 KB allocated, 1.3 KB copied, 2.0 GB peak memory
    rand,n=100,m=10000:      OK (3.59s)
      850  μs ±  46 μs, 1.1 MB allocated,  65 KB copied, 2.0 GB peak memory
    rand,n=10000,m=100000:   OK (1.85s)
      40.3 ms ± 2.5 ms,  18 MB allocated,  11 MB copied, 2.0 GB peak memory
    rand,n=100000,m=1000000: OK (6.40s)
      757  ms ±  33 ms, 182 MB allocated, 142 MB copied, 2.0 GB peak memory
    star,n=100:              OK (5.01s)
      18.0 μs ± 1.5 μs,  71 KB allocated, 186 B  copied, 2.0 GB peak memory
    star,n=1000000:          OK (16.09s)
      0.999 s ±  38 ms, 798 MB allocated, 1.0 GB copied, 2.1 GB peak memory
    line,n=100:              OK (4.99s)
      18.3 μs ± 1.4 μs,  71 KB allocated, 183 B  copied, 2.1 GB peak memory
    line,n=1000000:          OK (15.27s)
      945  ms ±  30 ms, 798 MB allocated, 1.0 GB copied, 2.1 GB peak memory
    maxDAG,n=15:             OK (5.74s)
      7.13 μs ± 673 ns,  21 KB allocated,  12 B  copied, 2.1 GB peak memory
    maxDAG,n=1500:           OK (1.34s)
      200  ms ± 7.5 ms, 120 MB allocated,  94 MB copied, 2.1 GB peak memory
</pre>
</details>