### PR TITLE
Build Set and Map more efficiently and consistently

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -88,7 +88,24 @@ main = do
         , bench "intersection" $ whnf (M.intersection m) m_even
         , bench "split" $ whnf (M.split (bound `div` 2)) m
         , bench "fromList" $ whnf M.fromList elems
-        , bench "fromList-desc" $ whnf M.fromList elems_desc
+        , bench "fromList-distinctAsc" $ whnf M.fromList elems_distinct_asc
+        , bench "fromList-distinctAsc:fusion" $
+            whnf (\n -> M.fromList [(i,i) | i <- [1..n]]) bound
+        , bench "fromList-distinctDesc" $ whnf M.fromList elems_distinct_desc
+        , bench "fromList-distinctDesc:fusion" $
+            whnf (\n -> M.fromList [(i,i) | i <- [n,n-1..1]]) bound
+        , bench "fromListWith-asc" $ whnf (M.fromListWith (+)) elems_asc
+        , bench "fromListWith-asc:fusion" $
+            whnf (\n -> M.fromListWith (+) [(i `div` 2, i) | i <- [1..n]]) bound
+        , bench "fromListWith-desc" $ whnf (M.fromListWith (+)) elems_desc
+        , bench "fromListWith-desc:fusion" $
+            whnf (\n -> M.fromListWith (+) [(i `div` 2, i) | i <- [n,n-1..1]]) bound
+        , bench "fromListWithKey-asc" $ whnf (M.fromListWithKey sumkv) elems_asc
+        , bench "fromListWithKey-asc:fusion" $
+            whnf (\n -> M.fromListWithKey sumkv [(i `div` 2, i) | i <- [1..n]]) bound
+        , bench "fromListWithKey-desc" $ whnf (M.fromListWithKey sumkv) elems_desc
+        , bench "fromListWithKey-desc:fusion" $
+            whnf (\n -> M.fromListWithKey sumkv [(i `div` 2, i) | i <- [n,n-1..1]]) bound
         , bench "fromAscList" $ whnf M.fromAscList elems_asc
         , bench "fromAscList:fusion" $
             whnf (\n -> M.fromAscList [(i `div` 2, i) | i <- [1..n]]) bound
@@ -113,6 +130,10 @@ main = do
         , bgroup "folds" $ foldBenchmarks M.foldr M.foldl M.foldr' M.foldl' foldMap m
         , bgroup "folds with key" $
             foldWithKeyBenchmarks M.foldrWithKey M.foldlWithKey M.foldrWithKey' M.foldlWithKey' M.foldMapWithKey m
+        , bench "mapKeys:asc" $ whnf (M.mapKeys (+1)) m
+        , bench "mapKeys:desc" $ whnf (M.mapKeys (negate . (+1))) m
+        , bench "mapKeysWith:asc" $ whnf (M.mapKeysWith (+) (`div` 2)) m
+        , bench "mapKeysWith:desc" $ whnf (M.mapKeysWith (+) (negate . (`div` 2))) m
         ]
   where
     bound = 2^12

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -22,7 +22,8 @@ main = do
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
-        , bench "map" $ whnf (S.map (+ 1)) s
+        , bench "map:asc" $ whnf (S.map (+ 1)) s
+        , bench "map:desc" $ whnf (S.map (negate . (+ 1))) s
         , bench "filter" $ whnf (S.filter ((== 0) . (`mod` 2))) s
         , bench "partition" $ whnf (S.partition ((== 0) . (`mod` 2))) s
         , bench "delete" $ whnf (del elems) s
@@ -35,7 +36,10 @@ main = do
         , bench "difference" $ whnf (S.difference s) s_even
         , bench "intersection" $ whnf (S.intersection s) s_even
         , bench "fromList" $ whnf S.fromList elems
-        , bench "fromList-desc" $ whnf S.fromList elems_desc
+        , bench "fromList-distinctAsc" $ whnf S.fromList elems_distinct_asc
+        , bench "fromList-distinctAsc:fusion" $ whnf (\n -> S.fromList [1..n]) bound
+        , bench "fromList-distinctDesc" $ whnf S.fromList elems_distinct_desc
+        , bench "fromList-distinctDesc:fusion" $ whnf (\n -> S.fromList [n,n-1..1]) bound
         , bench "fromAscList" $ whnf S.fromAscList elems_asc
         , bench "fromAscList:fusion" $
             whnf (\n -> S.fromAscList [i `div` 2 | i <- [1..n]]) bound

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -201,6 +201,8 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "toDescList"           prop_descList
          , testProperty "toAscList+toDescList" prop_ascDescList
          , testProperty "fromList"             prop_fromList
