### PR TITLE
Inline the common case of balance functions

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -58,7 +58,7 @@ common benchmark-deps
   build-depends:
       containers-tests
     , deepseq           >=1.1.0.0 && <1.6
-    , tasty-bench       >=0.3.1   && <0.4
+    , tasty-bench       >=0.3.1   && <0.5
 
   -- Flags recommended by tasty-bench
   if impl(ghc >= 8.6)

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -66,6 +66,10 @@
 * Improved performance for `Data.Set`'s `fromList`, `map` and `Data.Map`'s
   `fromList`, `fromListWith`, `fromListWithKey`, `mapKeys`, `mapKeysWith`.
 
+* Improved performance for many `Set` and `Map` modification operations,
+  including `insert` and `delete`, by inlining part of the balancing
+  routine. (Soumik Sarkar)
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions


### PR DESCRIPTION
Closes #1053

Benchmarks, using GHC 9.10.1:

Set:

<details>
<summary>Expand</summary>

```
Name                            Time - - - - - - - -    Allocated - - - - -
                                     A       B     %         A       B     %
alterF:delete                   845 μs  648 μs  -23%    2.2 MB  2.2 MB   +0%
alterF:four                     1.1 ms  870 μs  -21%    3.1 MB  3.1 MB   +0%
alterF:four:strings             1.8 ms  1.5 ms  -12%    3.1 MB  3.1 MB   +0%
alterF:insert                   938 μs  726 μs  -22%    2.8 MB  2.8 MB   +0%
alterF:member                   945 μs  726 μs  -23%    2.5 MB  2.5 MB   +0%
alterF_naive:four               1.6 ms  1.4 ms  -11%    2.2 MB  2.2 MB   +0%
alterF_naive:four:strings       3.9 ms  3.8 ms   -4%    2.2 MB  2.2 MB   +0%
compare                          37 μs   38 μs   +2%    128 KB  128 KB   +0%
delete                          793 μs  621 μs  -21%    1.6 MB  1.6 MB   +0%
deleteMax                        94 ns   47 ns  -50%    512 B   512 B    +0%
deleteMin                        83 ns   42 ns  -49%    472 B   472 B    +0%
difference                      179 μs  161 μs   -9%    436 KB  436 KB   +0%
disjoint:false                  722 ns  633 ns  -12%    2.3 KB  2.3 KB   +0%
disjoint:true                   125 μs  118 μs   -5%    246 KB  246 KB   +0%
eq                               37 μs   38 μs   +0%    128 KB  128 KB   +0%
filter                           87 μs   83 μs   -4%    121 KB  121 KB   +0%
findMax                          15 ns   15 ns   +0%     32 B    32 B    +0%
findMin                          14 ns   14 ns   +0%     32 B    32 B    +0%
folds.foldMap_elem              9.6 μs   10 μs   +3%     34 B    34 B    +0%
folds.foldMap_traverseSum       8.7 μs  8.6 μs   -1%     36 KB   36 KB   +0%
folds.foldl'_sum                 11 μs   11 μs   +2%     42 B    45 B    +7%
folds.foldl_cpsOneShotSum        34 μs   34 μs   -1%    192 KB  192 KB   +0%
folds.foldl_cpsSum               53 μs   53 μs   +0%    288 KB  288 KB   +0%
folds.foldl_elem                 23 μs   23 μs   +0%    160 KB  160 KB   +0%
folds.foldl_traverseSum          53 μs   53 μs   +0%    288 KB  288 KB   +0%
folds.foldr'_sum                 11 μs   12 μs   +4%     41 B    41 B    +0%
folds.foldr_cpsOneShotSum        34 μs   34 μs   +0%    192 KB  192 KB   +0%
folds.foldr_cpsSum               54 μs   53 μs   +0%    288 KB  288 KB   +0%
folds.foldr_elem                 23 μs   24 μs   +2%    160 KB  160 KB   +0%
folds.foldr_traverseSum          53 μs   56 μs   +6%    288 KB  288 KB   +0%
fromAscList                      20 μs   19 μs   -2%    176 KB  176 KB   +0%
fromAscList:fusion               13 μs   12 μs   -3%    192 KB  192 KB   +0%
fromDescList                     19 μs   18 μs   -2%    176 KB  176 KB   +0%
fromDescList:fusion              45 μs   44 μs   -1%    560 KB  560 KB   +0%
fromDistinctAscList              27 μs   26 μs   -3%    225 KB  225 KB   +0%
fromDistinctAscList:fusion       18 μs   18 μs   -1%    288 KB  288 KB   +0%
fromDistinctDescList             28 μs   28 μs   +2%    225 KB  225 KB   +0%
fromDistinctDescList:fusion      18 μs   18 μs   -2%    289 KB  289 KB   +0%
fromList                        820 μs  636 μs  -22%    2.0 MB  2.0 MB   +0%
fromList-distinctAsc             29 μs   28 μs   -3%    256 KB  256 KB   +0%
fromList-distinctAsc:fusion      29 μs   28 μs   -2%    417 KB  417 KB   +0%
fromList-distinctDesc           576 μs  328 μs  -43%    2.6 MB  2.6 MB   +0%
fromList-distinctDesc:fusion    621 μs  382 μs  -38%    2.9 MB  2.9 MB   +0%
insert                          809 μs  657 μs  -18%    2.0 MB  2.0 MB   +0%
intersection                    181 μs  178 μs   -1%    333 KB  333 KB   +0%
map:asc                          73 μs   75 μs   +2%    417 KB  417 KB   +0%
map:desc                        639 μs  413 μs  -35%    2.7 MB  2.7 MB   +0%
member                          265 μs  270 μs   +1%    221 B   130 B   -41%
member.powerSet (14)             12 ms   12 ms   +0%     32 MB   32 MB   +0%
member.powerSet (15)             27 ms   28 ms   +0%     73 MB   73 MB   +0%
null.intersection:false         184 μs  174 μs   -5%    333 KB  333 KB   +0%
null.intersection:true          118 μs  115 μs   -2%    314 KB  314 KB   +0%
partition                       134 μs  127 μs   -5%    239 KB  239 KB   +0%
powerSet (15)                   8.2 ms  8.2 ms   +0%    7.5 MB  7.5 MB   +0%
powerSet (16)                    22 ms   22 ms   +0%     15 MB   15 MB   +0%
union                           129 μs  125 μs   -2%    488 KB  488 KB   +0%
unions                          128 μs  125 μs   -2%    488 KB  488 KB   +0%
```

