### PR TITLE
Update references

### DIFF
--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -36,8 +36,11 @@
 --
 -- The implementation is based on
 --
---   * /Structuring Depth-First Search Algorithms in Haskell/,
---     by David King and John Launchbury, <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.52.6526>
+--   * David King and John Launchbury,
+--     \"/Structuring Depth-First Search Algorithms in Haskell/\",
+--     Proceedings of the 22nd ACM SIGPLAN-SIGACT Symposium on Principles of
+--     Programming Languages, 344-354, 1995,
+--     <https://doi.org/10.1145/199448.199530>.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -44,7 +44,7 @@
 --    * Chris Okasaki and Andy Gill,
 --      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
+--      <https://web.archive.org/web/20150417234429/https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
 --    * D.R. Morrison,
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",

--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -41,12 +41,15 @@
 -- (much) faster on insertions and deletions when compared to a generic
 -- size-balanced map implementation (see "Data.Map").
 --
---    * Chris Okasaki and Andy Gill,  \"/Fast Mergeable Integer Maps/\",
+--    * Chris Okasaki and Andy Gill,
+--      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452>
+--      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
---    * D.R. Morrison, \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
---      Journal of the ACM, 15(4), October 1968, pages 514-534.
+--    * D.R. Morrison,
+--      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
+--      Journal of the ACM, 15(4), October 1968, pages 514-534,
+--      <https://doi.org/10.1145/321479.321481>.
 --
 -- Operation comments contain the operation time complexity in
 -- the Big-O notation <http://en.wikipedia.org/wiki/Big_O_notation>.

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -59,7 +59,7 @@
 --    * Chris Okasaki and Andy Gill,
 --      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
+--      <https://web.archive.org/web/20150417234429/https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
 --    * D.R. Morrison,
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -56,12 +56,15 @@
 -- on insertions and deletions when compared to a generic size-balanced map
 -- implementation (see "Data.Map").
 --
---    * Chris Okasaki and Andy Gill,  \"/Fast Mergeable Integer Maps/\",
+--    * Chris Okasaki and Andy Gill,
+--      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452>
+--      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
---    * D.R. Morrison, \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
---      Journal of the ACM, 15(4), October 1968, pages 514-534.
+--    * D.R. Morrison,
+--      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
+--      Journal of the ACM, 15(4), October 1968, pages 514-534,
+--      <https://doi.org/10.1145/321479.321481>.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -73,12 +73,15 @@
 -- on insertions and deletions when compared to a generic size-balanced map
 -- implementation (see "Data.Map").
 --
---    * Chris Okasaki and Andy Gill,  \"/Fast Mergeable Integer Maps/\",
+--    * Chris Okasaki and Andy Gill,
+--      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452>
+--      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
---    * D.R. Morrison, \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
---      Journal of the ACM, 15(4), October 1968, pages 514-534.
+--    * D.R. Morrison,
+--      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
+--      Journal of the ACM, 15(4), October 1968, pages 514-534,
+--      <https://doi.org/10.1145/321479.321481>.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -76,7 +76,7 @@
 --    * Chris Okasaki and Andy Gill,
 --      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
+--      <https://web.archive.org/web/20150417234429/https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
 --    * D.R. Morrison,
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -48,7 +48,7 @@
 --    * Chris Okasaki and Andy Gill,
 --      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
+--      <https://web.archive.org/web/20150417234429/https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
 --    * D.R. Morrison,
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -45,12 +45,15 @@
 -- (much) faster on insertions and deletions when compared to a generic
 -- size-balanced set implementation (see "Data.Set").
 --
---    * Chris Okasaki and Andy Gill,  \"/Fast Mergeable Integer Maps/\",
+--    * Chris Okasaki and Andy Gill,
+--      \"/Fast Mergeable Integer Maps/\",
 --      Workshop on ML, September 1998, pages 77-86,
---      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452>
+--      <https://ittc.ku.edu/~andygill/papers/IntMap98.pdf>.
 --