+         , testProperty "fromListWith"         prop_fromListWith
+         , testProperty "fromListWithKey"      prop_fromListWithKey
          , testProperty "alter"                prop_alter
          , testProperty "alterF/alter"         prop_alterF_alter
          , testProperty "alterF/alter/noRULES" prop_alterF_alter_noRULES
@@ -229,7 +231,8 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "partition"            prop_partition
          , testProperty "map"                  prop_map
          , testProperty "fmap"                 prop_fmap
-         , testProperty "mapkeys"              prop_mapkeys
+         , testProperty "mapKeys"              prop_mapKeys
+         , testProperty "mapKeysWith"          prop_mapKeysWith
          , testProperty "split"                prop_splitModel
          , testProperty "fold"                 prop_fold
          , testProperty "foldMap"              prop_foldMap
@@ -1338,6 +1341,16 @@ prop_fromDistinctAscList kxs =
       List.sortBy (comparing fst) kxs
     t = fromDistinctAscList nubSortedKxs
 
+prop_fromListWith :: Fun (A, A) A -> [(Int, A)] -> Property
+prop_fromListWith f kxs =
+  fromListWith (applyFun2 f) kxs ===
+  List.foldl' (\m (kx, x) -> insertWith (applyFun2 f) kx x m) empty kxs
+
+prop_fromListWithKey :: Fun (Int, A, A) A -> [(Int, A)] -> Property
+prop_fromListWithKey f kxs =
+  fromListWithKey (applyFun3 f) kxs ===
+  List.foldl' (\m (kx, x) -> insertWithKey (applyFun3 f) kx x m) empty kxs
+
 ----------------------------------------------------------------
 
 prop_alter :: UMap -> Int -> Bool
@@ -1543,11 +1556,15 @@ prop_fmap f ys = length ys > 0 ==>
       m  = fromList xs
   in  fmap (apply f) m == fromList [ (a, (apply f) b) | (a,b) <- xs ]
 
-prop_mapkeys :: Fun Int Int -> [(Int, Int)] -> Property
-prop_mapkeys f ys = length ys > 0 ==>
-  let xs = List.nubBy ((==) `on` fst) ys
-      m  = fromList xs
-  in  mapKeys (apply f) m == (fromList $ List.nubBy ((==) `on` fst) $ reverse [ (apply f a, b) | (a,b) <- sort xs])
+prop_mapKeys :: Fun Int Int -> Map Int A -> Property
+prop_mapKeys f m =
+  mapKeys (applyFun f) m ===
+  fromList (fmap (\(kx,x) -> (applyFun f kx, x)) (toList m))
+
+prop_mapKeysWith :: Fun (A, A) A -> Fun Int Int -> Map Int A -> Property
+prop_mapKeysWith f g m =
+  mapKeysWith (applyFun2 f) (applyFun g) m ===
+  fromListWith (applyFun2 f) (fmap (\(kx,x) -> (applyFun g kx, x)) (toList m))
 
 prop_splitModel :: Int -> [(Int, Int)] -> Property
 prop_splitModel n ys = length ys > 0 ==>

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -63,6 +63,9 @@
 * Improved performance for `Data.Set` and `Data.Map`'s `fromAscList*` and
   `fromDescList*` functions.
 
+* Improved performance for `Data.Set`'s `fromList`, `map` and `Data.Map`'s
+  `fromList`, `fromListWith`, `fromListWithKey`, `mapKeys`, `mapKeysWith`.
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -333,6 +333,10 @@ import Data.Map.Internal
   , descLinkTop
   , descLinkAll
   , Stack (..)
+  , MapBuilder(..)
+  , emptyB
+  , insertB
+  , finishB
   , (!)
   , (!?)
   , (\\)
@@ -375,7 +379,6 @@ import Data.Map.Internal
   , foldrWithKey
   , foldrWithKey'
   , glue
-  , insertMax
   , intersection
   , isProperSubmapOf
   , isProperSubmapOfBy
@@ -430,7 +433,6 @@ import qualified Data.Set.Internal as Set
 import qualified Data.Map.Internal as L
 import Utils.Containers.Internal.StrictPair
 
