### PR TITLE
Update Eq IntSet and Eq (IntMap a)

### DIFF
--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -53,6 +53,7 @@ main = do
         , bench "spanAntitone" $ whnf (M.spanAntitone (<key_mid)) m
         , bench "split" $ whnf (M.split key_mid) m
         , bench "splitLookup" $ whnf (M.splitLookup key_mid) m
+        , bench "eq" $ whnf (\m' -> m' == m') m
         ]
   where
     elems = elems_hits

--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -53,7 +53,7 @@ main = do
         , bench "spanAntitone" $ whnf (M.spanAntitone (<key_mid)) m
         , bench "split" $ whnf (M.split key_mid) m
         , bench "splitLookup" $ whnf (M.splitLookup key_mid) m
-        , bench "eq" $ whnf (\m' -> m' == m') m
+        , bench "eq" $ whnf (\m' -> m' == m') m -- worst case, compares everything
         ]
   where
     elems = elems_hits

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -56,6 +56,7 @@ main = do
         , bench "split:sparse" $ whnf (IS.split elem_sparse_mid) s_sparse
         , bench "splitMember:dense" $ whnf (IS.splitMember elem_mid) s
         , bench "splitMember:sparse" $ whnf (IS.splitMember elem_sparse_mid) s_sparse
+        , bench "eq" $ whnf (\s' -> s' == s') s
         ]
   where
     bound = 2^12

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -56,7 +56,7 @@ main = do
         , bench "split:sparse" $ whnf (IS.split elem_sparse_mid) s_sparse
         , bench "splitMember:dense" $ whnf (IS.splitMember elem_mid) s
         , bench "splitMember:sparse" $ whnf (IS.splitMember elem_sparse_mid) s_sparse
-        , bench "eq" $ whnf (\s' -> s' == s') s
+        , bench "eq" $ whnf (\s' -> s' == s') s -- worst case, compares everything
         ]
   where
     bound = 2^12

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -3415,8 +3415,7 @@ data Distinct = Distinct | Nondistinct
   Eq
 --------------------------------------------------------------------}
 instance Eq a => Eq (IntMap a) where
-  t1 == t2  = equal t1 t2
-  t1 /= t2  = nequal t1 t2
+  (==) = equal
 
 equal :: Eq a => IntMap a -> IntMap a -> Bool
 equal (Bin p1 l1 r1) (Bin p2 l2 r2)
@@ -3425,14 +3424,7 @@ equal (Tip kx x) (Tip ky y)
   = (kx == ky) && (x==y)
 equal Nil Nil = True
 equal _   _   = False
-
-nequal :: Eq a => IntMap a -> IntMap a -> Bool
-nequal (Bin p1 l1 r1) (Bin p2 l2 r2)
-  = (p1 /= p2) || (nequal l1 l2) || (nequal r1 r2)
-nequal (Tip kx x) (Tip ky y)
-  = (kx /= ky) || (x/=y)
-nequal Nil Nil = False
-nequal _   _   = True
+{-# INLINABLE equal #-}
 
 -- | @since 0.5.9
 instance Eq1 IntMap where

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1388,8 +1388,7 @@ data Inserted = Inserted !IntSet ![Key]
   Eq
 --------------------------------------------------------------------}
 instance Eq IntSet where
-  t1 == t2  = equal t1 t2
-  t1 /= t2  = nequal t1 t2
+  (==) = equal
 
 equal :: IntSet -> IntSet -> Bool
 equal (Bin p1 l1 r1) (Bin p2 l2 r2)
@@ -1398,14 +1397,6 @@ equal (Tip kx1 bm1) (Tip kx2 bm2)
   = kx1 == kx2 && bm1 == bm2
 equal Nil Nil = True
 equal _   _   = False
-
-nequal :: IntSet -> IntSet -> Bool
-nequal (Bin p1 l1 r1) (Bin p2 l2 r2)
-  = (p1 /= p2) || (nequal l1 l2) || (nequal r1 r2)
-nequal (Tip kx1 bm1) (Tip kx2 bm2)
-  = kx1 /= kx2 || bm1 /= bm2
-nequal Nil Nil = False
-nequal _   _   = True
 
 {--------------------------------------------------------------------
   Ord


### PR DESCRIPTION
* Add benchmarks
* Mark the function INLINABLE for IntMap. On benchmarks for IntMap Int this reduces the run time by ~22%.
* Remove definitions for (/=). There is no good reason to implement this manually.

Related to #1016.

---

Benchmarks on GHC 9.6.3

```
IntMap before
  eq: OK
    39.0 μs ± 3.4 μs,   0 B  allocated,   0 B  copied,  10 MB peak memory
IntMap after
  eq: OK
    30.2 μs ± 3.0 μs,   0 B  allocated,   0 B  copied,  10 MB peak memory, 22% less than baseline
```