---    * D.R. Morrison, \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
---      Journal of the ACM, 15(4), October 1968, pages 514-534.
+--    * D.R. Morrison,
+--      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
+--      Journal of the ACM, 15(4), October 1968, pages 514-534,
+--      <https://doi.org/10.1145/321479.321481>.
 --
 -- Additionally, this implementation places bitmaps in the leaves of the tree.
 -- Their size is the natural size of a machine word (32 or 64 bits) and greatly

--- a/containers/src/Data/Map.hs
+++ b/containers/src/Data/Map.hs
@@ -36,19 +36,25 @@
 -- The implementation of 'Map' is based on /size balanced/ binary trees (or
 -- trees of /bounded balance/) as described by:
 --
---    * Stephen Adams, \"/Efficient sets: a balancing act/\",
---     Journal of Functional Programming 3(4):553-562, October 1993,
---     <http://www.swiss.ai.mit.edu/~adams/BB/>.
+--    * Stephen Adams, \"/Efficient sets—a balancing act/\",
+--      Journal of Functional Programming 3(4):553-562, October 1993,
+--      <https://doi.org/10.1017/S0956796800000885>,
+--      <https://groups.csail.mit.edu/mac/users/adams/BB/index.html>.
 --    * J. Nievergelt and E.M. Reingold,
 --      \"/Binary search trees of bounded balance/\",
 --      SIAM journal of computing 2(1), March 1973.
+--      <https://doi.org/10.1137/0202005>.
+--    * Yoichi Hirai and Kazuhiko Yamamoto,
+--      \"/Balancing weight-balanced trees/\",
+--      Journal of Functional Programming 21(3):287-307, 2011,
+--      <https://doi.org/10.1017/S0956796811000104>
 --
 --  Bounds for 'union', 'intersection', and 'difference' are as given
 --  by
 --
 --    * Guy Blelloch, Daniel Ferizovic, and Yihan Sun,
---      \"/Just Join for Parallel Ordered Sets/\",
---      <https://arxiv.org/abs/1602.02120v3>.
+--      \"/Parallel Ordered Sets Using Join/\",
+--      <https://arxiv.org/abs/1602.02120v4>.
 --
 -- Note that the implementation is /left-biased/ -- the elements of a
 -- first argument are always preferred to the second, for example in

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -68,19 +68,25 @@
 -- The implementation of 'Map' is based on /size balanced/ binary trees (or
 -- trees of /bounded balance/) as described by:
 --
---    * Stephen Adams, \"/Efficient sets: a balancing act/\",
---     Journal of Functional Programming 3(4):553-562, October 1993,
---     <http://www.swiss.ai.mit.edu/~adams/BB/>.
+--    * Stephen Adams, \"/Efficient sets—a balancing act/\",
+--      Journal of Functional Programming 3(4):553-562, October 1993,
+--      <https://doi.org/10.1017/S0956796800000885>,
+--      <https://groups.csail.mit.edu/mac/users/adams/BB/index.html>.
 --    * J. Nievergelt and E.M. Reingold,
 --      \"/Binary search trees of bounded balance/\",
 --      SIAM journal of computing 2(1), March 1973.
+--      <https://doi.org/10.1137/0202005>.
+--    * Yoichi Hirai and Kazuhiko Yamamoto,
+--      \"/Balancing weight-balanced trees/\",
+--      Journal of Functional Programming 21(3):287-307, 2011,
+--      <https://doi.org/10.1017/S0956796811000104>
 --
 --  Bounds for 'union', 'intersection', and 'difference' are as given
 --  by
 --
 --    * Guy Blelloch, Daniel Ferizovic, and Yihan Sun,
---      \"/Just Join for Parallel Ordered Sets/\",
---      <https://arxiv.org/abs/1602.02120v3>.
+--      \"/Parallel Ordered Sets Using Join/\",
+--      <https://arxiv.org/abs/1602.02120v4>.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -80,19 +80,25 @@
 -- The implementation of 'Map' is based on /size balanced/ binary trees (or
 -- trees of /bounded balance/) as described by:
 --
