### PR TITLE
Use randomly structured Set and Map in benchmarks

### DIFF
--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -9,14 +9,16 @@ import Data.List (foldl')
 import qualified Data.Set as S
 
 import Utils.Fold (foldBenchmarks)
+import Utils.Random (shuffle)
 
 main = do
-    let s = S.fromAscList elems :: S.Set Int
-        s_even = S.fromAscList elems_even :: S.Set Int
-        s_odd = S.fromAscList elems_odd :: S.Set Int
+    let s = S.fromList elems :: S.Set Int
+        s_even = S.fromList elems_even :: S.Set Int
+        s_odd = S.fromList elems_odd :: S.Set Int
         strings_s = S.fromList strings
     evaluate $ rnf [s, s_even, s_odd]
-    evaluate $ rnf [elems_rev, elems_asc, elems_desc]
+    evaluate $ rnf
+      [elems_distinct_asc, elems_distinct_desc, elems_asc, elems_desc]
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
@@ -35,10 +37,10 @@ main = do
         , bench "fromList" $ whnf S.fromList elems
         , bench "fromList-desc" $ whnf S.fromList elems_desc
         , bench "fromAscList" $ whnf S.fromAscList elems_asc
-        , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems
+        , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems_distinct_asc
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
         , bench "fromDescList" $ whnf S.fromDescList elems_desc
-        , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_rev
+        , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_distinct_desc
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even
         , bench "disjoint:true" $ whnf (S.disjoint s_odd) s_even
@@ -61,10 +63,11 @@ main = do
         ]
   where
     bound = 2^12
-    elems = [1..bound]
-    elems_even = [2,4..bound]
-    elems_odd = [1,3..bound]
-    elems_rev = reverse elems
+    elems_distinct_asc = [1..bound]
+    elems_distinct_desc = reverse elems_distinct_asc
+    elems = shuffle elems_distinct_asc
+    elems_even = shuffle [2,4..bound]
+    elems_odd = shuffle [1,3..bound]
     elems_asc = map (`div` 2) [1..bound] -- [0,1,1,2,2..]
     elems_desc = map (`div` 2) [bound,bound-1..1] -- [..2,2,1,1,0]
     strings = map show elems

--- a/containers-tests/benchmarks/SetOperations/SetOperations-Map.hs
+++ b/containers-tests/benchmarks/SetOperations/SetOperations-Map.hs
@@ -3,8 +3,10 @@ module Main where
 import Data.Map as C
 import SetOperations
 
+import Utils.Random (shuffle)
+
 main :: IO ()
-main = benchmark (\xs -> fromList [(x, x) | x <- xs]) True
+main = benchmark (\xs -> fromList [(x, x) | x <- shuffle xs]) True
   [ ("union", C.union)
   , ("difference", C.difference)
   , ("intersection", C.intersection)

--- a/containers-tests/benchmarks/SetOperations/SetOperations-Set.hs
+++ b/containers-tests/benchmarks/SetOperations/SetOperations-Set.hs
@@ -3,8 +3,10 @@ module Main where
 import Data.Set as C
 import SetOperations
 
+import Utils.Random (shuffle)
+
 main :: IO ()
-main = benchmark fromList True
+main = benchmark (fromList . shuffle) True
   [ ("union", C.union)
   , ("difference", C.difference)
   , ("intersection", C.intersection)

--- a/containers-tests/benchmarks/Utils/Random.hs
+++ b/containers-tests/benchmarks/Utils/Random.hs
@@ -1,0 +1,22 @@
+module Utils.Random
+  ( shuffle
+  ) where
+
+import Data.List (unfoldr)
+import qualified Data.Sequence as Seq
+import System.Random (StdGen, mkStdGen, randomR)
+
+-- O(n log n). Deterministic shuffle. Implements Fisher-Yates.
+shuffle :: [a] -> [a]
+shuffle xs0 = unfoldr f (gen, Seq.fromList xs0)
+  where
+    f (g, xs)
+      | Seq.null xs = Nothing
+      | otherwise = Just (x, (g', xs'))
+      where
+        (i, g') = randomR (0, Seq.length xs - 1) g
+        x = Seq.index xs i
+        xs' = Seq.deleteAt i xs
+
+gen :: StdGen
+gen = mkStdGen 42

--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -167,6 +167,11 @@ benchmark map-benchmarks
   hs-source-dirs: benchmarks
   main-is:        Map.hs
   ghc-options:    -O2
+  build-depends:
+      random >=1.0 && <1.3
+
+  other-modules:
+      Utils.Random
 
   other-modules:
     Utils.Fold
@@ -196,7 +201,7 @@ benchmark sequence-benchmarks
   main-is:        Sequence.hs
   ghc-options:    -O2
   build-depends:
-      random            >=0       && <1.2
+      random >=1.0 && <1.3
     , transformers
 
   other-modules:
@@ -212,6 +217,11 @@ benchmark set-benchmarks
   hs-source-dirs: benchmarks
   main-is:        Set.hs
   ghc-options:    -O2
+  build-depends:
+      random >=1.0 && <1.3
+
+  other-modules:
+      Utils.Random
 
   other-modules:
     Utils.Fold
@@ -227,7 +237,7 @@ benchmark graph-benchmarks
   main-is:        Graph.hs
   ghc-options:    -O2
   build-depends:
-      random            >=0       && <1.2
+      random >=1.0 && <1.3
 
 benchmark set-operations-intmap
   import: benchmark-deps, warnings
@@ -251,19 +261,33 @@ benchmark set-operations-map
   import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
-  hs-source-dirs: benchmarks/SetOperations
+  hs-source-dirs:
+      benchmarks/SetOperations
+      benchmarks
   main-is:        SetOperations-Map.hs
   other-modules:  SetOperations
   ghc-options:    -O2
+  build-depends:
+      random >=1.0 && <1.3
+
+  other-modules:
+      Utils.Random
 
 benchmark set-operations-set
   import: benchmark-deps, warnings
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
-  hs-source-dirs: benchmarks/SetOperations
+  hs-source-dirs:
+      benchmarks/SetOperations
+      benchmarks
   main-is:        SetOperations-Set.hs
   other-modules:  SetOperations
   ghc-options:    -O2
+  build-depends:
+      random >=1.0 && <1.3
+
+  other-modules:
+      Utils.Random
 
 benchmark lookupge-intmap
   import: benchmark-deps, warnings


### PR DESCRIPTION
Trees constructed from [1..n] have a specific structure of perfect
binary trees linked together. We shuffle the list so that the tree
is generated from repeated insertions instead, which forms a random
structure that should be more representative of average use cases.

Most benchmarks show an increase in measured times, the amount varying
from 10% to 80%.