### PR TITLE
Import `Data.Array.ST` instead of `Data.Array.ST.Safe`

### DIFF
--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -108,11 +108,11 @@ import Utils.Containers.Internal.Prelude
 import Prelude ()
 #if USE_ST_MONAD
 import Control.Monad.ST
-import Data.Array.ST.Safe (newArray, readArray, writeArray)
+import Data.Array.ST (newArray, readArray, writeArray)
 # if USE_UNBOXED_ARRAYS
-import Data.Array.ST.Safe (STUArray)
+import Data.Array.ST (STUArray)
 # else
-import Data.Array.ST.Safe (STArray)
+import Data.Array.ST (STArray)
 # endif
 #else
 import Data.IntSet (IntSet)

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -6,8 +6,10 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
+#if !MIN_VERSION_array(0,5,7)
+{-# LANGUAGE Trustworthy #-}
+#endif
 #endif
 #ifdef DEFINE_PATTERN_SYNONYMS
 {-# LANGUAGE PatternSynonyms #-}


### PR DESCRIPTION
`Data.Array.ST` exports the same things as `Data.Array.ST.Safe`, the latter was just added as a migration strategy. The `*.Safe` modules in `array` might get deprecated in the future, see https://gitlab.haskell.org/ghc/packages/array/-/issues/11.