### PR TITLE
Future-proof testsuite against potential Prelude.foldl' 

### DIFF
--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -21,7 +21,7 @@ import Data.Ord
 import Data.Foldable (foldMap)
 import Data.Function
 import Data.Traversable (Traversable(traverse), foldMapDefault)
-import Prelude hiding (lookup, null, map, filter, foldr, foldl)
+import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl')
 import qualified Prelude (map)
 
 import Data.List (nub,sort)

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -8,7 +8,7 @@ import qualified Data.List as List
 import Data.Monoid (mempty)
 import qualified Data.Set as Set
 import IntSetValidity (valid)
-import Prelude hiding (lookup, null, map, filter, foldr, foldl)
+import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl')
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck hiding ((.&.))

--- a/containers-tests/tests/intset-strictness.hs
+++ b/containers-tests/tests/intset-strictness.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
-import Prelude hiding (foldl)
+import Prelude hiding (foldl, foldl')
 
 import Test.ChasingBottoms.IsBottom
 import Test.Tasty (TestTree, defaultMain, testGroup)

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -23,7 +23,7 @@ import Data.Semigroup (Arg(..))
 import Data.Function
 import qualified Data.Foldable as Foldable
 import qualified Data.Bifoldable as Bifoldable
-import Prelude hiding (lookup, null, map, filter, foldr, foldl, take, drop, splitAt)
+import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl', take, drop, splitAt)
 import qualified Prelude
 
 import Data.List (nub,sort)

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -30,7 +30,7 @@ import Data.Semigroup (stimes, stimesMonoid)
 import Data.Traversable (Traversable(traverse), sequenceA)
 import Prelude hiding (
   lookup, null, length, take, drop, splitAt,
-  foldl, foldl1, foldr, foldr1, scanl, scanl1, scanr, scanr1,
+  foldl, foldl', foldl1, foldr, foldr1, scanl, scanl1, scanr, scanr1,
   filter, reverse, replicate, zip, zipWith, zip3, zipWith3,
   all, sum)
 import qualified Prelude

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -5,7 +5,7 @@ import qualified Data.List as List
 import Data.Monoid (mempty)
 import Data.Maybe
 import Data.Set
-import Prelude hiding (lookup, null, map, filter, foldr, foldl, all, take, drop, splitAt)
+import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl', all, take, drop, splitAt)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck


### PR DESCRIPTION
This is a follow-up to https://github.com/haskell/containers/pull/948.
That only dealt with the library. This also makes the test suites compatible