### PR TITLE
Remove hetPtrEq

### DIFF
--- a/containers/src/Utils/Containers/Internal/PtrEquality.hs
+++ b/containers/src/Utils/Containers/Internal/PtrEquality.hs
@@ -6,12 +6,10 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 -- | Really unsafe pointer equality
-module Utils.Containers.Internal.PtrEquality (ptrEq, hetPtrEq) where
+module Utils.Containers.Internal.PtrEquality (ptrEq) where
 
 #ifdef __GLASGOW_HASKELL__
-import GHC.Exts ( reallyUnsafePtrEquality# )
-import Unsafe.Coerce ( unsafeCoerce )
-import GHC.Exts ( Int#, isTrue# )
+import GHC.Exts ( isTrue#, reallyUnsafePtrEquality# )
 #endif
 
 -- | Checks if two pointers are equal. Yes means yes;
@@ -19,24 +17,13 @@ import GHC.Exts ( Int#, isTrue# )
 -- WHNF before comparison to get moderately reliable results.
 ptrEq :: a -> a -> Bool
 
--- | Checks if two pointers are equal, without requiring
--- them to have the same type. The values should be forced
--- to at least WHNF before comparison to get moderately
--- reliable results.
-hetPtrEq :: a -> b -> Bool
-
 #ifdef __GLASGOW_HASKELL__
 ptrEq x y = isTrue# (reallyUnsafePtrEquality# x y)
-hetPtrEq x y = isTrue# (unsafeCoerce (reallyUnsafePtrEquality# :: x -> x -> Int#) x y)
-
 #else
 -- Not GHC
 ptrEq _ _ = False
-hetPtrEq _ _ = False
 #endif
 
 {-# INLINE ptrEq #-}
-{-# INLINE hetPtrEq #-}
 
 infix 4 `ptrEq`
-infix 4 `hetPtrEq`


### PR DESCRIPTION
This is unusued today, and triggers an hpc bug by merely existing.

As suggested in https://github.com/haskell/containers/issues/997#issuecomment-2027831451