### PR TITLE
Add Data.IntSet.fromRange

### DIFF
--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -38,6 +38,8 @@ main = do
         , bench "difference" $ whnf (IS.difference s) s_even
         , bench "intersection" $ whnf (IS.intersection s) s_even
         , bench "fromList" $ whnf IS.fromList elems
+        , bench "fromRange" $ whnf IS.fromRange (1,bound)
+        , bench "fromRange:small" $ whnf IS.fromRange (-1,0)
         , bench "fromAscList" $ whnf IS.fromAscList elems
         , bench "fromDistinctAscList" $ whnf IS.fromDistinctAscList elems
         , bench "disjoint:false" $ whnf (IS.disjoint s) s_even
@@ -56,12 +58,13 @@ main = do
         , bench "splitMember:sparse" $ whnf (IS.splitMember elem_sparse_mid) s_sparse
         ]
   where
-    elems = [1..2^12]
-    elems_even = [2,4..2^12]
-    elems_odd = [1,3..2^12]
-    elem_mid = 2^11 + 31 -- falls in the middle of a packed Tip bitmask (assuming 64-bit words)
+    bound = 2^12
+    elems = [1..bound]
+    elems_even = [2,4..bound]
+    elems_odd = [1,3..bound]
+    elem_mid = bound `div` 2 + 31 -- falls in the middle of a packed Tip bitmask (assuming 64-bit words)
     elems_sparse = map (*64) elems -- when built into a map, each Tip is a singleton
-    elem_sparse_mid = 2^11 * 64
+    elem_sparse_mid = bound `div` 2 * 64
 
 member :: [Int] -> IS.IntSet -> Int
 member xs s = foldl' (\n x -> if IS.member x s then n + 1 else n) 0 xs

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -45,6 +45,7 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_DescList" prop_DescList
                    , testProperty "prop_AscDescList" prop_AscDescList
                    , testProperty "prop_fromList" prop_fromList
+                   , testProperty "prop_fromRange" prop_fromRange
                    , testProperty "prop_MaskPow2" prop_MaskPow2
                    , testProperty "prop_Prefix" prop_Prefix
                    , testProperty "prop_LeftRight" prop_LeftRight
@@ -276,6 +277,12 @@ prop_fromList xs
            t === List.foldr insert empty xs
   where sort_xs = sort xs
         nub_sort_xs = List.map List.head $ List.group sort_xs
+
+prop_fromRange :: Property
+prop_fromRange = forAll (scale (*100) arbitrary) go
+  where
+    go (l,h) = valid t .&&. t === fromAscList [l..h]
+      where t = fromRange (l,h)
 
 {--------------------------------------------------------------------
   Bin invariants

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -76,6 +76,7 @@ module Data.IntSet (
             , empty
             , singleton
             , fromList
+            , fromRange
             , fromAscList
             , fromDistinctAscList
 


### PR DESCRIPTION
For #632

Benchmark on GHC 9.2.5:
```
  fromRange:       OK (0.20s)
    376  ns ±  22 ns, 4.0 KB allocated,   2 B  copied, 7.0 MB peak memory
  fromRange:small: OK (0.18s)
    10.0 ns ± 872 ps, 119 B  allocated,   0 B  copied, 7.0 MB peak memory
```

Comparing `fromDistinctAscList [1..2^12]` from #951 against `fromRange (1,2^12)`, currently it takes `24.3 μs` (~62x the time) and with fusion it would still take `4.49 μs` (~11x the time).