</details>

Map:

<details>
<summary>Expand</summary>

```
Name                                  Time - - - - - - - -    Allocated - - - - -
                                           A       B     %         A       B     %
<$                                     28 μs   29 μs   +2%    192 KB  192 KB   +0%
<$ really                              68 μs   70 μs   +2%    192 KB  192 KB   +0%
alter absent                          403 μs  328 μs  -18%    1.1 MB  1.1 MB   +0%
alter delete                          469 μs  382 μs  -18%    1.1 MB  1.1 MB   +0%
alter insert                          422 μs  338 μs  -19%    1.2 MB  1.2 MB   +0%
alter update                          350 μs  276 μs  -21%    1.0 MB  1.0 MB   +0%
alterF alter absent                   237 μs  240 μs   +1%    270 B   281 B    +4%
alterF alter delete                   534 μs  437 μs  -18%    1.4 MB  1.4 MB   +0%
alterF alter insert                   491 μs  402 μs  -18%    1.6 MB  1.6 MB   +0%
alterF alter update                   284 μs  287 μs   +1%    1.4 MB  1.4 MB   +0%
alterF delete absent                  228 μs  233 μs   +2%    141 B   141 B    +0%
alterF delete present                 502 μs  414 μs  -17%    1.4 MB  1.4 MB   +0%
alterF insert absent                  506 μs  396 μs  -21%    1.7 MB  1.7 MB   +0%
alterF insert present                 288 μs  289 μs   +0%    1.4 MB  1.4 MB   +0%
alterF lookup absent                  129 μs  129 μs   +0%    163 B   165 B    +1%
alterF lookup present                 123 μs  124 μs   +0%     32 KB   32 KB   +0%
alterF no rules alter absent          140 μs  142 μs   +1%     82 B   153 B   +86%
alterF no rules alter delete          589 μs  516 μs  -12%    1.1 MB  1.1 MB   +0%
alterF no rules alter insert          550 μs  458 μs  -16%    1.2 MB  1.2 MB   +0%
alterF no rules alter update          350 μs  357 μs   +1%    1.0 MB  1.0 MB   +0%
alterF no rules delete absent         138 μs  144 μs   +3%    152 B    82 B   -46%
alterF no rules delete present        563 μs  491 μs  -12%    1.1 MB  1.1 MB   +0%
alterF no rules insert absent         553 μs  459 μs  -17%    1.3 MB  1.3 MB   +0%
alterF no rules insert present        346 μs  350 μs   +1%    1.1 MB  1.1 MB   +0%
alterF no rules lookup absent         140 μs  141 μs   +0%     98 B   162 B   +65%
alterF no rules lookup present        132 μs  130 μs   -1%     32 KB   32 KB   +0%
compare                                49 μs   48 μs   -1%    160 KB  160 KB   +0%
delete absent                         219 μs  230 μs   +4%    141 B   149 B    +5%
delete present                        455 μs  377 μs  -17%    1.1 MB  1.1 MB   +0%
difference                            184 μs  168 μs   -8%    524 KB  524 KB   +0%
eq                                     47 μs   45 μs   -3%    160 KB  160 KB   +0%
folds with key.foldMap_elem            11 μs   11 μs   -4%     33 B    32 B    -3%
folds with key.foldMap_traverseSum     13 μs   13 μs   -1%     36 KB   36 KB   +0%
folds with key.foldl'_sum              15 μs   14 μs   -5%     43 B    47 B    +9%
folds with key.foldl_cpsOneShotSum     47 μs   48 μs   +1%    384 KB  384 KB   +0%
folds with key.foldl_cpsSum            85 μs   86 μs   +1%    608 KB  608 KB   +0%
folds with key.foldl_elem              32 μs   33 μs   +3%    192 KB  192 KB   +0%
folds with key.foldl_traverseSum       76 μs   77 μs   +2%    480 KB  480 KB   +0%
folds with key.foldr'_sum              14 μs   14 μs   +0%     47 B    47 B    +0%
folds with key.foldr_cpsOneShotSum     48 μs   47 μs   -1%    384 KB  384 KB   +0%
folds with key.foldr_cpsSum            86 μs   86 μs   +0%    608 KB  608 KB   +0%
folds with key.foldr_elem              32 μs   32 μs   -1%    192 KB  192 KB   +0%
folds with key.foldr_traverseSum       78 μs   76 μs   -1%    480 KB  480 KB   +0%
folds.foldMap_elem                     12 μs   12 μs   +0%     39 B    39 B    +0%
folds.foldMap_traverseSum              21 μs   21 μs   -2%     64 KB   64 KB   +0%
folds.foldl'_sum                       12 μs   12 μs   -1%     47 B    47 B    +0%
folds.foldl_cpsOneShotSum              45 μs   46 μs   +1%    320 KB  320 KB   +0%
folds.foldl_cpsSum                     69 μs   70 μs   +1%    416 KB  416 KB   +0%
folds.foldl_elem                       29 μs   30 μs   +2%    160 KB  160 KB   +0%
folds.foldl_traverseSum                60 μs   61 μs   +2%    288 KB  288 KB   +0%
folds.foldr'_sum                       13 μs   14 μs   +3%     47 B    47 B    +0%
folds.foldr_cpsOneShotSum              45 μs   46 μs   +2%    320 KB  320 KB   +0%
folds.foldr_cpsSum                     69 μs   70 μs   +0%    416 KB  416 KB   +0%
folds.foldr_elem                       28 μs   29 μs   +2%    160 KB  160 KB   +0%
folds.foldr_traverseSum                62 μs   61 μs   -1%    288 KB  288 KB   +0%
fromAscList                            27 μs   26 μs   +0%    209 KB  209 KB   +0%
fromAscList:fusion                     15 μs   15 μs   +0%    289 KB  289 KB   +0%
fromAscListWithKey                     36 μs   36 μs   -1%    289 KB  289 KB   +0%
fromAscListWithKey:fusion              16 μs   16 μs   -1%    297 KB  297 KB   +0%
fromDescList                           27 μs   28 μs   +3%    209 KB  209 KB   +0%
fromDescList:fusion                    48 μs   48 μs   +0%    609 KB  609 KB   +0%
fromDescListWithKey                    36 μs   36 μs   +0%    289 KB  289 KB   +0%
fromDescListWithKey:fusion             54 μs   53 μs   -1%    689 KB  689 KB   +0%
fromDistinctAscList                    34 μs   35 μs   +1%    273 KB  273 KB   +0%
fromDistinctAscList:fusion             21 μs   20 μs   +0%    337 KB  337 KB   +0%
fromDistinctDescList                   30 μs   30 μs   -1%    273 KB  273 KB   +0%
fromDistinctDescList:fusion            21 μs   21 μs   +0%    337 KB  337 KB   +0%
fromList                              818 μs  742 μs   -9%    2.3 MB  2.3 MB   +0%
fromList-distinctAsc                   32 μs   32 μs   +0%    305 KB  305 KB   +0%
fromList-distinctAsc:fusion            32 μs   32 μs   +0%    481 KB  481 KB   +0%
fromList-distinctDesc                 574 μs  412 μs  -28%    3.1 MB  3.1 MB   +0%
fromList-distinctDesc:fusion          620 μs  461 μs  -25%    3.4 MB  3.4 MB   +0%
fromListWith-asc                       30 μs   28 μs   -7%    273 KB  273 KB   +0%
fromListWith-asc:fusion                29 μs   29 μs   +0%    513 KB  513 KB   +0%
fromListWith-desc                     530 μs  331 μs  -37%    2.8 MB  2.8 MB   +0%
fromListWith-desc:fusion              578 μs  381 μs  -34%    3.1 MB  3.1 MB   +0%
fromListWithKey-asc                    36 μs   29 μs  -18%    289 KB  289 KB   +0%
fromListWithKey-asc:fusion             30 μs   30 μs   -1%    529 KB  529 KB   +0%
fromListWithKey-desc                  529 μs  340 μs  -35%    2.8 MB  2.8 MB   +0%
fromListWithKey-desc:fusion           575 μs  388 μs  -32%    3.2 MB  3.2 MB   +0%
insert absent                         428 μs  340 μs  -20%    1.2 MB  1.2 MB   +0%
insert present                        206 μs  204 μs   +0%    198 B   195 B    -1%
insertLookupWithKey absent            444 μs  353 μs  -20%    1.2 MB  1.2 MB   +0%
insertLookupWithKey present           375 μs  291 μs  -22%    1.1 MB  1.1 MB   +0%
insertLookupWithKey' absent           432 μs  346 μs  -19%    1.2 MB  1.2 MB   +0%
insertLookupWithKey' present          360 μs  289 μs  -19%    1.1 MB  1.1 MB   +0%
insertWith absent                     429 μs  331 μs  -22%    1.2 MB  1.2 MB   +0%
insertWith present                    369 μs  272 μs  -26%    1.1 MB  1.1 MB   +0%
insertWith' absent                    423 μs  322 μs  -23%    1.2 MB  1.2 MB   +0%
insertWith' present                   350 μs  269 μs  -23%    1.1 MB  1.1 MB   +0%
insertWithKey absent                  422 μs  332 μs  -21%    1.2 MB  1.2 MB   +0%
insertWithKey present                 363 μs  278 μs  -23%    1.1 MB  1.1 MB   +0%
insertWithKey' absent                 426 μs  324 μs  -23%    1.2 MB  1.2 MB   +0%
insertWithKey' present                358 μs  267 μs  -25%    1.0 MB  1.0 MB   +0%
intersection                          189 μs  177 μs   -6%    400 KB  400 KB   +0%
lookup absent                         129 μs  128 μs   +0%    162 B    69 B   -57%
lookup present                        121 μs  124 μs   +2%     32 KB   32 KB   +0%
lookupIndex                           167 μs  161 μs   -3%    128 KB  128 KB   +0%
map                                    37 μs   38 μs   +3%    288 KB  288 KB   +0%
map really                             88 μs   91 μs   +3%    352 KB  352 KB   +0%
mapKeys:asc                            82 μs   81 μs   +0%    481 KB  481 KB   +0%
mapKeys:desc                          646 μs  482 μs  -25%    3.2 MB  3.2 MB   +0%
mapKeysWith:asc                        72 μs   71 μs   -1%    465 KB  465 KB   +0%
mapKeysWith:desc                      584 μs  391 μs  -33%    2.9 MB  2.9 MB   +0%
mapMaybe                              108 μs  103 μs   -4%    253 KB  254 KB   +0%
mapMaybeWithKey                       108 μs  104 μs   -4%    254 KB  254 KB   +0%
mapWithKey                             40 μs   43 μs   +6%    352 KB  352 KB   +0%
minView                                22 ns   18 ns  -19%    136 B   136 B    +0%
split                                 187 ns  163 ns  -12%    1.1 KB  1.1 KB   +0%
union                                 128 μs  126 μs   -1%    583 KB  583 KB   +0%
update absent                         393 μs  316 μs  -19%    1.1 MB  1.1 MB   +0%
update delete                         470 μs  379 μs  -19%    1.1 MB  1.1 MB   +0%
update present                        328 μs  256 μs  -21%    921 KB  920 KB   +0%
updateLookupWithKey absent            413 μs  332 μs  -19%    1.1 MB  1.1 MB   +0%
updateLookupWithKey delete            478 μs  387 μs  -19%    1.1 MB  1.1 MB   +0%
updateLookupWithKey present           344 μs  259 μs  -24%    953 KB  952 KB   +0%
```

