### PR TITLE
Adjust strictness of from{Asc,Desc}List* for maps

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -9,6 +9,22 @@
   `Data.IntSet.splitMember` are now strict in the key. Previously, the key was
   ignored for an empty map or set. (Soumik Sarkar)
 
+* The following functions have been updated to match the strictness of their
+  `fromList` counterparts:
+
+  * `Data.Map.Strict.fromAscList`
+  * `Data.Map.Strict.fromAscListWith`
+  * `Data.Map.Strict.fromAscListWithKey`
+  * `Data.Map.Strict.fromDescList`
+  * `Data.Map.Strict.fromDescListWith`
+  * `Data.Map.Strict.fromDescListWithKey`
+  * `Data.IntMap.Strict.fromAscList`
+  * `Data.IntMap.Strict.fromAscListWith`
+  * `Data.IntMap.Strict.fromAscListWithKey`
+
+  Previously they were lazier and did not force the first value in runs of at
+  least 2 entries with equal keys. (Soumik Sarkar)
+
 ### Bug fixes
 
 * `Data.Map.Strict.mergeWithKey` now forces the result of the combining function

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1678,20 +1678,20 @@ fromDescListWith f xs
 -- Also see the performance note on 'fromListWith'.
 
 fromAscListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
-fromAscListWithKey f xs
-  = fromDistinctAscList (combineEq f xs)
+fromAscListWithKey f xs0 = fromDistinctAscList xs1
   where
-  -- [combineEq f xs] combines equal elements with function [f] in an ordered list [xs]
-  combineEq _ xs'
-    = case xs' of
-        []     -> []
-        [x]    -> [x]
-        (x:xx) -> combineEq' x xx
+    xs1 = case xs0 of
+      []   -> []
+      [x]  -> [x]
+      x:xs -> combineEq x xs
 
-  combineEq' z [] = [z]
-  combineEq' z@(kz,zz) (x@(kx,xx):xs')
-    | kx==kz    = let yy = f kx xx zz in yy `seq` combineEq' (kx,yy) xs'
-    | otherwise = z:combineEq' x xs'
+    -- We want to have the same strictness as fromListWithKey, which is achieved
+    -- with the bang on yy.
+    combineEq y@(ky, !yy) xs = case xs of
+      [] -> [y]
+      x@(kx, xx) : xs'
+        | kx == ky -> combineEq (kx, f kx xx yy) xs'
+        | otherwise -> y : combineEq x xs'
 #if __GLASGOW_HASKELL__
 {-# INLINABLE fromAscListWithKey #-}
 #endif
@@ -1708,20 +1708,20 @@ fromAscListWithKey f xs
 -- Also see the performance note on 'fromListWith'.
 
 fromDescListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
-fromDescListWithKey f xs
-  = fromDistinctDescList (combineEq f xs)
+fromDescListWithKey f xs0 = fromDistinctDescList xs1
   where
-  -- [combineEq f xs] combines equal elements with function [f] in an ordered list [xs]
-  combineEq _ xs'
-    = case xs' of
-        []     -> []
-        [x]    -> [x]
-        (x:xx) -> combineEq' x xx
+    xs1 = case xs0 of
+      []   -> []
+      [x]  -> [x]
+      x:xs -> combineEq x xs
 
-  combineEq' z [] = [z]
-  combineEq' z@(kz,zz) (x@(kx,xx):xs')
-    | kx==kz    = let yy = f kx xx zz in yy `seq` combineEq' (kx,yy) xs'
-    | otherwise = z:combineEq' x xs'
+    -- We want to have the same strictness as fromListWithKey, which is achieved
+    -- with the bang on yy.
+    combineEq y@(ky, !yy) xs = case xs of
+      [] -> [y]
+      x@(kx, xx) : xs'
+        | kx == ky -> combineEq (kx, f kx xx yy) xs'
+        | otherwise -> y : combineEq x xs'
 #if __GLASGOW_HASKELL__
 {-# INLINABLE fromDescListWithKey #-}
 #endif


### PR DESCRIPTION
Make the functions strict in the first value of the run of equal keys. This makes the strictness match that of the fromList functions.

Fixes #473.

No impact on benchmarks, on GHC 9.6.3

```
Map:
  fromAscList: OK
    65.2 μs ± 5.4 μs, 686 KB allocated,  21 KB copied, 9.0 MB peak memory,       same as baseline

IntMap:
  fromAscList: OK
    46.3 μs ± 2.7 μs, 223 KB allocated, 6.1 KB copied,  10 MB peak memory,       same as baseline
```