### PR TITLE
Clarify replicateM Haddock

### DIFF
--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -1707,7 +1707,8 @@ replicateA n x
   | otherwise   = error "replicateA takes a nonnegative integer argument"
 {-# SPECIALIZE replicateA :: Int -> State a b -> State a (Seq b) #-}
 
--- | 'replicateM' is a sequence counterpart of 'Control.Monad.replicateM'.
+-- | 'replicateM' is the @Seq@ counterpart of
+-- @Control.Monad.'Control.Monad.replicateM'@.
 --
 -- > replicateM n x = sequence (replicate n x)
 --


### PR DESCRIPTION
"`replicateM` is a sequence counterpart of `replicateM`" doesn't really make much sense, so this PR clarifies it.

### Before

![screenshot1](https://github.com/haskell/containers/assets/1951567/b9ced2b2-74d7-4215-9cbe-6cb863cf8bbd)

### After

![screenshot1](https://github.com/haskell/containers/assets/1951567/0976ad16-d2b3-4a37-bb44-67abfe462e21)

