### PR TITLE
Perf/lazy insert ptr removal

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -35,6 +35,7 @@ main = do
         , bench "alterF no rules lookup present" $ whnf (atLookupNoRules evens) m_even
         , bench "insert absent" $ whnf (ins elems_even) m_odd
         , bench "insert present" $ whnf (ins elems_even) m_even
+        , bench "insert alternate" $ whnf (ins elems_alts) m_even
         , bench "alterF insert absent" $ whnf (atIns elems_even) m_odd
         , bench "alterF insert present" $ whnf (atIns elems_even) m_even
         , bench "alterF no rules insert absent" $ whnf (atInsNoRules elems_even) m_odd
@@ -100,6 +101,7 @@ main = do
     bound = 2^12
     elems = zip keys values
     elems_even = zip evens evens
+    elems_alts = zip evens odds
     elems_odd = zip odds odds
     elems_rev = reverse elems
     keys = [1..bound]


### PR DESCRIPTION
This is to open the conversation. I haven't looked at the strict version or any other alternatives like `insertR`.

I'm not convinced that the optimisations for identical pointers is worth the complexity, and it hurts performance for inserts of new elements and the replacement of elements compared to this version.


```
Old
  insert absent:    OK (1.46s)
    352  μs ±  27 μs
  insert same:      OK (1.63s)
    194  μs ±  16 μs
  insert alternate: OK (1.45s)
    351  μs ±  28 μs


New
  insert absent:    OK (1.27s)
    312  μs ±  29 μs
  insert same:      OK (2.00s)
    242  μs ±  13 μs
  insert alternate: OK (1.27s)
    308  μs ±  29 μs
```