### PR TITLE
Delete findWithDefault for Strict Map/IntMap

### DIFF
--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -316,6 +316,7 @@ import Data.IntMap.Internal
   , isSubmapOf
   , isSubmapOfBy
   , lookup
+  , findWithDefault
   , lookupLE
   , lookupGE
   , lookupLT
@@ -357,28 +358,6 @@ import qualified Data.IntSet.Internal as IntSet
 import Utils.Containers.Internal.BitUtil
 import Utils.Containers.Internal.StrictPair
 import qualified Data.Foldable as Foldable
-
-{--------------------------------------------------------------------
-  Query
---------------------------------------------------------------------}
-
--- | \(O(\min(n,W))\). The expression @('findWithDefault' def k map)@
--- returns the value at key @k@ or returns @def@ when the key is not an
--- element of the map.
---
--- > findWithDefault 'x' 1 (fromList [(5,'a'), (3,'b')]) == 'x'
--- > findWithDefault 'x' 5 (fromList [(5,'a'), (3,'b')]) == 'a'
-
--- See IntMap.Internal.Note: Local 'go' functions and capturing]
-findWithDefault :: a -> Key -> IntMap a -> a
-findWithDefault def !k = go
-  where
-    go (Bin p l r) | nomatch k p = def
-                   | left k p  = go l
-                   | otherwise = go r
-    go (Tip kx x) | k == kx   = x
-                  | otherwise = def
-    go Nil = def
 
 {--------------------------------------------------------------------
   Construction

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -386,6 +386,7 @@ import Data.Map.Internal
   , keysSet
   , link
   , lookup
+  , findWithDefault
   , lookupGE
   , lookupGT
   , lookupIndex
@@ -472,32 +473,6 @@ import qualified Data.Foldable as Foldable
 -- While we *could* do so, we would only get sharing under fairly
 -- narrow conditions and at a relatively high cost. It does not seem
 -- worth the price.
-
-{--------------------------------------------------------------------
-  Query
---------------------------------------------------------------------}
-
--- | \(O(\log n)\). The expression @('findWithDefault' def k map)@ returns
--- the value at key @k@ or returns default value @def@
--- when the key is not in the map.
---
--- > findWithDefault 'x' 1 (fromList [(5,'a'), (3,'b')]) == 'x'
--- > findWithDefault 'x' 5 (fromList [(5,'a'), (3,'b')]) == 'a'
-
--- See Map.Internal.Note: Local 'go' functions and capturing
-findWithDefault :: Ord k => a -> k -> Map k a -> a
-findWithDefault def k = k `seq` go
-  where
-    go Tip = def
-    go (Bin _ kx x l r) = case compare k kx of
-      LT -> go l
-      GT -> go r
-      EQ -> x
-#if __GLASGOW_HASKELL__
-{-# INLINABLE findWithDefault #-}
-#else
-{-# INLINE findWithDefault #-}
-#endif
 
 {--------------------------------------------------------------------
   Construction


### PR DESCRIPTION
They are redundant because they have the same strictness characteristics as the lazy versions.