-import Data.Bits (shiftL, shiftR)
 #ifdef __GLASGOW_HASKELL__
 import Data.Coerce
 #endif
@@ -1448,7 +1450,8 @@ mapAccumRWithKey f a (Bin sx kx x l r) =
 -- Also see the performance note on 'fromListWith'.
 
 mapKeysWith :: Ord k2 => (a -> a -> a) -> (k1->k2) -> Map k1 a -> Map k2 a
-mapKeysWith c f = fromListWith c . foldrWithKey (\k x xs -> (f k, x) : xs) []
+mapKeysWith c f m =
+  finishB (foldlWithKey' (\b kx x -> insertWithB c (f kx) x b) emptyB m)
 #if __GLASGOW_HASKELL__
 {-# INLINABLE mapKeysWith #-}
 #endif
@@ -1489,46 +1492,10 @@ fromArgSet (Set.Bin sz (Arg x v) l r) = v `seq` Bin sz x v (fromArgSet l) (fromA
 -- > fromList [(5,"a"), (3,"b"), (5, "c")] == fromList [(5,"c"), (3,"b")]
 -- > fromList [(5,"c"), (3,"b"), (5, "a")] == fromList [(5,"a"), (3,"b")]
 
--- For some reason, when 'singleton' is used in fromList or in
--- create, it is not inlined, so we inline it manually.
 fromList :: Ord k => [(k,a)] -> Map k a
-fromList [] = Tip
-fromList [(kx, x)] = x `seq` Bin 1 kx x Tip Tip
-fromList ((kx0, x0) : xs0) | not_ordered kx0 xs0 = x0 `seq` fromList' (Bin 1 kx0 x0 Tip Tip) xs0
-                           | otherwise = x0 `seq` go (1::Int) (Bin 1 kx0 x0 Tip Tip) xs0
-  where
-    not_ordered _ [] = False
-    not_ordered kx ((ky,_) : _) = kx >= ky
-    {-# INLINE not_ordered #-}
-
-    fromList' t0 xs = Foldable.foldl' ins t0 xs
-      where ins t (k,x) = insert k x t
-
-    go !_ t [] = t
-    go _ t [(kx, x)] = x `seq` insertMax kx x t
-    go s l xs@((kx, x) : xss) | not_ordered kx xss = fromList' l xs
-                              | otherwise = case create s xss of
-                                  (r, ys, []) -> x `seq` go (s `shiftL` 1) (link kx x l r) ys
-                                  (r, _,  ys) -> x `seq` fromList' (link kx x l r) ys
-
-    -- The create is returning a triple (tree, xs, ys). Both xs and ys
-    -- represent not yet processed elements and only one of them can be nonempty.
-    -- If ys is nonempty, the keys in ys are not ordered with respect to tree
-    -- and must be inserted using fromList'. Otherwise the keys have been
-    -- ordered so far.
-    create !_ [] = (Tip, [], [])
-    create s xs@(xp : xss)
-      | s == 1 = case xp of (kx, x) | not_ordered kx xss -> x `seq` (Bin 1 kx x Tip Tip, [], xss)
-                                    | otherwise -> x `seq` (Bin 1 kx x Tip Tip, xss, [])
-      | otherwise = case create (s `shiftR` 1) xs of
-                      res@(_, [], _) -> res
-                      (l, [(ky, y)], zs) -> y `seq` (insertMax ky y l, [], zs)
-                      (l, ys@((ky, y):yss), _) | not_ordered ky yss -> (l, [], ys)
-                                               | otherwise -> case create (s `shiftR` 1) yss of
-                                                   (r, zs, ws) -> y `seq` (link ky y l r, zs, ws)
-#if __GLASGOW_HASKELL__
-{-# INLINABLE fromList #-}
-#endif
+fromList xs =
+  finishB (Foldable.foldl' (\b (kx, !x) -> insertB kx x b) emptyB xs)
+{-# INLINE fromList #-} -- INLINE for fusion
 
 -- | \(O(n \log n)\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
 --
@@ -1567,11 +1534,9 @@ fromList ((kx0, x0) : xs0) | not_ordered kx0 xs0 = x0 `seq` fromList' (Bin 1 kx0
 -- > fromListWith (++) $ reverse $ map (\(k, v) -> (k, [v])) someListOfTuples
 
 fromListWith :: Ord k => (a -> a -> a) -> [(k,a)] -> Map k a
-fromListWith f xs
-  = fromListWithKey (\_ x y -> f x y) xs
-#if __GLASGOW_HASKELL__
-{-# INLINABLE fromListWith #-}
-#endif
+fromListWith f xs =
+  finishB (Foldable.foldl' (\b (kx, x) -> insertWithB f kx x b) emptyB xs)
+{-# INLINE fromListWith #-}  -- INLINE for fusion
 
 -- | \(O(n \log n)\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWithKey'.
 --
@@ -1582,13 +1547,9 @@ fromListWith f xs
 -- Also see the performance note on 'fromListWith'.
 
 fromListWithKey :: Ord k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
-fromListWithKey f xs
-  = Foldable.foldl' ins empty xs
-  where
-    ins t (k,x) = insertWithKey f k x t
-#if __GLASGOW_HASKELL__
-{-# INLINABLE fromListWithKey #-}
-#endif
+fromListWithKey f xs =
+  finishB (Foldable.foldl' (\b (kx, x) -> insertWithB (f kx) kx x b) emptyB xs)
+{-# INLINE fromListWithKey #-}  -- INLINE for fusion
 
 {--------------------------------------------------------------------
   Building trees from ascending/descending lists can be done in linear time.
@@ -1731,3 +1692,25 @@ fromDistinctDescList xs = descLinkAll (Foldable.foldl' next Nada xs)
     next (Push ky y Tip stk) (!kx, !x) = descLinkTop kx x 1 (singleton ky y) stk
     next stk (!ky, !y) = Push ky y Tip stk
 {-# INLINE fromDistinctDescList #-}  -- INLINE for fusion
+
+{--------------------------------------------------------------------
+  MapBuilder
+--------------------------------------------------------------------}
+
+-- Insert a key and value. The new value is combined with the old value if one
+-- already exists for the key. Strict in the inserted value.
+insertWithB
+  :: Ord k => (a -> a -> a) -> k -> a -> MapBuilder k a -> MapBuilder k a
+insertWithB f !ky y b = case b of
+  BAsc stk -> case stk of
+    Push kx x l stk' -> case compare ky kx of
+      LT -> BMap (insertWith f ky y (ascLinkAll stk))
+      EQ -> BAsc (push' ky (f y x) l stk')
+      GT -> case l of
+        Tip -> y `seq` BAsc (ascLinkTop stk' 1 (singleton kx x) ky y)
+        Bin{} -> BAsc (push' ky y Tip stk)
+    Nada -> BAsc (push' ky y Tip Nada)
+  BMap m -> BMap (insertWith f ky y m)
+  where
+    push' kx !x = Push kx x
+{-# INLINE insertWithB #-}

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -1439,6 +1439,8 @@ mapAccumRWithKey f a (Bin sx kx x l r) =
 -- | \(O(n \log n)\).
 -- @'mapKeysWith' c f s@ is the map obtained by applying @f@ to each key of @s@.
 --
+-- If `f` is monotonically non-decreasing, this function takes \(O(n)\) time.
+--
 -- The size of the result may be smaller if @f@ maps two or more distinct
 -- keys to the same new key.  In this case the associated values will be
 -- combined using @c@. The value at the greater of the two original keys
@@ -1486,7 +1488,7 @@ fromArgSet (Set.Bin sz (Arg x v) l r) = v `seq` Bin sz x v (fromArgSet l) (fromA
 -- If the list contains more than one value for the same key, the last value
 -- for the key is retained.
 --
--- If the keys of the list are ordered, a linear-time implementation is used.
+-- If the keys are in non-decreasing order, this function takes \(O(n)\) time.
 --
 -- > fromList [] == empty
 -- > fromList [(5,"a"), (3,"b"), (5, "c")] == fromList [(5,"c"), (3,"b")]
@@ -1498,6 +1500,8 @@ fromList xs =
 {-# INLINE fromList #-} -- INLINE for fusion
 
 -- | \(O(n \log n)\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
+--
+-- If the keys are in non-decreasing order, this function takes \(O(n)\) time.
 --
 -- > fromListWith (++) [(5,"a"), (5,"b"), (3,"x"), (5,"c")] == fromList [(3, "x"), (5, "cba")]
 -- > fromListWith (++) [] == empty
@@ -1539,6 +1543,8 @@ fromListWith f xs =
 {-# INLINE fromListWith #-}  -- INLINE for fusion
 
 -- | \(O(n \log n)\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWithKey'.
+--
+-- If the keys are in non-decreasing order, this function takes \(O(n)\) time.
 --
 -- > let f key new_value old_value = show key ++ ":" ++ new_value ++ "|" ++ old_value
 -- > fromListWithKey f [(5,"a"), (5,"b"), (3,"b"), (3,"a"), (5,"c")] == fromList [(3, "3:a|b"), (5, "5:c|5:b|a")]


### PR DESCRIPTION
Use "Builder"s to implement some Set and Map construction functions.
As a result, some have become good consumers in terms of list fusion,
and all are now O(n) for non-decreasing input.

```
                     Fusible  Fusible  O(n) for     O(n) for
                     before   after    before       after
Set.fromList         No       Yes      Strict incr  Non-decr
Set.map              -        -        Strict incr  Non-decr
Map.fromList         No       Yes      Strict incr  Non-decr
Map.fromListWith     Yes      Yes      Never        Non-decr
Map.fromListWithKey  Yes      Yes      Never        Non-decr
Map.mapKeys          -        -        Strict incr  Non-decr
Map.mapKeysWith      -        -        Never        Non-decr
```

---

For #1027. Also related to #949.

---

Benchmarks with GHC 9.10.1:

Set:
```
Name                    Time - - - - - - - -    Allocated - - - - -
                             A       B     %         A       B     %
fromList                        795 μs  784 μs   -1%    1.9 MB  1.9 MB   +0%
fromList-distinctAsc             50 μs   26 μs  -48%    271 KB  256 KB   -5%
fromList-distinctAsc:fusion      70 μs   29 μs  -58%    559 KB  415 KB  -25%
fromList-distinctDesc           559 μs  557 μs   +0%    2.6 MB  2.6 MB   +0%
fromList-distinctDesc:fusion    592 μs  604 μs   +2%    2.9 MB  2.9 MB   +0%
map:asc                          95 μs   75 μs  -20%    557 KB  414 KB  -25%
map:desc                        620 μs  620 μs   +0%    2.8 MB  2.7 MB   -4%
```

Map:
```
Name                           Time - - - - - - - -    Allocated - - - - -
                                    A       B     %         A       B     %
fromList                        838 μs  829 μs   -1%    2.3 MB  2.3 MB   +0%
fromList-distinctAsc             56 μs   30 μs  -46%    319 KB  303 KB   -4%
fromList-distinctAsc:fusion      81 μs   31 μs  -61%    702 KB  480 KB  -31%
fromList-distinctDesc           579 μs  582 μs   +0%    3.1 MB  3.1 MB   +0%
fromList-distinctDesc:fusion    609 μs  624 μs   +2%    3.5 MB  3.4 MB   -1%
fromListWith-asc                509 μs   35 μs  -93%    2.7 MB  272 KB  -90%
fromListWith-asc:fusion         543 μs   29 μs  -94%    3.1 MB  511 KB  -83%
fromListWith-desc               502 μs  528 μs   +5%    2.7 MB  2.8 MB   +3%
fromListWith-desc:fusion        539 μs  584 μs   +8%    3.1 MB  3.1 MB   +0%
fromListWithKey-asc             501 μs   31 μs  -93%    2.7 MB  288 KB  -89%
fromListWithKey-asc:fusion      542 μs   30 μs  -94%    3.1 MB  527 KB  -83%
fromListWithKey-desc            505 μs  540 μs   +6%    2.7 MB  2.8 MB   +4%
fromListWithKey-desc:fusion     532 μs  595 μs  +11%    3.2 MB  3.2 MB   +0%
mapKeys:asc                     137 μs   81 μs  -41%    864 KB  477 KB  -44%
mapKeys:desc                    706 μs  669 μs   -5%    3.6 MB  3.2 MB  -11%
mapKeysWith:asc                 750 μs   74 μs  -90%    3.2 MB  463 KB  -85%
mapKeysWith:desc                722 μs  599 μs  -16%    3.2 MB  2.9 MB  -10%
```

Note: You may notice desc fusion cases haven't improved, though they really should. It turns out to be a `enumFromThen`/fusion issue, and not really a problem with our code. I opened a GHC issue for it: [GHC#25259](https://gitlab.haskell.org/ghc/ghc/-/issues/25259)