### PR TITLE
Remove unnecessary Int-Word conversions

### DIFF
--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -266,8 +266,6 @@ import Data.IntSet.Internal.IntTreeCommons
   (Key, Prefix(..), nomatch, left, signBranch, mask, branchMask)
 import Data.IntMap.Internal
   ( IntMap (..)
-  , natFromInt
-  , intFromNat
   , bin
   , binCheckLeft
   , binCheckRight
@@ -346,7 +344,7 @@ import Data.IntMap.Internal
   , withoutKeys
   )
 import qualified Data.IntSet.Internal as IntSet
-import Utils.Containers.Internal.BitUtil
+import Utils.Containers.Internal.BitUtil (iShiftRL, shiftLL, shiftRL)
 import Utils.Containers.Internal.StrictPair
 import qualified Data.Foldable as Foldable
 
@@ -1056,7 +1054,7 @@ fromSet f (IntSet.Tip kx bm) = buildTree f kx bm (IntSet.suffixBitMask + 1)
         -- one of them is nonempty and we construct the IntMap from that half.
         buildTree g !prefix !bmask bits = case bits of
           0 -> Tip prefix $! g prefix
-          _ -> case intFromNat ((natFromInt bits) `shiftRL` 1) of
+          _ -> case bits `iShiftRL` 1 of
                  bits2 | bmask .&. ((1 `shiftLL` bits2) - 1) == 0 ->
                            buildTree g (prefix + bits2) (bmask `shiftRL` bits2) bits2
                        | (bmask `shiftRL` bits2) .&. ((1 `shiftLL` bits2) - 1) == 0 ->

--- a/containers/src/Data/IntSet/Internal/IntTreeCommons.hs
+++ b/containers/src/Data/IntSet/Internal/IntTreeCommons.hs
@@ -35,10 +35,11 @@ module Data.IntSet.Internal.IntTreeCommons
   , treeTreeBranch
   , mask
   , branchMask
+  , i2w
   ) where
 
-import Data.Bits (Bits(..))
-import Utils.Containers.Internal.BitUtil (highestBitMask)
+import Data.Bits (Bits(..), countLeadingZeros)
+import Utils.Containers.Internal.BitUtil (wordSize)
 
 #ifdef __GLASGOW_HASKELL__
 import Language.Haskell.TH.Syntax (Lift)
@@ -149,17 +150,16 @@ mask i m = i .&. ((-m) `xor` m)
 {-# INLINE mask #-}
 
 -- | The first switching bit where the two prefixes disagree.
+--
+-- Precondition for defined behavior: p1 /= p2
 branchMask :: Int -> Int -> Int
-branchMask p1 p2 = w2i (highestBitMask (i2w (p1 `xor` p2)))
+branchMask p1 p2 =
+  unsafeShiftL 1 (wordSize - 1 - countLeadingZeros (p1 `xor` p2))
 {-# INLINE branchMask #-}
 
 i2w :: Int -> Word
 i2w = fromIntegral
 {-# INLINE i2w #-}
-
-w2i :: Word -> Int
-w2i = fromIntegral
-{-# INLINE w2i #-}
 
 {--------------------------------------------------------------------
   Notes


### PR DESCRIPTION
This simplifies the code and the GHC Core. It is not expected to affect
performance since Int-Word conversions are free at runtime.

Additionally,
* Remove the Nat synonym
* Document some preconditions

Closes #1018