### PR TITLE
Improve {Set,Map}.fromDistinct{Asc,Desc}List

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -21,6 +21,7 @@ main = do
         m_even = M.fromAscList elems_even :: M.Map Int Int
         m_odd = M.fromAscList elems_odd :: M.Map Int Int
     evaluate $ rnf [m, m_even, m_odd]
+    evaluate $ rnf elems_rev
     defaultMain
         [ bench "lookup absent" $ whnf (lookup evens) m_odd
         , bench "lookup present" $ whnf (lookup evens) m_even
@@ -90,6 +91,9 @@ main = do
         , bench "fromList-desc" $ whnf M.fromList (reverse elems)
         , bench "fromAscList" $ whnf M.fromAscList elems
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
+        , bench "fromDistinctAscList:fusion" $ whnf (\n -> M.fromDistinctAscList [(i,i) | i <- [1..n]]) bound
+        , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_rev
+        , bench "fromDistinctDescList:fusion" $ whnf (\n -> M.fromDistinctDescList [(i,i) | i <- [n,n-1..1]]) bound
         , bench "minView" $ whnf (\m' -> case M.minViewWithKey m' of {Nothing -> 0; Just ((k,v),m'') -> k+v+M.size m''}) (M.fromAscList $ zip [1..10::Int] [100..110::Int])
         ]
   where
@@ -97,6 +101,7 @@ main = do
     elems = zip keys values
     elems_even = zip evens evens
     elems_odd = zip odds odds
+    elems_rev = reverse elems
     keys = [1..bound]
     evens = [2,4..bound]
     odds = [1,3..bound]

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -14,6 +14,7 @@ main = do
         s_odd = S.fromAscList elems_odd :: S.Set Int
         strings_s = S.fromList strings
     evaluate $ rnf [s, s_even, s_odd]
+    evaluate $ rnf elems_rev
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
@@ -34,6 +35,9 @@ main = do
         , bench "fromList-desc" $ whnf S.fromList (reverse elems)
         , bench "fromAscList" $ whnf S.fromAscList elems
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
+        , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
+        , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_rev
+        , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even
         , bench "disjoint:true" $ whnf (S.disjoint s_odd) s_even
         , bench "null.intersection:false" $ whnf (S.null. S.intersection s) s_even
@@ -53,9 +57,11 @@ main = do
         , bench "member.powerSet (18)" $ whnf (\ s -> all (flip S.member s) s) (S.powerSet (S.fromList [1..18]))
         ]
   where
-    elems = [1..2^12]
-    elems_even = [2,4..2^12]
-    elems_odd = [1,3..2^12]
+    bound = 2^12
+    elems = [1..bound]
+    elems_even = [2,4..bound]
+    elems_odd = [1,3..bound]
+    elems_rev = reverse elems
     strings = map show elems
 
 member :: [Int] -> S.Set Int -> Int

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -67,7 +67,9 @@ main = defaultMain $ testGroup "set-properties"
                    , testProperty "prop_DescList" prop_DescList
                    , testProperty "prop_AscDescList" prop_AscDescList
                    , testProperty "prop_fromList" prop_fromList
+                   , testProperty "prop_fromDistinctAscList" prop_fromDistinctAscList
                    , testProperty "prop_fromListDesc" prop_fromListDesc
+                   , testProperty "prop_fromDistinctDescList" prop_fromDistinctDescList
                    , testProperty "prop_isProperSubsetOf" prop_isProperSubsetOf
                    , testProperty "prop_isProperSubsetOf2" prop_isProperSubsetOf2
                    , testProperty "prop_isSubsetOf" prop_isSubsetOf
@@ -514,11 +516,17 @@ prop_AscDescList xs = toAscList s == reverse (toDescList s)
 prop_fromList :: [Int] -> Property
 prop_fromList xs =
            t === fromAscList sort_xs .&&.
-           t === fromDistinctAscList nub_sort_xs .&&.
            t === List.foldr insert empty xs
   where t = fromList xs
         sort_xs = sort xs
-        nub_sort_xs = List.map List.head $ List.group sort_xs
+
+prop_fromDistinctAscList :: [Int] -> Property
+prop_fromDistinctAscList xs =
+    valid t .&&.
+    toList t === nub_sort_xs
+  where
+    t = fromDistinctAscList nub_sort_xs
+    nub_sort_xs = List.map List.head $ List.group $ sort xs
 
 prop_fromListDesc :: [Int] -> Property
 prop_fromListDesc xs =
@@ -528,6 +536,14 @@ prop_fromListDesc xs =
   where t = fromList xs
         sort_xs = reverse (sort xs)
         nub_sort_xs = List.map List.head $ List.group sort_xs
