### PR TITLE
Improve {Set,Map}.fromAscList and friends

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -90,7 +90,9 @@ main = do
         , bench "fromList" $ whnf M.fromList elems
         , bench "fromList-desc" $ whnf M.fromList (reverse elems)
         , bench "fromAscList" $ whnf M.fromAscList elems_asc
+        , bench "fromAscList:fusion" $ whnf (\n -> M.fromAscList [(i `div` 2, i) | i <- [1..n]]) bound
         , bench "fromDescList" $ whnf M.fromDescList elems_desc
+        , bench "fromDescList:fusion" $ whnf (\n -> M.fromDescList [(i `div` 2, i) | i <- [n,n-1..1]]) bound
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> M.fromDistinctAscList [(i,i) | i <- [1..n]]) bound
         , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_rev

--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -21,7 +21,7 @@ main = do
         m_even = M.fromAscList elems_even :: M.Map Int Int
         m_odd = M.fromAscList elems_odd :: M.Map Int Int
     evaluate $ rnf [m, m_even, m_odd]
-    evaluate $ rnf elems_rev
+    evaluate $ rnf [elems_rev, elems_asc, elems_desc]
     defaultMain
         [ bench "lookup absent" $ whnf (lookup evens) m_odd
         , bench "lookup present" $ whnf (lookup evens) m_even
@@ -89,7 +89,8 @@ main = do
         , bench "split" $ whnf (M.split (bound `div` 2)) m
         , bench "fromList" $ whnf M.fromList elems
         , bench "fromList-desc" $ whnf M.fromList (reverse elems)
-        , bench "fromAscList" $ whnf M.fromAscList elems
+        , bench "fromAscList" $ whnf M.fromAscList elems_asc
+        , bench "fromDescList" $ whnf M.fromDescList elems_desc
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> M.fromDistinctAscList [(i,i) | i <- [1..n]]) bound
         , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_rev
@@ -102,6 +103,10 @@ main = do
     elems_even = zip evens evens
     elems_odd = zip odds odds
     elems_rev = reverse elems
+    keys_asc = map (`div` 2) [1..bound]
+    elems_asc = zip keys_asc values
+    keys_desc = map (`div` 2) [bound,bound-1..1]
+    elems_desc = zip keys_desc values
     keys = [1..bound]
     evens = [2,4..bound]
     odds = [1,3..bound]

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -14,7 +14,7 @@ main = do
         s_odd = S.fromAscList elems_odd :: S.Set Int
         strings_s = S.fromList strings
     evaluate $ rnf [s, s_even, s_odd]
-    evaluate $ rnf elems_rev
+    evaluate $ rnf [elems_rev, elems_asc, elems_desc]
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
@@ -33,9 +33,10 @@ main = do
         , bench "intersection" $ whnf (S.intersection s) s_even
         , bench "fromList" $ whnf S.fromList elems
         , bench "fromList-desc" $ whnf S.fromList (reverse elems)
-        , bench "fromAscList" $ whnf S.fromAscList elems
+        , bench "fromAscList" $ whnf S.fromAscList elems_asc
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
+        , bench "fromDescList" $ whnf S.fromDescList elems_desc
         , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_rev
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even
@@ -62,6 +63,8 @@ main = do
     elems_even = [2,4..bound]
     elems_odd = [1,3..bound]
     elems_rev = reverse elems
+    elems_asc = map (`div` 2) [1..bound]
+    elems_desc = map (`div` 2) [bound,bound-1..1]
     strings = map show elems
 
 member :: [Int] -> S.Set Int -> Int

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -36,7 +36,9 @@ main = do
         , bench "fromAscList" $ whnf S.fromAscList elems_asc
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
+        , bench "fromAscList:fusion" $ whnf (\n -> S.fromAscList [i `div` 2 | i <- [1..n]]) bound
         , bench "fromDescList" $ whnf S.fromDescList elems_desc
