### PR TITLE
Error on unused-top-binds in tests

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -40,6 +40,9 @@ common deps
     , deepseq  >=1.2     && <1.6
     , template-haskell
 
+common warnings
+  ghc-options: -Werror=unused-top-binds
+
 common test-deps
   import: deps
   build-depends:
@@ -140,7 +143,7 @@ library
 -----------------------------
 
 benchmark intmap-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -148,7 +151,7 @@ benchmark intmap-benchmarks
   ghc-options:    -O2
 
 benchmark intset-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -156,7 +159,7 @@ benchmark intset-benchmarks
   ghc-options:    -O2
 
 benchmark map-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -164,7 +167,7 @@ benchmark map-benchmarks
   ghc-options:    -O2
 
 benchmark tree-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -172,7 +175,7 @@ benchmark tree-benchmarks
   ghc-options:    -O2
 
 benchmark sequence-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -183,7 +186,7 @@ benchmark sequence-benchmarks
     , transformers
 
 benchmark set-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -191,7 +194,7 @@ benchmark set-benchmarks
   ghc-options:    -O2
 
 benchmark graph-benchmarks
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
@@ -201,7 +204,7 @@ benchmark graph-benchmarks
       random            >=0       && <1.2
 
 benchmark set-operations-intmap
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
@@ -210,7 +213,7 @@ benchmark set-operations-intmap
   ghc-options:    -O2
 
 benchmark set-operations-intset
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
@@ -219,7 +222,7 @@ benchmark set-operations-intset
   ghc-options:    -O2
 
 benchmark set-operations-map
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
@@ -228,7 +231,7 @@ benchmark set-operations-map
   ghc-options:    -O2
 
 benchmark set-operations-set
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/SetOperations
@@ -237,7 +240,7 @@ benchmark set-operations-set
   ghc-options:    -O2
 
 benchmark lookupge-intmap
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/LookupGE
@@ -246,7 +249,7 @@ benchmark lookupge-intmap
   build-depends:  containers-tests
 
 benchmark lookupge-map
-  import: benchmark-deps
+  import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks/LookupGE
@@ -263,7 +266,7 @@ benchmark lookupge-map
 -- plus the testing stuff.
 
 test-suite map-lazy-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-properties.hs
@@ -275,7 +278,7 @@ test-suite map-lazy-properties
     CPP
 
 test-suite map-strict-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-properties.hs
@@ -288,7 +291,7 @@ test-suite map-strict-properties
     CPP
 
 test-suite bitqueue-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          bitqueue-properties.hs
@@ -299,7 +302,7 @@ test-suite bitqueue-properties
     CPP
 
 test-suite set-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          set-properties.hs
@@ -317,7 +320,7 @@ test-suite set-properties
       Utils.NoThunks
 
 test-suite intmap-lazy-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-properties.hs
@@ -330,7 +333,7 @@ test-suite intmap-lazy-properties
     CPP
 
 test-suite intmap-strict-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-properties.hs
@@ -344,7 +347,7 @@ test-suite intmap-strict-properties
     CPP
 
 test-suite intset-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intset-properties.hs
@@ -357,7 +360,7 @@ test-suite intset-properties
     CPP
 
 test-suite seq-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          seq-properties.hs
@@ -369,7 +372,7 @@ test-suite seq-properties
     CPP
 
 test-suite tree-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          tree-properties.hs
@@ -381,7 +384,7 @@ test-suite tree-properties
     CPP
 
 test-suite graph-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          graph-properties.hs
@@ -389,7 +392,7 @@ test-suite graph-properties
   ghc-options:      -O2
 
 test-suite map-strictness-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          map-strictness.hs
@@ -412,7 +415,7 @@ test-suite map-strictness-properties
       Utils.NoThunks
 
 test-suite intmap-strictness-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intmap-strictness.hs
