### PR TITLE
Fix Issue 1004: effect order in filterAMissing

### DIFF
--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2891,12 +2891,12 @@ filterWithKey p t@(Bin _ kx x l r)
 filterWithKeyA :: Applicative f => (k -> a -> f Bool) -> Map k a -> f (Map k a)
 filterWithKeyA _ Tip = pure Tip
 filterWithKeyA p t@(Bin _ kx x l r) =
-  liftA3 combine (p kx x) (filterWithKeyA p l) (filterWithKeyA p r)
+  liftA3 combine (filterWithKeyA p l) (p kx x) (filterWithKeyA p r)
   where
-    combine True pl pr
+    combine pl True pr
       | pl `ptrEq` l && pr `ptrEq` r = t
       | otherwise = link kx x pl pr
-    combine False pl pr = link2 pl pr
+    combine pl False pr = link2 pl pr
 
 -- | \(O(\log n)\). Take while a predicate on the keys holds.
 -- The user is responsible for ensuring that for all keys @j@ and @k@ in the map,


### PR DESCRIPTION
The order of Applicative effects in filterAMissing
was incorrect, causing the order of effects to
differ from key order and be influenced by how
the binary tree was balanced.

The fix is to arrange that effects arising from
the key and value at an internal node come after
those in its left branch instead of before.
(Regardless of this fix such effects come before
those effects arising from the right branch.)

This change also expands test coverage
to detect a regression of this fix.