### PR TITLE
Tests and benchmarks for {Set,Map}.fromAscList and friends

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -21,7 +21,7 @@ main = do
         m_even = M.fromAscList elems_even :: M.Map Int Int
         m_odd = M.fromAscList elems_odd :: M.Map Int Int
     evaluate $ rnf [m, m_even, m_odd]
-    evaluate $ rnf elems_rev
+    evaluate $ rnf [elems_rev, elems_asc, elems_desc]
     defaultMain
         [ bench "lookup absent" $ whnf (lookup evens) m_odd
         , bench "lookup present" $ whnf (lookup evens) m_even
@@ -71,7 +71,7 @@ main = do
         , bench "insertLookupWithKey' present" $ whnf (insLookupWithKey' elems_even) m_even
         , bench "mapWithKey" $ whnf (M.mapWithKey (+)) m
         , bench "foldlWithKey" $ whnf (ins elems) m
-        , bench "foldlWithKey'" $ whnf (M.foldlWithKey' sum 0) m
+        , bench "foldlWithKey'" $ whnf (M.foldlWithKey' sumkv 0) m
         , bench "foldrWithKey" $ whnf (M.foldrWithKey consPair []) m
         , bench "foldrWithKey'" $ whnf (M.foldrWithKey' consPair []) m
         , bench "update absent" $ whnf (upd Just evens) m_odd
@@ -88,8 +88,13 @@ main = do
         , bench "intersection" $ whnf (M.intersection m) m_even
         , bench "split" $ whnf (M.split (bound `div` 2)) m
         , bench "fromList" $ whnf M.fromList elems
-        , bench "fromList-desc" $ whnf M.fromList (reverse elems)
-        , bench "fromAscList" $ whnf M.fromAscList elems
+        , bench "fromList-desc" $ whnf M.fromList elems_desc
+        , bench "fromAscList" $ whnf M.fromAscList elems_asc
+        , bench "fromAscListWithKey" $
+            whnf (M.fromAscListWithKey sumkv) elems_asc
+        , bench "fromDescList" $ whnf M.fromDescList elems_desc
+        , bench "fromDescListWithKey" $
+            whnf (M.fromDescListWithKey sumkv) elems_desc
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> M.fromDistinctAscList [(i,i) | i <- [1..n]]) bound
         , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_rev
@@ -104,11 +109,15 @@ main = do
     elems_even = zip evens evens
     elems_odd = zip odds odds
     elems_rev = reverse elems
+    keys_asc = map (`div` 2) [1..bound] -- [0,1,1,2,2..]
+    elems_asc = zip keys_asc values
+    keys_desc = map (`div` 2) [bound,bound-1..1] -- [..2,2,1,1,0]
+    elems_desc = zip keys_desc values
     keys = [1..bound]
     evens = [2,4..bound]
     odds = [1,3..bound]
     values = [1..bound]
-    sum k v1 v2 = k + v1 + v2
+    sumkv k v1 v2 = k + v1 + v2
     consPair k v xs = (k, v) : xs
 
 add3 :: Int -> Int -> Int -> Int

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -14,7 +14,7 @@ main = do
         s_odd = S.fromAscList elems_odd :: S.Set Int
         strings_s = S.fromList strings
     evaluate $ rnf [s, s_even, s_odd]
-    evaluate $ rnf elems_rev
+    evaluate $ rnf [elems_rev, elems_asc, elems_desc]
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
@@ -31,10 +31,11 @@ main = do
         , bench "difference" $ whnf (S.difference s) s_even
         , bench "intersection" $ whnf (S.intersection s) s_even
         , bench "fromList" $ whnf S.fromList elems
-        , bench "fromList-desc" $ whnf S.fromList (reverse elems)
-        , bench "fromAscList" $ whnf S.fromAscList elems
+        , bench "fromList-desc" $ whnf S.fromList elems_desc
+        , bench "fromAscList" $ whnf S.fromAscList elems_asc
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
+        , bench "fromDescList" $ whnf S.fromDescList elems_desc
         , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_rev
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even
@@ -63,6 +64,8 @@ main = do
     elems_even = [2,4..bound]
     elems_odd = [1,3..bound]
     elems_rev = reverse elems
+    elems_asc = map (`div` 2) [1..bound] -- [0,1,1,2,2..]
+    elems_desc = map (`div` 2) [bound,bound-1..1] -- [..2,2,1,1,0]
     strings = map show elems
 
 member :: [Int] -> S.Set Int -> Int


### PR DESCRIPTION
I wrote these up while working on making `fromAscList` fuse well. But I'm seeing some odd behavior there, so I thought I would split this straightforward PR out and work on the rest afterwards.

Current benchmarks on GHC 9.2.5
Set:
```
  fromAscList:  OK (0.21s)
    50.1 μs ± 2.7 μs, 240 KB allocated, 2.4 KB copied, 8.0 MB peak memory
  fromDescList: OK (0.21s)
    49.1 μs ± 4.1 μs, 240 KB allocated, 2.4 KB copied, 8.0 MB peak memory
```
Map:
```
  fromAscList:         OK
    39.6 μs ± 2.7 μs, 343 KB allocated, 5.2 KB copied,  10 MB peak memory
  fromAscListWithKey:  OK
    47.0 μs ± 4.3 μs, 455 KB allocated,  12 KB copied,  10 MB peak memory
  fromDescList:        OK
    39.6 μs ± 2.6 μs, 343 KB allocated, 5.5 KB copied,  10 MB peak memory
  fromDescListWithKey: OK
    48.1 μs ± 3.2 μs, 455 KB allocated,  13 KB copied,  10 MB peak memory
```