+        , bench "fromDescList:fusion" $ whnf (\n -> S.fromDescList [i `div` 2 | i <- [n,n-1..1]]) bound
         , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_rev
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 import qualified Data.IntSet as IntSet
-import Data.List (nub,sort)
+import Data.List (nub, sort, sortBy)
 import qualified Data.List as List
 import Data.Monoid (mempty)
 import Data.Maybe
@@ -15,6 +15,7 @@ import Control.Monad.Trans.Class
 import Control.Monad (liftM, liftM3)
 import Data.Functor.Identity
 import Data.Foldable (all)
+import Data.Ord (Down(..), comparing)
 import Control.Applicative (liftA2)
 
 #if __GLASGOW_HASKELL__ >= 806
@@ -67,8 +68,9 @@ main = defaultMain $ testGroup "set-properties"
                    , testProperty "prop_DescList" prop_DescList
                    , testProperty "prop_AscDescList" prop_AscDescList
                    , testProperty "prop_fromList" prop_fromList
+                   , testProperty "prop_fromAscList" prop_fromAscList
                    , testProperty "prop_fromDistinctAscList" prop_fromDistinctAscList
-                   , testProperty "prop_fromListDesc" prop_fromListDesc
+                   , testProperty "prop_fromDescList" prop_fromDescList
                    , testProperty "prop_fromDistinctDescList" prop_fromDistinctDescList
                    , testProperty "prop_isProperSubsetOf" prop_isProperSubsetOf
                    , testProperty "prop_isProperSubsetOf2" prop_isProperSubsetOf2
@@ -515,10 +517,18 @@ prop_AscDescList xs = toAscList s == reverse (toDescList s)
 
 prop_fromList :: [Int] -> Property
 prop_fromList xs =
-           t === fromAscList sort_xs .&&.
+           valid t .&&.
            t === List.foldr insert empty xs
   where t = fromList xs
-        sort_xs = sort xs
+
+prop_fromAscList :: [Int] -> Property
+prop_fromAscList xs =
+    valid t .&&.
+    toList t === nub_sort_xs
+  where
+    sort_xs = sort xs
+    t = fromAscList sort_xs
+    nub_sort_xs = List.map List.head $ List.group sort_xs
 
 prop_fromDistinctAscList :: [Int] -> Property
 prop_fromDistinctAscList xs =
@@ -528,22 +538,22 @@ prop_fromDistinctAscList xs =
     t = fromDistinctAscList nub_sort_xs
     nub_sort_xs = List.map List.head $ List.group $ sort xs
 
-prop_fromListDesc :: [Int] -> Property
-prop_fromListDesc xs =
-           t === fromDescList sort_xs .&&.
-           t === fromDistinctDescList nub_sort_xs .&&.
-           t === List.foldr insert empty xs
-  where t = fromList xs
-        sort_xs = reverse (sort xs)
-        nub_sort_xs = List.map List.head $ List.group sort_xs
+prop_fromDescList :: [Int] -> Property
+prop_fromDescList xs =
+    valid t .&&.
+    toList t === reverse nub_down_sort_xs
+  where
+    down_sort_xs = sortBy (comparing Down) xs
+    t = fromDescList down_sort_xs
+    nub_down_sort_xs = List.map List.head $ List.group down_sort_xs
 
 prop_fromDistinctDescList :: [Int] -> Property
 prop_fromDistinctDescList xs =
     valid t .&&.
-    toList t === nub_sort_xs
+    toList t === reverse nub_down_sort_xs
   where
