### PR TITLE
Deprecate Data.Set.fold and Data.IntSet.fold

### DIFF
--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -27,7 +27,6 @@ main = do
         , bench "map" $ whnf (IS.map (+ 1)) s
         , bench "filter" $ whnf (IS.filter ((== 0) . (`mod` 2))) s
         , bench "partition" $ whnf (IS.partition ((== 0) . (`mod` 2))) s
-        , bench "fold" $ whnf (IS.fold (:) []) s
         , bench "delete" $ whnf (del elems) s
         , bench "findMin" $ whnf IS.findMin s
         , bench "findMax" $ whnf IS.findMax s

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -21,7 +21,6 @@ main = do
         , bench "map" $ whnf (S.map (+ 1)) s
         , bench "filter" $ whnf (S.filter ((== 0) . (`mod` 2))) s
         , bench "partition" $ whnf (S.partition ((== 0) . (`mod` 2))) s
-        , bench "fold" $ whnf (S.fold (:) []) s
         , bench "delete" $ whnf (del elems) s
         , bench "findMin" $ whnf S.findMin s
         , bench "findMax" $ whnf S.findMax s

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -28,6 +28,10 @@
 * Various deprecated functions, whose definitions currently cause type errors,
   have been removed. (Soumik Sarkar)
 
+* `Data.Set.fold` and `Data.IntSet.fold` have long been documented as
+  deprecated and are now marked as such. They will be removed in a future
+  release.
+
 ### Bug fixes
 
 * Make the package compile with MicroHs. (Lennart Augustsson)

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1180,10 +1180,9 @@ mapMonotonic f = fromDistinctAscList . List.map f . toAscList
   Fold
 --------------------------------------------------------------------}
 -- | \(O(n)\). Fold the elements in the set using the given right-associative
--- binary operator. This function is an equivalent of 'foldr' and is present
--- for compatibility only.
+-- binary operator.
 --
--- /Please note that fold will be deprecated in the future and removed./
+{-# DEPRECATED fold "Use Data.IntSet.foldr instead" #-}
 fold :: (Key -> b -> b) -> b -> IntSet -> b
 fold = foldr
 {-# INLINE fold #-}

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1027,10 +1027,9 @@ mapMonotonic f (Bin sz x l r) = Bin sz (f x) (mapMonotonic f l) (mapMonotonic f 
   Fold
 --------------------------------------------------------------------}
 -- | \(O(n)\). Fold the elements in the set using the given right-associative
--- binary operator. This function is an equivalent of 'foldr' and is present
--- for compatibility only.
+-- binary operator.
 --
--- /Please note that fold will be deprecated in the future and removed./
+{-# DEPRECATED fold "Use Data.Set.foldr instead" #-}
 fold :: (a -> b -> b) -> b -> Set a -> b
 fold = foldr
 {-# INLINE fold #-}


### PR DESCRIPTION
They are aliases for foldr and have long been documented as deprecated. Similar functions for Map and IntMap were deprecated in 0.5.8.1.

Related: #1044