</details>

Set operations, Set:

<details>
<summary>Expand</summary>

```
Name                                  Time - - - - - - - -    Allocated - - - - -
                                           A       B     %         A       B     %
difference-block_nn                   463 μs  457 μs   -1%    1.1 MB  1.1 MB   +0%
difference-block_nn_swap              461 μs  455 μs   -1%    1.1 MB  1.1 MB   +0%
difference-block_ns                    52 μs   50 μs   -4%    153 KB  153 KB   +0%
difference-block_sn_swap               52 μs   50 μs   -4%    142 KB  142 KB   +0%
difference-common_nn                  7.0 ms  6.5 ms   -7%     10 MB   10 MB   +0%
difference-common_nn_swap             3.5 ms  3.3 ms   -5%    5.0 MB  5.0 MB   +0%
difference-common_ns                  3.3 ms  3.1 ms   -7%    5.0 MB  5.0 MB   +0%
difference-common_nt                  150 μs  130 μs  -13%    361 KB  361 KB   +0%
difference-common_sn_swap             1.2 ms  1.1 ms   -5%    1.9 MB  1.9 MB   +0%
difference-common_tn_swap              84 μs   80 μs   -4%    130 KB  130 KB   +0%
difference-disj_nn                    2.8 μs  2.8 μs   +0%     10 KB   10 KB   +0%
difference-disj_nn_swap               2.6 μs  2.6 μs   +0%     10 KB   10 KB   +0%
difference-disj_ns                    2.3 μs  2.3 μs   +1%    8.2 KB  8.2 KB   +0%
difference-disj_nt                    1.4 μs  1.4 μs   +0%    5.0 KB  5.0 KB   +0%
difference-disj_sn_swap               2.4 μs  2.4 μs   +0%    8.5 KB  8.5 KB   +0%
difference-disj_tn_swap               1.5 μs  1.4 μs   -1%    5.0 KB  5.0 KB   +0%
difference-mix_nn                     6.8 ms  6.4 ms   -5%     15 MB   15 MB   +0%
difference-mix_nn_swap                6.8 ms  6.3 ms   -6%     15 MB   15 MB   +0%
difference-mix_ns                     2.0 ms  1.8 ms   -5%    4.1 MB  4.1 MB   +0%
difference-mix_nt                     114 μs  104 μs   -8%    261 KB  261 KB   +0%
difference-mix_sn_swap                1.7 ms  1.7 ms   -3%    2.8 MB  2.8 MB   +0%
difference-mix_tn_swap                 94 μs   94 μs   +0%    154 KB  154 KB   +0%
intersection-block_nn                 469 μs  466 μs   +0%    1.1 MB  1.1 MB   +0%
intersection-block_nn_swap            472 μs  459 μs   -2%    1.1 MB  1.1 MB   +0%
intersection-block_ns                  52 μs   50 μs   -2%    142 KB  142 KB   +0%
intersection-block_sn_swap             52 μs   50 μs   -3%    153 KB  153 KB   +0%
intersection-common_nn                6.1 ms  5.8 ms   -4%    7.9 MB  7.9 MB   +0%
intersection-common_nn_swap           2.8 ms  2.7 ms   -4%    4.8 MB  4.8 MB   +0%
intersection-common_ns                1.7 ms  1.6 ms   -4%    2.7 MB  2.7 MB   +0%
intersection-common_nt                105 μs  100 μs   -4%    161 KB  161 KB   +0%
intersection-common_sn_swap           1.4 ms  1.3 ms   -6%    3.0 MB  3.0 MB   +0%
intersection-common_tn_swap           100 μs   90 μs  -10%    232 KB  232 KB   +0%
intersection-disj_nn                  2.7 μs  2.6 μs   +0%     10 KB   10 KB   +0%
intersection-disj_nn_swap             2.9 μs  2.9 μs   +0%     10 KB   10 KB   +0%
intersection-disj_ns                  2.4 μs  2.4 μs   +2%    8.5 KB  8.5 KB   +0%
intersection-disj_nt                  1.5 μs  1.5 μs   +1%    5.0 KB  5.0 KB   +0%
intersection-disj_sn_swap             2.3 μs  2.4 μs   +0%    8.2 KB  8.2 KB   +0%
intersection-disj_tn_swap             1.4 μs  1.4 μs   +0%    5.0 KB  5.0 KB   +0%
intersection-mix_nn                   6.2 ms  6.0 ms   -3%     15 MB   15 MB   +0%
intersection-mix_nn_swap              6.1 ms  6.0 ms   -2%     15 MB   15 MB   +0%
intersection-mix_ns                   1.6 ms  1.6 ms   -2%    2.8 MB  2.8 MB   +0%
intersection-mix_nt                    99 μs  101 μs   +1%    154 KB  154 KB   +0%
intersection-mix_sn_swap              1.9 ms  1.8 ms   -7%    4.1 MB  4.1 MB   +0%
intersection-mix_tn_swap              113 μs  104 μs   -8%    261 KB  261 KB   +0%
symmetricDifference-block_nn          689 μs  641 μs   -6%    1.7 MB  1.7 MB   +0%
symmetricDifference-block_nn_swap     688 μs  641 μs   -6%    1.7 MB  1.7 MB   +0%
symmetricDifference-block_ns           69 μs   64 μs   -7%    211 KB  211 KB   +0%
symmetricDifference-block_sn_swap      77 μs   67 μs  -12%    249 KB  249 KB   +0%
symmetricDifference-common_nn         6.1 ms  5.9 ms   -4%    7.9 MB  7.9 MB   +0%
symmetricDifference-common_nn_swap    6.5 ms  6.1 ms   -5%    8.5 MB  8.5 MB   +0%
symmetricDifference-common_ns         2.1 ms  2.0 ms   -1%    3.4 MB  3.4 MB   +0%
symmetricDifference-common_nt         117 μs  116 μs   +0%    243 KB  243 KB   +0%
symmetricDifference-common_sn_swap    3.0 ms  2.9 ms   -5%    4.7 MB  4.7 MB   +0%
symmetricDifference-common_tn_swap    147 μs  128 μs  -12%    349 KB  348 KB   +0%
symmetricDifference-disj_nn           4.0 μs  3.4 μs  -13%     16 KB   16 KB   +0%
symmetricDifference-disj_nn_swap      4.3 μs  3.6 μs  -15%     17 KB   17 KB   +0%
symmetricDifference-disj_ns           3.3 μs  2.9 μs  -10%     13 KB   13 KB   +0%
symmetricDifference-disj_nt           1.9 μs  1.7 μs   -9%    7.1 KB  7.1 KB   +0%
symmetricDifference-disj_sn_swap      3.7 μs  3.1 μs  -16%     15 KB   15 KB   +0%
symmetricDifference-disj_tn_swap      2.4 μs  2.0 μs  -17%    9.6 KB  9.6 KB   +0%
symmetricDifference-mix_nn             19 ms   18 ms   -2%     19 MB   19 MB   +0%
symmetricDifference-mix_nn_swap        19 ms   18 ms   -2%     19 MB   19 MB   +0%
symmetricDifference-mix_ns            3.3 ms  3.2 ms   -2%    5.1 MB  5.1 MB   +0%
symmetricDifference-mix_nt            126 μs  126 μs   +0%    297 KB  297 KB   +0%
symmetricDifference-mix_sn_swap       3.1 ms  3.0 ms   -3%    4.5 MB  4.5 MB   +0%
symmetricDifference-mix_tn_swap       118 μs  109 μs   -7%    273 KB  273 KB   +0%
union-block_nn                        674 μs  629 μs   -6%    1.6 MB  1.6 MB   +0%
union-block_nn_swap                   672 μs  626 μs   -6%    1.6 MB  1.6 MB   +0%
union-block_ns                         69 μs   62 μs   -9%    204 KB  204 KB   +0%
union-block_sn_swap                    75 μs   65 μs  -12%    238 KB  238 KB   +0%
union-common_nn                       3.0 ms  3.0 ms   +0%    4.7 MB  4.7 MB   +0%
union-common_nn_swap                  7.7 ms  7.5 ms   -3%    7.3 MB  7.3 MB   +0%
union-common_ns                       876 μs  878 μs   +0%    1.3 MB  1.3 MB   +0%
union-common_nt                        41 μs   40 μs   +0%     49 KB   49 KB   +0%
union-common_sn_swap                  1.6 ms  1.6 ms   -4%    2.8 MB  2.8 MB   +0%
union-common_tn_swap                   85 μs   75 μs  -11%    200 KB  200 KB   +0%
union-disj_nn                         3.8 μs  3.2 μs  -14%     16 KB   16 KB   +0%
union-disj_nn_swap                    4.0 μs  3.6 μs  -10%     16 KB   16 KB   +0%
union-disj_ns                         3.2 μs  2.9 μs  -10%     12 KB   12 KB   +0%
union-disj_nt                         1.9 μs  1.7 μs  -10%    6.8 KB  6.8 KB   +0%
union-disj_sn_swap                    3.6 μs  3.0 μs  -16%     14 KB   14 KB   +0%
union-disj_tn_swap                    2.2 μs  1.8 μs  -17%    9.0 KB  9.0 KB   +0%
union-mix_nn                           21 ms   20 ms   -1%     23 MB   23 MB   +0%
union-mix_nn_swap                      20 ms   20 ms   +0%     23 MB   23 MB   +0%
union-mix_ns                          2.1 ms  2.0 ms   -1%    3.8 MB  3.8 MB   +0%
union-mix_nt                           81 μs   71 μs  -12%    188 KB  188 KB   +0%
union-mix_sn_swap                     3.3 ms  3.2 ms   -3%    4.0 MB  4.0 MB   +0%
union-mix_tn_swap                     100 μs   89 μs  -11%    228 KB  228 KB   +0%
```