---    * Stephen Adams, \"/Efficient sets: a balancing act/\",
---     Journal of Functional Programming 3(4):553-562, October 1993,
---     <http://www.swiss.ai.mit.edu/~adams/BB/>.
+--    * Stephen Adams, \"/Efficient sets—a balancing act/\",
+--      Journal of Functional Programming 3(4):553-562, October 1993,
+--      <https://doi.org/10.1017/S0956796800000885>,
+--      <https://groups.csail.mit.edu/mac/users/adams/BB/index.html>.
 --    * J. Nievergelt and E.M. Reingold,
 --      \"/Binary search trees of bounded balance/\",
 --      SIAM journal of computing 2(1), March 1973.
+--      <https://doi.org/10.1137/0202005>.
+--    * Yoichi Hirai and Kazuhiko Yamamoto,
+--      \"/Balancing weight-balanced trees/\",
+--      Journal of Functional Programming 21(3):287-307, 2011,
+--      <https://doi.org/10.1017/S0956796811000104>
 --
 --  Bounds for 'union', 'intersection', and 'difference' are as given
 --  by
 --
 --    * Guy Blelloch, Daniel Ferizovic, and Yihan Sun,
---      \"/Just Join for Parallel Ordered Sets/\",
---      <https://arxiv.org/abs/1602.02120v3>.
+--      \"/Parallel Ordered Sets Using Join/\",
+--      <https://arxiv.org/abs/1602.02120v4>.
 --
 --
 -----------------------------------------------------------------------------

--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -127,9 +127,9 @@
 -- as described in section 4.2 of
 --
 --    * Ralf Hinze and Ross Paterson,
---      [\"Finger trees: a simple general-purpose data structure\"]
---      (http://staff.city.ac.uk/~ross/papers/FingerTree.html),
---      /Journal of Functional Programming/ 16:2 (2006) pp 197-217.
+--      \"/Finger trees: a simple general-purpose data structure/\",
+--      Journal of Functional Programming 16:2 (2006) pp 197-217.
+--      <http://staff.city.ac.uk/~ross/papers/FingerTree.html>.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -48,19 +48,25 @@
 -- The implementation of 'Set' is based on /size balanced/ binary trees (or
 -- trees of /bounded balance/) as described by:
 --
---    * Stephen Adams, \"/Efficient sets: a balancing act/\",
+--    * Stephen Adams, \"/Efficient sets—a balancing act/\",
 --      Journal of Functional Programming 3(4):553-562, October 1993,
---      <http://www.swiss.ai.mit.edu/~adams/BB/>.
+--      <https://doi.org/10.1017/S0956796800000885>,
+--      <https://groups.csail.mit.edu/mac/users/adams/BB/index.html>.
 --    * J. Nievergelt and E.M. Reingold,
 --      \"/Binary search trees of bounded balance/\",
 --      SIAM journal of computing 2(1), March 1973.
+--      <https://doi.org/10.1137/0202005>.
+--    * Yoichi Hirai and Kazuhiko Yamamoto,
+--      \"/Balancing weight-balanced trees/\",
+--      Journal of Functional Programming 21(3):287-307, 2011,
+--      <https://doi.org/10.1017/S0956796811000104>
 --
 --  Bounds for 'union', 'intersection', and 'difference' are as given
 --  by
 --
 --    * Guy Blelloch, Daniel Ferizovic, and Yihan Sun,
---      \"/Just Join for Parallel Ordered Sets/\",
---      <https://arxiv.org/abs/1602.02120v3>.
+--      \"/Parallel Ordered Sets Using Join/\",
+--      <https://arxiv.org/abs/1602.02120v4>.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
* Add or update links
* Correct some titles
* Add a reference to "Balancing weight-balanced trees"

Notes:
* The "Fast Mergeable Integer Maps" link I've added is actually dead. However, it is the best link I could find. The contents have been archived on https://web.archive.org.
* I've added a reference to "Balancing weight-balanced trees", which goes into the choice of delta/ratio we use for Set/Map and proves that it preserves balance.

Fixes #1034.