### PR TITLE
More efficient Eq, Ord for Set, Map

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -95,6 +95,8 @@ main = do
         , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_rev
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> M.fromDistinctDescList [(i,i) | i <- [n,n-1..1]]) bound
         , bench "minView" $ whnf (\m' -> case M.minViewWithKey m' of {Nothing -> 0; Just ((k,v),m'') -> k+v+M.size m''}) (M.fromAscList $ zip [1..10::Int] [100..110::Int])
+        , bench "eq" $ whnf (\m' -> m' == m') m -- worst case, compares everything
+        , bench "compare" $ whnf (\m' -> compare m' m') m -- worst case, compares everything
         ]
   where
     bound = 2^12

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -55,6 +55,8 @@ main = do
         , bench "member.powerSet (16)" $ whnf (\ s -> all (flip S.member s) s) (S.powerSet (S.fromList [1..16]))
         , bench "member.powerSet (17)" $ whnf (\ s -> all (flip S.member s) s) (S.powerSet (S.fromList [1..17]))
         , bench "member.powerSet (18)" $ whnf (\ s -> all (flip S.member s) s) (S.powerSet (S.fromList [1..18]))
+        , bench "eq" $ whnf (\s' -> s' == s') s -- worst case, compares everything
+        , bench "compare" $ whnf (\s' -> compare s' s') s -- worst case, compares everything
         ]
   where
     bound = 2^12

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -124,6 +124,7 @@ library
     Utils.Containers.Internal.PtrEquality
     Utils.Containers.Internal.State
     Utils.Containers.Internal.StrictMaybe
+    Utils.Containers.Internal.EqOrdUtil
 
   if impl(ghc)
     other-modules:

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -33,7 +33,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import Test.QuickCheck.Function (apply)
-import Test.QuickCheck.Poly (A, B)
+import Test.QuickCheck.Poly (A, B, OrdA)
 import Control.Arrow (first)
 
 default (Int)
@@ -250,6 +250,8 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "splitAt"              prop_splitAt
          , testProperty "lookupMin"            prop_lookupMin
          , testProperty "lookupMax"            prop_lookupMax
+         , testProperty "eq"                   prop_eq
+         , testProperty "compare"              prop_compare
          ]
 
 {--------------------------------------------------------------------
@@ -1636,3 +1638,9 @@ prop_fromArgSet :: [(Int, Int)] -> Bool
 prop_fromArgSet ys =
   let xs = List.nubBy ((==) `on` fst) ys
   in fromArgSet (Set.fromList $ List.map (uncurry Arg) xs) == fromList xs
+
+prop_eq :: Map Int A -> Map Int A -> Property
+prop_eq m1 m2 = (m1 == m2) === (toList m1 == toList m2)
+
+prop_compare :: Map Int OrdA -> Map Int OrdA -> Property
+prop_compare m1 m2 = compare m1 m2 === compare (toList m1) (toList m2)

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -110,6 +110,8 @@ main = defaultMain $ testGroup "set-properties"
                    , testProperty "strict foldr"         prop_strictFoldr'
                    , testProperty "strict foldl"         prop_strictFoldl'
 #endif
+                   , testProperty "eq" prop_eq
+                   , testProperty "compare" prop_compare
                    ]
 
 -- A type with a peculiar Eq instance designed to make sure keys
@@ -730,3 +732,9 @@ prop_strictFoldr' m = whnfHasNoThunks (foldr' (:) [] m)
 prop_strictFoldl' :: Set Int -> Property
 prop_strictFoldl' m = whnfHasNoThunks (foldl' (flip (:)) [] m)
 #endif
+
+prop_eq :: Set Int -> Set Int -> Property
+prop_eq s1 s2 = (s1 == s2) === (toList s1 == toList s2)
+
+prop_compare :: Set Int -> Set Int -> Property
+prop_compare s1 s2 = compare s1 s2 === compare (toList s1) (toList s2)

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -80,6 +80,7 @@ Library
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality
         Utils.Containers.Internal.Coercions
+        Utils.Containers.Internal.EqOrdUtil
     if impl(ghc)
       other-modules:
         Utils.Containers.Internal.TypeError

--- a/containers/src/Utils/Containers/Internal/EqOrdUtil.hs
+++ b/containers/src/Utils/Containers/Internal/EqOrdUtil.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE CPP #-}
+module Utils.Containers.Internal.EqOrdUtil
+  ( EqM(..)
+  , OrdM(..)
+  ) where
+
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup (Semigroup(..))
+#endif
+import Utils.Containers.Internal.StrictPair
+
+newtype EqM a = EqM { runEqM :: a -> StrictPair Bool a }
+
+-- | Composes left-to-right, short-circuits on False
+instance Semigroup (EqM a) where
+  f <> g = EqM $ \x -> case runEqM f x of
+    r@(e :*: x') -> if e then runEqM g x' else r
+
+instance Monoid (EqM a) where
+  mempty = EqM (True :*:)
+#if !MIN_VERSION_base(4,11,0)
+  mappend = (<>)
+#endif
+
+newtype OrdM a = OrdM { runOrdM :: a -> StrictPair Ordering a }
+
+-- | Composes left-to-right, short-circuits on non-EQ
+instance Semigroup (OrdM a) where
+  f <> g = OrdM $ \x -> case runOrdM f x of
+    r@(o :*: x') -> case o of
+      EQ -> runOrdM g x'
+      _ -> r
+
+instance Monoid (OrdM a) where
+  mempty = OrdM (EQ :*:)
+#if !MIN_VERSION_base(4,11,0)
+  mappend = (<>)
+#endif


### PR DESCRIPTION
More efficient implementation moving away from the `toList` based approach.

For #1016.

---

Benchmarks, on GHC 9.6.3:

```
Set before:
  eq:      OK
    74.9 μs ± 5.6 μs, 447 KB allocated,  86 B  copied, 7.0 MB peak memory
  compare: OK
    61.9 μs ± 5.9 μs, 447 KB allocated,  85 B  copied, 7.0 MB peak memory

Set after:
  eq:      OK
    29.2 μs ± 2.7 μs, 128 KB allocated,  11 B  copied, 7.0 MB peak memory, 61% less than baseline
  compare: OK
    29.1 μs ± 2.8 μs, 128 KB allocated,  11 B  copied, 7.0 MB peak memory, 53% less than baseline

Map before:
  eq:      OK
    123  μs ±  11 μs, 637 KB allocated, 163 B  copied, 9.0 MB peak memory
  compare: OK
    168  μs ±  15 μs, 637 KB allocated, 163 B  copied, 9.0 MB peak memory

Map after:
  eq:      OK
    38.5 μs ± 3.6 μs, 159 KB allocated,  15 B  copied, 9.0 MB peak memory, 68% less than baseline
  compare: OK
    39.1 μs ± 3.4 μs, 159 KB allocated,  15 B  copied, 9.0 MB peak memory, 76% less than baseline
```

Note: Why is the improvement less for `Set`? This is because the benchmarks use `Set Int`, and there happen to be specializations for `Eq [Int]` and `Ord [Int]`. Without specializations, the improvement for `Set` is (70-75%) just like `Map` (see numbers in #1016).