### PR TITLE
Make IntMap split, splitLookup strict in the key

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -1,5 +1,14 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
 
+## Next release
+
+### Breaking changes
+
+* `Data.IntMap.Lazy.split`, `Data.IntMap.Strict.split`,
+  `Data.IntMap.Lazy.splitLookup` and `Data.IntMap.Strict.splitLookup` are now
+  strict in the key. Previously, the key was ignored for an empty map.
+  (Soumik Sarkar)
+
 ## 0.7
 
 ### Breaking changes

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -2815,7 +2815,7 @@ split k t =
     _ -> case go k t of
           (lt :*: gt) -> (lt, gt)
   where
-    go k' t'@(Bin p m l r)
+    go !k' t'@(Bin p m l r)
       | nomatch k' p m = if k' > p then t' :*: Nil else Nil :*: t'
       | zero k' m = case go k' l of (lt :*: gt) -> lt :*: bin p m gt r
       | otherwise = case go k' r of (lt :*: gt) -> bin p m l lt :*: gt
@@ -2857,7 +2857,7 @@ splitLookup k t =
       _ -> go k t
   of SplitLookup lt fnd gt -> (lt, fnd, gt)
   where
-    go k' t'@(Bin p m l r)
+    go !k' t'@(Bin p m l r)
       | nomatch k' p m =
           if k' > p
           then SplitLookup t' Nothing Nil


### PR DESCRIPTION
All IntMap and IntSet functions taking a key are strict in the key. This allows the Int to be unboxed.

This is technically a breaking change. Currently `split undefined empty = (empty, empty)`, but with this change `split undefined empty = undefined`.