### PR TITLE
Fix strictness bugs in `fromDistinctAscList` and `fromDistinctDescList`

### DIFF
--- a/containers-tests/tests/Utils/NoThunks.hs
+++ b/containers-tests/tests/Utils/NoThunks.hs
@@ -1,15 +1,12 @@
 module Utils.NoThunks (whnfHasNoThunks) where
 
-import Data.Maybe (isNothing)
-
 import NoThunks.Class (NoThunks, noThunks)
-import Test.QuickCheck (Property, ioProperty)
+import Test.QuickCheck (Property, counterexample, ioProperty, property)
 
 -- | Check that after evaluating the argument to weak head normal form there
 -- are no thunks.
 --
 whnfHasNoThunks :: NoThunks a => a -> Property
-whnfHasNoThunks a = ioProperty
-                  . fmap isNothing
-                  . noThunks []
-                 $! a
+whnfHasNoThunks a = ioProperty $
+  maybe (property True) ((`counterexample` False) . show)
+    <$> (noThunks [] $! a)

--- a/containers-tests/tests/intmap-strictness.hs
+++ b/containers-tests/tests/intmap-strictness.hs
@@ -116,6 +116,13 @@ pStrictFoldl' :: IntMap Int -> Property
 pStrictFoldl' m = whnfHasNoThunks (M.foldl' (flip (:)) [] m)
 #endif
 
+#if __GLASGOW_HASKELL__ >= 806
+pStrictFromDistinctAscList :: [Int] -> Property
+pStrictFromDistinctAscList = whnfHasNoThunks . evalSpine . M.elems . M.fromDistinctAscList . zip [0::Int ..] . map (Just $!)
+  where
+    evalSpine xs = length xs `seq` xs
+#endif
+
 ------------------------------------------------------------------------
 -- check for extra thunks
 --
@@ -202,6 +209,7 @@ tests =
 #if __GLASGOW_HASKELL__ >= 806
       , testProperty "strict foldr'" pStrictFoldr'
       , testProperty "strict foldl'" pStrictFoldl'
+      , testProperty "strict fromDistinctAscList" pStrictFromDistinctAscList
 #endif
       ]
       , tExtraThunksM

--- a/containers-tests/tests/map-strictness.hs
+++ b/containers-tests/tests/map-strictness.hs
@@ -108,6 +108,20 @@ pStrictFoldlWithKey' :: Map Int Int -> Property
 pStrictFoldlWithKey' m = whnfHasNoThunks (M.foldlWithKey' (\as _ a -> a : as) [] m)
 #endif
 
+#if __GLASGOW_HASKELL__ >= 806
+pStrictFromDistinctAscList :: [Int] -> Property
+pStrictFromDistinctAscList = whnfHasNoThunks . evalSpine . M.elems . M.fromDistinctAscList . zip [0::Int ..] . map (Just $!)
+  where
+    evalSpine xs = length xs `seq` xs
+#endif
+
+#if __GLASGOW_HASKELL__ >= 806
+pStrictFromDistinctDescList :: [Int] -> Property
+pStrictFromDistinctDescList = whnfHasNoThunks . evalSpine . M.elems . M.fromDistinctDescList . zip [0::Int, -1 ..] . map (Just $!)
+  where
+    evalSpine xs = length xs `seq` xs
+#endif
+
 ------------------------------------------------------------------------
 -- check for extra thunks
 --
@@ -193,6 +207,8 @@ tests =
       , testProperty "strict foldl'" pStrictFoldl'
       , testProperty "strict foldrWithKey'" pStrictFoldrWithKey'
       , testProperty "strict foldlWithKey'" pStrictFoldlWithKey'
+      , testProperty "strict fromDistinctAscList" pStrictFromDistinctAscList
+      , testProperty "strict fromDistinctDescList" pStrictFromDistinctDescList
 #endif
       ]
       , tExtraThunksM

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1762,7 +1762,7 @@ fromDistinctAscList = fromDistinctAscList_linkAll . Foldable.foldl' next (State0
   where
     next :: FromDistinctMonoState k a -> (k,a) -> FromDistinctMonoState k a
     next (State0 stk) (!kx, !x) = fromDistinctAscList_linkTop (Bin 1 kx x Tip Tip) stk
-    next (State1 l stk) (kx, x) = State0 (Push kx x l stk)
+    next (State1 l stk) (!kx, !x) = State0 (Push kx x l stk)
 {-# INLINE fromDistinctAscList #-}  -- INLINE for fusion
 
 -- | \(O(n)\). Build a map from a descending list of distinct elements in linear time.
@@ -1781,5 +1781,5 @@ fromDistinctDescList = fromDistinctDescList_linkAll . Foldable.foldl' next (Stat
   where
     next :: FromDistinctMonoState k a -> (k,a) -> FromDistinctMonoState k a
     next (State0 stk) (!kx, !x) = fromDistinctDescList_linkTop (Bin 1 kx x Tip Tip) stk
-    next (State1 r stk) (kx, x) = State0 (Push kx x r stk)
+    next (State1 r stk) (!kx, !x) = State0 (Push kx x r stk)
 {-# INLINE fromDistinctDescList #-}  -- INLINE for fusion


### PR DESCRIPTION
The `fromDistinctAscList` and `fromDistinctDescList` functions from `Data.Map.Strict` fail to enforce strictness on values.

Consider the following `ghci` session:

```
λ> import qualified Data.Map.Strict as Map
λ> l = Map.elems . Map.fromDistinctAscList . zip ['a'..'f'] $ Just <$> [0::Int ..]
λ> length l
6
λ> :sprint l
l = [Just 0,_,Just 2,_,Just 4,_]
```

The odd-numbered elements are still thunks. This strange behaviour is caused by the two-state algorithm used in the functions. In particular, in `State1` the value isn't forced because the `Push` datatype from the lazy interface is used, and this doesn't have strict fields:

```haskell
next (State1 l stk) (kx, x) = State0 (Push kx x l stk)
```

The solution is to add bangs to the tuple arguments in the `State1` pattern like there are in the `State0` pattern:

```haskell
next (State0 stk) (!kx, !x) = ...
next (State1 l stk) (!kx, !x) = ...
```
I've added two new `NoThunks` tests that demonstrate this problem.

Unfortunately, the existing strictness tests aren't failing, for several reasons:

1. The `fromDistinctAscList` tests don't actually call `fromDistinctAscList`
2. The tests use a one-element list as input
3. The units used as elements aren't lazy enough

I haven't tried to fix these as I'm not sure how they would ever fail in their present form.

The benchmarks show no difference in performance as a result of this PR.

The bug isn't present in `IntMap` but I added a test for it anyway.