### PR TITLE
Bump deepseq bound to allow 1.5

### DIFF
--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -34,7 +34,7 @@ source-repository head
 
 Library
     default-language: Haskell2010
-    build-depends: base >= 4.10 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.5, template-haskell
+    build-depends: base >= 4.10 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.6, template-haskell
     hs-source-dirs: src
     ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 


### PR DESCRIPTION
Necessary for GHC 9.8.