-    t = fromDistinctDescList (reverse nub_sort_xs)
-    nub_sort_xs = List.map List.head $ List.group $ sort xs
+    t = fromDistinctDescList nub_down_sort_xs
+    nub_down_sort_xs = List.map List.head $ List.group $ sortBy (comparing Down) xs
 
 {--------------------------------------------------------------------
   Set operations are like IntSet operations


### PR DESCRIPTION
Following up on https://github.com/haskell/containers/issues/949#issuecomment-1574528332

This PR is based off #962, so marking as draft.

This PR improves
* `Set.fromAscList`, `Set.fromDescList`
* `Map.fromAscList`, `Map.fromDescList`, `Map.fromAscListWith`, `Map.fromDescListWith`, `Map.fromAscListWithKey`, `Map.fromDescListWithKey`

by making the combine function they use a good consumer and producer in terms of fusion. This gets rid of the intermediate list always created today, and also fuses with the input list if possible.

---

Benchmarks on GHC 9.2.5:

<details>
<summary>Before</summary>

```
Set
  fromAscList:         OK (0.20s)
    50.1 μs ± 2.9 μs, 240 KB allocated, 2.4 KB copied, 8.0 MB peak memory
  fromAscList:fusion:  OK (0.19s)
    89.5 μs ± 5.7 μs, 528 KB allocated, 6.8 KB copied, 8.0 MB peak memory
  fromDescList:        OK (0.22s)
    51.2 μs ± 2.9 μs, 240 KB allocated, 2.4 KB copied, 8.0 MB peak memory
  fromDescList:fusion: OK (0.18s)
    88.9 μs ± 5.7 μs, 559 KB allocated, 7.3 KB copied, 8.0 MB peak memory

Map
  fromAscList:         OK (0.18s)
    41.9 μs ± 3.6 μs, 343 KB allocated, 5.2 KB copied,  10 MB peak memory
  fromAscList:fusion:  OK (0.13s)
    63.0 μs ± 6.0 μs, 792 KB allocated,  15 KB copied,  10 MB peak memory
  fromDescList:        OK (0.17s)
    40.5 μs ± 3.9 μs, 343 KB allocated, 5.5 KB copied,  10 MB peak memory
  fromDescList:fusion: OK (0.25s)
    63.1 μs ± 5.3 μs, 824 KB allocated,  16 KB copied,  10 MB peak memory
```

</details>

After

```
Set
  fromAscList:         OK (0.18s)
    21.3 μs ± 1.4 μs, 128 KB allocated, 1.4 KB copied, 8.0 MB peak memory, 57% less than baseline
  fromAscList:fusion:  OK (0.89s)
    13.3 μs ± 221 ns, 144 KB allocated, 1.9 KB copied, 8.0 MB peak memory, 85% less than baseline
  fromDescList:        OK (0.18s)
    20.9 μs ± 1.6 μs, 128 KB allocated, 1.5 KB copied, 8.0 MB peak memory, 59% less than baseline
  fromDescList:fusion: OK (0.23s)
    13.7 μs ± 737 ns, 144 KB allocated, 2.0 KB copied, 8.0 MB peak memory, 84% less than baseline

Map
  fromAscList:        OK (0.22s)
    25.5 μs ± 2.0 μs, 152 KB allocated, 2.1 KB copied,  10 MB peak memory, 39% less than baseline
  fromAscList:fusion: OK (0.30s)
    18.0 μs ± 677 ns, 232 KB allocated, 4.3 KB copied,  10 MB peak memory, 71% less than baseline
  fromDescList:        OK (0.21s)
    25.1 μs ± 1.4 μs, 152 KB allocated, 2.1 KB copied,  10 MB peak memory, 38% less than baseline
  fromDescList:fusion: OK (0.20s)
    50.2 μs ± 3.1 μs, 577 KB allocated,  11 KB copied,  10 MB peak memory, 20% less than baseline
```

Some observations:
* There is no allocations penalty (unlike #950), likely because we rid of the intermediate list and avoid a lot of allocations there.
* Map's `fromDescList:fusion` improves but not as much as `fromAscList:fusion`. The cause seems be that fusion with `[n,n-1..1]` does not work out as well as `[1..n]`, but I don't know why and didn't dig into it much.