+
+prop_fromDistinctDescList :: [Int] -> Property
+prop_fromDistinctDescList xs =
+    valid t .&&.
+    toList t === nub_sort_xs
+  where
+    t = fromDistinctDescList (reverse nub_sort_xs)
+    nub_sort_xs = List.map List.head $ List.group $ sort xs
 
 {--------------------------------------------------------------------
   Set operations are like IntSet operations

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -3413,8 +3413,7 @@ instance (Ord k) => GHCExts.IsList (Map k v) where
 -- If the list contains more than one value for the same key, the last value
 -- for the key is retained.
 --
--- If the keys of the list are ordered, linear-time implementation is used,
--- with the performance equal to 'fromDistinctAscList'.
+-- If the keys of the list are ordered, a linear-time implementation is used.
 --
 -- > fromList [] == empty
 -- > fromList [(5,"a"), (3,"b"), (5, "c")] == fromList [(5,"c"), (3,"b")]

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -3703,6 +3703,8 @@ fromDescListWithKey f xs
 
 -- For some reason, when 'singleton' is used in fromDistinctAscList or in
 -- create, it is not inlined, so we inline it manually.
+
+-- See Note [fromDistinctAscList implementation] in Data.Set.Internal.
 fromDistinctAscList :: [(k,a)] -> Map k a
 fromDistinctAscList = linkAll . Foldable.foldl' next (State0 Nada)
   where
@@ -3732,6 +3734,8 @@ fromDistinctAscList = linkAll . Foldable.foldl' next (State0 Nada)
 
 -- For some reason, when 'singleton' is used in fromDistinctDescList or in
 -- create, it is not inlined, so we inline it manually.
+
+-- See Note [fromDistinctAscList implementation] in Data.Set.Internal.
 fromDistinctDescList :: [(k,a)] -> Map k a
 fromDistinctDescList = linkAll . Foldable.foldl' next (State0 Nada)
   where

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1700,6 +1700,8 @@ fromDescListWithKey f xs
 
 -- For some reason, when 'singleton' is used in fromDistinctAscList or in
 -- create, it is not inlined, so we inline it manually.
+
+-- See Note [fromDistinctAscList implementation] in Data.Set.Internal.
 fromDistinctAscList :: [(k,a)] -> Map k a
 fromDistinctAscList = linkAll . Foldable.foldl' next (State0 Nada)
   where
@@ -1727,6 +1729,8 @@ fromDistinctAscList = linkAll . Foldable.foldl' next (State0 Nada)
 
 -- For some reason, when 'singleton' is used in fromDistinctDescList or in
 -- create, it is not inlined, so we inline it manually.
+
+-- See Note [fromDistinctAscList implementation] in Data.Set.Internal.
 fromDistinctDescList :: [(k,a)] -> Map k a
 fromDistinctDescList = linkAll . Foldable.foldl' next (State0 Nada)
   where

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1493,8 +1493,7 @@ fromArgSet (Set.Bin sz (Arg x v) l r) = v `seq` Bin sz x v (fromArgSet l) (fromA
 -- If the list contains more than one value for the same key, the last value
 -- for the key is retained.
 --
--- If the keys of the list are ordered, linear-time implementation is used,
--- with the performance equal to 'fromDistinctAscList'.
+-- If the keys of the list are ordered, a linear-time implementation is used.
 --
 -- > fromList [] == empty
 -- > fromList [(5,"a"), (3,"b"), (5, "c")] == fromList [(5,"c"), (3,"b")]

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1085,8 +1085,7 @@ foldlFB = foldl
 
 -- | \(O(n \log n)\). Create a set from a list of elements.
 --
--- If the elements are ordered, a linear-time implementation is used,
--- with the performance equal to 'fromDistinctAscList'.
+-- If the elements are ordered, a linear-time implementation is used.
 
 -- For some reason, when 'singleton' is used in fromList or in
 -- create, it is not inlined, so we inline it manually.


### PR DESCRIPTION
As discussed in #949, this is a different implementation of the current strategy that is faster and is a good consumer of the input list. However there is an increase in allocations in the no-fusion case.

### Benchmarks

On GHC 9.2.5:

<details>
<summary>Before</summary>

```
Set
  fromDistinctAscList:         OK (0.15s)
    37.7 μs ± 2.9 μs, 159 KB allocated, 3.1 KB copied, 8.0 MB peak memory
  fromDistinctAscList:fusion:  OK (0.12s)
    58.7 μs ± 5.6 μs, 448 KB allocated,  12 KB copied, 8.0 MB peak memory
  fromDistinctDescList:        OK (0.16s)
    38.1 μs ± 3.6 μs, 159 KB allocated, 3.1 KB copied, 8.0 MB peak memory
  fromDistinctDescList:fusion: OK (0.26s)
    61.5 μs ± 3.1 μs, 480 KB allocated,  13 KB copied, 8.0 MB peak memory

Map
  fromDistinctAscList:         OK (0.18s)
    41.1 μs ± 2.8 μs, 191 KB allocated, 4.5 KB copied, 9.0 MB peak memory
  fromDistinctAscList:fusion:  OK (0.14s)
    67.0 μs ± 5.4 μs, 574 KB allocated,  17 KB copied, 9.0 MB peak memory
  fromDistinctDescList:        OK (0.16s)
    40.2 μs ± 2.7 μs, 191 KB allocated, 4.5 KB copied, 9.0 MB peak memory
  fromDistinctDescList:fusion: OK (0.15s)
    70.8 μs ± 6.1 μs, 608 KB allocated,  19 KB copied, 9.0 MB peak memory
```

</details>

After

```
Set
  fromDistinctAscList:         OK (0.21s)
    26.1 μs ± 1.5 μs, 224 KB allocated, 4.4 KB copied, 8.0 MB peak memory, 30% less than baseline
  fromDistinctAscList:fusion:  OK (0.22s)
    25.6 μs ± 1.5 μs, 288 KB allocated, 7.7 KB copied, 8.0 MB peak memory, 56% less than baseline
  fromDistinctDescList:        OK (0.22s)
    25.9 μs ± 1.3 μs, 224 KB allocated, 4.4 KB copied, 8.0 MB peak memory, 31% less than baseline
  fromDistinctDescList:fusion: OK (0.20s)
    26.0 μs ± 1.4 μs, 288 KB allocated, 7.9 KB copied, 8.0 MB peak memory, 57% less than baseline

Map
  fromDistinctAscList:         OK (0.14s)
    34.1 μs ± 3.0 μs, 271 KB allocated, 6.5 KB copied, 9.0 MB peak memory, 17% less than baseline
  fromDistinctAscList:fusion:  OK (0.11s)
    30.2 μs ± 3.0 μs, 336 KB allocated,  10 KB copied, 9.0 MB peak memory, 54% less than baseline
  fromDistinctDescList:        OK (0.14s)
    33.5 μs ± 2.9 μs, 271 KB allocated, 6.5 KB copied, 9.0 MB peak memory, 16% less than baseline
  fromDistinctDescList:fusion: OK (0.13s)
    31.2 μs ± 2.9 μs, 336 KB allocated,  10 KB copied, 9.0 MB peak memory, 55% less than baseline
```

I also decided to try the latest GHC 9.6.2 and it turns out to be better there.

<details>
<summary>Before</summary>

```
Set
  fromDistinctAscList:         OK (0.15s)
    35.3 μs ± 3.2 μs, 159 KB allocated, 3.2 KB copied, 8.0 MB peak memory
  fromDistinctAscList:fusion:  OK (0.23s)
    55.0 μs ± 3.0 μs, 448 KB allocated,  12 KB copied, 8.0 MB peak memory
  fromDistinctDescList:        OK (0.15s)
    36.1 μs ± 2.7 μs, 159 KB allocated, 3.2 KB copied, 8.0 MB peak memory
  fromDistinctDescList:fusion: OK (0.24s)
    56.6 μs ± 2.8 μs, 480 KB allocated,  13 KB copied, 8.0 MB peak memory

Map
  fromDistinctAscList:         OK (0.17s)
    40.9 μs ± 3.6 μs, 191 KB allocated, 4.4 KB copied, 9.0 MB peak memory
  fromDistinctAscList:fusion:  OK (0.13s)
    64.5 μs ± 5.7 μs, 574 KB allocated,  17 KB copied, 9.0 MB peak memory
  fromDistinctDescList:        OK (0.17s)
    40.1 μs ± 2.9 μs, 191 KB allocated, 4.4 KB copied, 9.0 MB peak memory
  fromDistinctDescList:fusion: OK (0.14s)
    68.0 μs ± 5.6 μs, 608 KB allocated,  19 KB copied, 9.0 MB peak memory
```

</details>

After:

```
Set
  fromDistinctAscList:         OK (0.16s)
    19.7 μs ± 1.4 μs, 224 KB allocated, 4.4 KB copied, 8.0 MB peak memory, 44% less than baseline
  fromDistinctAscList:fusion:  OK (0.13s)
    17.9 μs ± 1.4 μs, 288 KB allocated, 7.7 KB copied, 8.0 MB peak memory, 67% less than baseline
  fromDistinctDescList:        OK (0.16s)
    20.1 μs ± 1.5 μs, 224 KB allocated, 4.4 KB copied, 8.0 MB peak memory, 44% less than baseline
  fromDistinctDescList:fusion: OK (0.16s)
    18.5 μs ± 1.5 μs, 288 KB allocated, 7.9 KB copied, 8.0 MB peak memory, 67% less than baseline

Map
  fromDistinctAscList:         OK (0.22s)
    26.3 μs ± 1.9 μs, 272 KB allocated, 6.6 KB copied, 9.0 MB peak memory, 35% less than baseline
  fromDistinctAscList:fusion:  OK (0.18s)
    21.1 μs ± 1.5 μs, 336 KB allocated,  10 KB copied, 9.0 MB peak memory, 67% less than baseline
  fromDistinctDescList:        OK (0.22s)
    26.1 μs ± 1.7 μs, 272 KB allocated, 6.6 KB copied, 9.0 MB peak memory, 34% less than baseline
  fromDistinctDescList:fusion: OK (0.18s)
    21.7 μs ± 1.4 μs, 336 KB allocated,  10 KB copied, 9.0 MB peak memory, 68% less than baseline
```

Closes #949.