</details>

Set operations, Map:
<details>
<summary>Expand</summary>

```
Name                                  Time - - - - - - - -    Allocated - - - - -
                                           A       B     %         A       B     %
difference-block_nn                   461 μs  439 μs   -4%    1.3 MB  1.3 MB   +0%
difference-block_nn_swap              460 μs  439 μs   -4%    1.3 MB  1.3 MB   +0%
difference-block_ns                    50 μs   47 μs   -6%    184 KB  184 KB   +0%
difference-block_sn_swap               51 μs   48 μs   -5%    171 KB  171 KB   +0%
difference-common_nn                  7.6 ms  7.3 ms   -4%     12 MB   12 MB   +0%
difference-common_nn_swap             3.4 ms  3.4 ms   -2%    6.0 MB  6.0 MB   +0%
difference-common_ns                  4.1 ms  3.9 ms   -4%    6.1 MB  6.1 MB   +0%
difference-common_nt                  151 μs  134 μs  -11%    433 KB  433 KB   +0%
difference-common_sn_swap             1.2 ms  1.2 ms   -2%    2.3 MB  2.3 MB   +0%
difference-common_tn_swap              78 μs   76 μs   -2%    156 KB  156 KB   +0%
difference-disj_nn                    2.6 μs  2.5 μs   -3%     12 KB   12 KB   +0%
difference-disj_nn_swap               2.3 μs  2.2 μs   -4%     12 KB   12 KB   +0%
difference-disj_ns                    2.0 μs  2.0 μs   -3%    9.8 KB  9.8 KB   +0%
difference-disj_nt                    1.3 μs  1.2 μs   -3%    6.0 KB  6.0 KB   +0%
difference-disj_sn_swap               2.3 μs  2.1 μs  -10%     10 KB   10 KB   +0%
difference-disj_tn_swap               1.4 μs  1.3 μs   -3%    6.0 KB  6.0 KB   +0%
difference-mix_nn                     7.2 ms  7.0 ms   -3%     18 MB   18 MB   +0%
difference-mix_nn_swap                7.1 ms  6.7 ms   -5%     18 MB   18 MB   +0%
difference-mix_ns                     2.0 ms  1.9 ms   -5%    4.9 MB  4.9 MB   +0%
difference-mix_nt                     114 μs  107 μs   -5%    313 KB  313 KB   +0%
difference-mix_sn_swap                1.6 ms  1.6 ms   -1%    3.4 MB  3.4 MB   +0%
difference-mix_tn_swap                 91 μs   88 μs   -3%    185 KB  185 KB   +0%
intersection-block_nn                 461 μs  435 μs   -5%    1.3 MB  1.3 MB   +0%
intersection-block_nn_swap            463 μs  437 μs   -5%    1.3 MB  1.3 MB   +0%
intersection-block_ns                  51 μs   48 μs   -5%    171 KB  171 KB   +0%
intersection-block_sn_swap             50 μs   47 μs   -6%    184 KB  184 KB   +0%
intersection-common_nn                6.9 ms  6.5 ms   -6%    9.4 MB  9.4 MB   +0%
intersection-common_nn_swap           2.9 ms  2.7 ms   -7%    5.7 MB  5.7 MB   +0%
intersection-common_ns                1.7 ms  1.6 ms   -5%    3.2 MB  3.2 MB   +0%
intersection-common_nt                101 μs   98 μs   -3%    194 KB  194 KB   +0%
intersection-common_sn_swap           1.4 ms  1.4 ms   -4%    3.6 MB  3.6 MB   +0%
intersection-common_tn_swap            99 μs   92 μs   -7%    278 KB  278 KB   +0%
intersection-disj_nn                  2.3 μs  2.2 μs   -4%     12 KB   12 KB   +0%
intersection-disj_nn_swap             2.5 μs  2.4 μs   -4%     12 KB   12 KB   +0%
intersection-disj_ns                  2.2 μs  2.1 μs   -6%     10 KB   10 KB   +0%
intersection-disj_nt                  1.4 μs  1.3 μs   -6%    6.0 KB  6.0 KB   +0%
intersection-disj_sn_swap             2.1 μs  2.0 μs   -5%    9.8 KB  9.8 KB   +0%
intersection-disj_tn_swap             1.3 μs  1.2 μs   -4%    6.0 KB  6.0 KB   +0%
intersection-mix_nn                   6.4 ms  6.3 ms   +0%     18 MB   18 MB   +0%
intersection-mix_nn_swap              6.3 ms  6.3 ms   +0%     18 MB   18 MB   +0%
intersection-mix_ns                   1.6 ms  1.6 ms   +0%    3.4 MB  3.4 MB   +0%
intersection-mix_nt                    94 μs   95 μs   +0%    185 KB  185 KB   +0%
intersection-mix_sn_swap              1.9 ms  1.8 ms   -4%    4.9 MB  4.9 MB   +0%
intersection-mix_tn_swap              112 μs  103 μs   -7%    313 KB  313 KB   +0%
symmetricDifference-block_nn          699 μs  658 μs   -5%    2.1 MB  2.1 MB   +0%
symmetricDifference-block_nn_swap     700 μs  670 μs   -4%    2.1 MB  2.1 MB   +0%
symmetricDifference-block_ns           68 μs   64 μs   -5%    253 KB  253 KB   +0%
symmetricDifference-block_sn_swap      76 μs   67 μs  -11%    299 KB  299 KB   +0%
symmetricDifference-common_nn         6.9 ms  6.8 ms   -1%    9.5 MB  9.5 MB   +0%
symmetricDifference-common_nn_swap    6.9 ms  6.7 ms   -3%     10 MB   10 MB   +0%
symmetricDifference-common_ns         2.3 ms  2.3 ms   -2%    4.0 MB  4.0 MB   +0%
symmetricDifference-common_nt         118 μs  114 μs   -3%    292 KB  292 KB   +0%
symmetricDifference-common_sn_swap    3.8 ms  3.6 ms   -5%    5.6 MB  5.6 MB   +0%
symmetricDifference-common_tn_swap    151 μs  134 μs  -11%    418 KB  418 KB   +0%
symmetricDifference-disj_nn           3.6 μs  3.2 μs  -11%     20 KB   20 KB   +0%
symmetricDifference-disj_nn_swap      3.9 μs  3.4 μs  -14%     20 KB   20 KB   +0%
symmetricDifference-disj_ns           3.1 μs  2.7 μs  -10%     15 KB   15 KB   +0%
symmetricDifference-disj_nt           1.8 μs  1.6 μs  -10%    8.5 KB  8.5 KB   +0%
symmetricDifference-disj_sn_swap      3.6 μs  2.9 μs  -18%     18 KB   18 KB   +0%
symmetricDifference-disj_tn_swap      2.3 μs  1.9 μs  -18%     12 KB   12 KB   +0%
symmetricDifference-mix_nn             15 ms   20 ms  +32%     23 MB   23 MB   +0%
symmetricDifference-mix_nn_swap        20 ms   20 ms   +0%     23 MB   23 MB   +0%
symmetricDifference-mix_ns            3.9 ms  4.1 ms   +3%    6.2 MB  6.2 MB   +0%
symmetricDifference-mix_nt            127 μs  126 μs   -1%    356 KB  356 KB   +0%
symmetricDifference-mix_sn_swap       4.0 ms  4.0 ms   +0%    5.4 MB  5.4 MB   +0%
symmetricDifference-mix_tn_swap       119 μs  113 μs   -5%    328 KB  328 KB   +0%
union-block_nn                        706 μs  630 μs  -10%    2.0 MB  2.0 MB   +0%
union-block_nn_swap                   695 μs  619 μs  -10%    2.0 MB  2.0 MB   +0%
union-block_ns                         70 μs   61 μs  -13%    245 KB  245 KB   +0%
union-block_sn_swap                    77 μs   65 μs  -16%    286 KB  286 KB   +0%
union-common_nn                       3.2 ms  3.2 ms   -1%    5.7 MB  5.7 MB   +0%
union-common_nn_swap                  8.1 ms  8.0 ms   -1%    8.3 MB  8.3 MB   +0%
union-common_ns                       933 μs  907 μs   -2%    1.5 MB  1.5 MB   +0%
union-common_nt                        43 μs   41 μs   -4%     59 KB   59 KB   +0%
union-common_sn_swap                  1.9 ms  1.8 ms   -5%    3.4 MB  3.4 MB   +0%
union-common_tn_swap                   87 μs   75 μs  -13%    240 KB  240 KB   +0%
union-disj_nn                         3.6 μs  3.1 μs  -16%     19 KB   19 KB   +0%
union-disj_nn_swap                    4.0 μs  3.3 μs  -15%     19 KB   19 KB   +0%
union-disj_ns                         3.1 μs  2.6 μs  -15%     14 KB   14 KB   +0%
union-disj_nt                         1.8 μs  1.6 μs  -15%    8.2 KB  8.2 KB   +0%
union-disj_sn_swap                    3.4 μs  2.9 μs  -16%     17 KB   17 KB   +0%
union-disj_tn_swap                    2.2 μs  1.8 μs  -16%     11 KB   11 KB   +0%
union-mix_nn                           23 ms   23 ms   -1%     28 MB   28 MB   +0%
union-mix_nn_swap                      23 ms   23 ms   +0%     28 MB   28 MB   +0%
union-mix_ns                          2.8 ms  2.6 ms   -4%    4.6 MB  4.6 MB   +0%
union-mix_nt                           86 μs   71 μs  -17%    225 KB  225 KB   +0%
union-mix_sn_swap                     3.8 ms  3.2 ms  -15%    4.8 MB  4.8 MB   +0%
union-mix_tn_swap                     105 μs   90 μs  -14%    273 KB  273 KB   +0%
```

</details>
