### PR TITLE
Fix Map.Strict.mergeWithKey strictness

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -9,6 +9,11 @@
   `Data.IntSet.splitMember` are now strict in the key. Previously, the key was
   ignored for an empty map or set. (Soumik Sarkar)
 
+### Bug fixes
+
+* `Data.Map.Strict.mergeWithKey` now forces the result of the combining function
+  to WHNF. (Soumik Sarkar)
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1250,7 +1250,7 @@ mergeWithKey f g1 g2 = go
                      _ -> error "mergeWithKey: Given function only1 does not fulfill required conditions (see documentation)"
         Just x2 -> case f kx x x2 of
                      Nothing -> link2 l' r'
-                     Just x' -> link kx x' l' r'
+                     Just !x' -> link kx x' l' r'
       where
         (l2, found, r2) = splitLookup kx t2
         l' = go l1 l2


### PR DESCRIPTION
mergeWithKey is expected to force the result of applying the combining function.

Fixes #1022.