### PR TITLE
Make IntSet splitMember strict in the key

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -5,9 +5,9 @@
 ### Breaking changes
 
 * `Data.IntMap.Lazy.split`, `Data.IntMap.Strict.split`,
-  `Data.IntMap.Lazy.splitLookup` and `Data.IntMap.Strict.splitLookup` are now
-  strict in the key. Previously, the key was ignored for an empty map.
-  (Soumik Sarkar)
+  `Data.IntMap.Lazy.splitLookup`, `Data.IntMap.Strict.splitLookup` and
+  `Data.IntSet.splitMember` are now strict in the key. Previously, the key was
+  ignored for an empty map or set. (Soumik Sarkar)
 
 ## 0.7
 

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -936,7 +936,7 @@ splitMember x t =
               in (lt, fnd, gt')
     _ -> go x t
   where
-    go x' t'@(Bin p m l r)
+    go !x' t'@(Bin p m l r)
         | nomatch x' p m = if x' < p then (Nil, False, t') else (t', False, Nil)
         | zero x' m =
           case go x' l of


### PR DESCRIPTION
Currently, the key is ignored for an empty set.

Similar to #982. I didn't notice it earlier else I would have included it there.

IntSet.split is already strict.