@@ -436,7 +439,7 @@ test-suite intmap-strictness-properties
       Utils.NoThunks
 
 test-suite intset-strictness-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs:   tests
   main-is:          intset-strictness.hs
@@ -457,7 +460,7 @@ test-suite intset-strictness-properties
       Utils.NoThunks
 
 test-suite listutils-properties
-  import: test-deps
+  import: test-deps, warnings
   default-language: Haskell2010
   hs-source-dirs: tests
   main-is:        listutils-properties.hs

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -216,13 +216,6 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "isSubmapOfBy"         prop_isSubmapOfBy
              ]
 
-apply2 :: Fun (a, b) c -> a -> b -> c
-apply2 f a b = apply f (a, b)
-
-apply3 :: Fun (a, b, c) d -> a -> b -> c -> d
-apply3 f a b c = apply f (a, b, c)
-
-
 {--------------------------------------------------------------------
   Arbitrary, reasonably balanced trees
 --------------------------------------------------------------------}

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -67,6 +67,8 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_foldL" prop_foldL
                    , testProperty "prop_foldL'" prop_foldL'
                    , testProperty "prop_map" prop_map
+                   , testProperty "prop_mapMonotonicId" prop_mapMonotonicId
+                   , testProperty "prop_mapMonotonicLinear" prop_mapMonotonicLinear
                    , testProperty "prop_maxView" prop_maxView
                    , testProperty "prop_minView" prop_minView
                    , testProperty "prop_split" prop_split
@@ -389,9 +391,13 @@ prop_mapMonotonicId :: IntSet -> Property
 prop_mapMonotonicId s = mapMonotonic id s === map id s
 
 prop_mapMonotonicLinear :: Positive Int -> Int -> IntSet -> Property
-prop_mapMonotonicLinear (Positive a) b s = mapMonotonic f s === map f s
+prop_mapMonotonicLinear (Positive a) b s =
+  all ok (toList s) ==>
+    mapMonotonic f s === map f s
   where
     f x = a*x + b
+    limit = (maxBound - b) `div` a
+    ok x = x /= minBound && abs x <= limit -- must not overflow
 
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -396,8 +396,10 @@ prop_mapMonotonicLinear (Positive a) b s =
     mapMonotonic f s === map f s
   where
     f x = a*x + b
-    limit = (maxBound - b) `div` a
-    ok x = x /= minBound && abs x <= limit -- must not overflow
+    ok x =  -- must not overflow
+      fromIntegral (minBound :: Int) <= y && y <= fromIntegral (maxBound :: Int)
+      where
+        y = fromIntegral a * fromIntegral x + fromIntegral b :: Integer
 
 prop_maxView :: IntSet -> Bool
 prop_maxView s = case maxView s of

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -345,8 +345,7 @@ mkArb step n
 -- A type with a peculiar Eq instance designed to make sure keys
 -- come from where they're supposed to.
 data OddEq a = OddEq a Bool deriving (Show)
-getOddEq :: OddEq a -> (a, Bool)
-getOddEq (OddEq a b) = (a, b)
+
 instance Arbitrary a => Arbitrary (OddEq a) where
   arbitrary = OddEq <$> arbitrary <*> arbitrary
 instance Eq a => Eq (OddEq a) where

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -562,10 +562,8 @@ prop_sort :: Seq OrdA -> Bool
 prop_sort xs =
     toList' (sort xs) ~= Data.List.sort (toList xs)
 
-data UnstableOrd = UnstableOrd
-    { ordKey :: OrdA
-    , _ignored :: A
-    } deriving (Show)
+data UnstableOrd = UnstableOrd OrdA A
+    deriving (Show)
 
 instance Eq UnstableOrd where
     x == y = compare x y == EQ


### PR DESCRIPTION
This guards against defining a test or benchmark but forgetting to include it in the test tree.

This was prompted by https://github.com/haskell/containers/pull/972#discussion_r1730341023, but it turns out we already had a couple of mistakenly unused tests.