### PR TITLE
Fix discrepancy between mergeWithKey impl and docs

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -14,6 +14,11 @@
 * `Data.Map.Strict.mergeWithKey` now forces the result of the combining function
   to WHNF. (Soumik Sarkar)
 
+* Fix an issue where `Data.Map.mergeWithKey`, `Data.Map.Strict.mergeWithKey`,
+  `Data.IntMap.mergeWithKey`, `Data.IntMap.Strict.mergeWithKey` could call the
+  provided `only2` function with empty maps, contrary to documentation.
+  (Soumik Sarkar)
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -1446,6 +1446,8 @@ mergeWithKey' bin' f g1 g2 = go
           | otherwise = maybe_link k1 (g1 t1) k2 (g2 t2)
         merge0 t1 _  Nil = g1 t1
 
+    go Nil Nil = Nil
+
     go Nil t2 = g2 t2
 
     maybe_link _ Nil _ t2 = t2

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2782,6 +2782,7 @@ mergeWithKey :: Ord k
              -> Map k a -> Map k b -> Map k c
 mergeWithKey f g1 g2 = go
   where
+    go Tip Tip = Tip
     go Tip t2 = g2 t2
     go t1 Tip = g1 t1
     go (Bin _ kx x l1 r1) t2 =

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1240,6 +1240,7 @@ mergeWithKey :: Ord k
              -> Map k a -> Map k b -> Map k c
 mergeWithKey f g1 g2 = go
   where
+    go Tip Tip = Tip
     go Tip t2 = g2 t2
     go t1 Tip = g1 t1
     go (Bin _ kx x l1 r1) t2 =


### PR DESCRIPTION
The given functions should be called only on nonempty trees.

Fixes #979.

This could alternately be fixed by changing the docs. I find it slightly better to keep the specification that the user will not receive an empty tree.