### PR TITLE
Improve folds over bits for IntSet

### DIFF
--- a/containers-tests/benchmarks/Utils/Fold.hs
+++ b/containers-tests/benchmarks/Utils/Fold.hs
@@ -37,7 +37,7 @@ foldBenchmarks foldr foldl foldr' foldl' foldMap xs =
   , bench "foldr_traverseSum" $ whnf foldr_traverseSum xs
 
     -- foldl
-  , bench "foldl_skip" $ whnf foldl_elem xs
+  , bench "foldl_elem" $ whnf foldl_elem xs
   , bench "foldl_cpsSum" $ whnf foldl_cpsSum xs
   , bench "foldl_cpsOneShotSum" $ whnf foldl_cpsOneShotSum xs
   , bench "foldl_traverseSum" $ whnf foldl_traverseSum xs

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -64,10 +64,10 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_findMin" prop_findMin
                    , testProperty "prop_ord" prop_ord
                    , testProperty "prop_readShow" prop_readShow
-                   , testProperty "prop_foldR" prop_foldR
-                   , testProperty "prop_foldR'" prop_foldR'
-                   , testProperty "prop_foldL" prop_foldL
-                   , testProperty "prop_foldL'" prop_foldL'
+                   , testProperty "prop_foldr" prop_foldr
+                   , testProperty "prop_foldr'" prop_foldr'
+                   , testProperty "prop_foldl" prop_foldl
+                   , testProperty "prop_foldl'" prop_foldl'
                    , testProperty "prop_foldMap" prop_foldMap
                    , testProperty "prop_map" prop_map
                    , testProperty "prop_mapMonotonicId" prop_mapMonotonicId
@@ -370,17 +370,17 @@ prop_ord s1 s2 = s1 `compare` s2 == toList s1 `compare` toList s2
 prop_readShow :: IntSet -> Bool
 prop_readShow s = s == read (show s)
 
-prop_foldR :: IntSet -> Bool
-prop_foldR s = foldr (:) [] s == toList s
+prop_foldr :: IntSet -> Property
+prop_foldr s = foldr (:) [] s === toList s
 
-prop_foldR' :: IntSet -> Bool
-prop_foldR' s = foldr' (:) [] s == toList s
+prop_foldr' :: IntSet -> Property
+prop_foldr' s = foldr' (:) [] s === toList s
 
-prop_foldL :: IntSet -> Bool
-prop_foldL s = foldl (flip (:)) [] s == List.foldl (flip (:)) [] (toList s)
+prop_foldl :: IntSet -> Property
+prop_foldl s = foldl (flip (:)) [] s === toDescList s
 
-prop_foldL' :: IntSet -> Bool
-prop_foldL' s = foldl' (flip (:)) [] s == List.foldl' (flip (:)) [] (toList s)
+prop_foldl' :: IntSet -> Property
+prop_foldl' s = foldl' (flip (:)) [] s === toDescList s
 
 prop_foldMap :: IntSet -> Property
 prop_foldMap s = foldMap (:[]) s === toList s

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -58,6 +58,8 @@
 * For `Data.Graph.SCC`, `Foldable.toList` and `Foldable1.toNonEmpty` now
   do not perform a copy. (Soumik Sarkar)
 
+* Improved performance for `Data.Intset`'s `foldr`, `foldl'`, `foldl`, `foldr'`.
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1724,9 +1724,10 @@ foldlBits prefix f z0 bitmap = go z0 $! revWord bitmap
   where
     -- Note: We pass the z as a static argument because it helps GHC with demand
     -- analysis. See GHC #25578 for details.
-    go z !bm = f (if bm' == 0 then z else go z bm') (prefix .|. bi)
+    go z !bm = f (if bm' == 0 then z else go z bm') x
       where
         bi = WORD_SIZE_IN_BITS - 1 - countTrailingZeros bm
+        !x = prefix .|. bi
         bm' = bm .&. (bm-1)
 
 foldl'Bits prefix f z0 bitmap = go z0 bitmap
@@ -1734,16 +1735,18 @@ foldl'Bits prefix f z0 bitmap = go z0 bitmap
     go !z !bm = if bm' == 0 then z' else go z' bm'
       where
         bi = countTrailingZeros bm
-        !z' = f z (prefix .|. bi)
+        !x = prefix .|. bi
+        !z' = f z x
         bm' = bm .&. (bm-1)
 
 foldrBits prefix f z0 bitmap = go bitmap z0
   where
     -- Note: We pass the z as a static argument because it helps GHC with demand
     -- analysis. See GHC #25578 for details.
-    go !bm z = f (prefix .|. bi) (if bm' == 0 then z else go bm' z)
+    go !bm z = f x (if bm' == 0 then z else go bm' z)
       where
         bi = countTrailingZeros bm
+        !x = prefix .|. bi
         bm' = bm .&. (bm-1)
 
 foldr'Bits prefix f z0 bitmap = (go $! revWord bitmap) z0
@@ -1751,7 +1754,8 @@ foldr'Bits prefix f z0 bitmap = (go $! revWord bitmap) z0
     go !bm !z = if bm' == 0 then z' else go bm' z'
       where
         bi = WORD_SIZE_IN_BITS - 1 - countTrailingZeros bm
-        !z' = f (prefix .|. bi) z
+        !x = prefix .|. bi
+        !z' = f x z
         bm' = bm .&. (bm-1)
 
 foldMapBits prefix f bitmap = go bitmap
@@ -1765,7 +1769,7 @@ foldMapBits prefix f bitmap = go bitmap
 #endif
       where
         bi = countTrailingZeros bm
-        x = prefix .|. bi
+        !x = prefix .|. bi
         bm' = bm .&. (bm-1)
 
 takeWhileAntitoneBits prefix predicate bitmap =

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1699,10 +1699,6 @@ takeWhileAntitoneBits :: Int -> (Int -> Bool) -> Word -> Word
 
 #if defined(__GLASGOW_HASKELL__)
 
-lowestBitMask :: Word -> Word
-lowestBitMask x = x .&. negate x
-{-# INLINE lowestBitMask #-}
-
 lowestBitSet x = countTrailingZeros x
 
 highestBitSet x = WORD_SIZE_IN_BITS - 1 - countLeadingZeros x
@@ -1724,45 +1720,53 @@ revWord x1 = case ((x1 `shiftRL` 1) .&. 0x5555555555555555) .|. ((x1 .&. 0x55555
                        x6 -> ( x6 `shiftRL` 32             ) .|. ( x6               `shiftLL` 32);
 #endif
 
-foldlBits prefix f z bitmap = go bitmap z
-  where go 0 acc = acc
-        go bm acc = go (bm `xor` bitmask) ((f acc) $! (prefix+bi))
-          where
-            !bitmask = lowestBitMask bm
-            !bi = countTrailingZeros bitmask
-
-foldl'Bits prefix f z bitmap = go bitmap z
-  where go 0 acc = acc
-        go bm !acc = go (bm `xor` bitmask) ((f acc) $! (prefix+bi))
-          where !bitmask = lowestBitMask bm
-                !bi = countTrailingZeros bitmask
-
-foldrBits prefix f z bitmap = go (revWord bitmap) z
-  where go 0 acc = acc
-        go bm acc = go (bm `xor` bitmask) ((f $! (prefix+(WORD_SIZE_IN_BITS-1)-bi)) acc)
-          where !bitmask = lowestBitMask bm
-                !bi = countTrailingZeros bitmask
-
-
-foldr'Bits prefix f z bitmap = go (revWord bitmap) z
-  where go 0 acc = acc
-        go bm !acc = go (bm `xor` bitmask) ((f $! (prefix+(WORD_SIZE_IN_BITS-1)-bi)) acc)
-          where !bitmask = lowestBitMask bm
-                !bi = countTrailingZeros bitmask
-
-foldMapBits prefix f bitmap = go (prefix + bi0) (bitmap `xor` bitmask0)
+foldlBits prefix f z0 bitmap = go z0 $! revWord bitmap
   where
-    bitmask0 = lowestBitMask bitmap
-    bi0 = countTrailingZeros bitmask0
-    go !x 0 = f x
+    -- Note: We pass the z as a static argument because it helps GHC with demand
+    -- analysis. See GHC #25578 for details.
+    go z !bm = f (if bm' == 0 then z else go z bm') (prefix .|. bi)
+      where
+        bi = WORD_SIZE_IN_BITS - 1 - countTrailingZeros bm
+        bm' = bm .&. (bm-1)
+
+foldl'Bits prefix f z0 bitmap = go z0 bitmap
+  where
+    go !z !bm = if bm' == 0 then z' else go z' bm'
+      where
+        bi = countTrailingZeros bm
+        !z' = f z (prefix .|. bi)
+        bm' = bm .&. (bm-1)
+
+foldrBits prefix f z0 bitmap = go bitmap z0
+  where
+    -- Note: We pass the z as a static argument because it helps GHC with demand
+    -- analysis. See GHC #25578 for details.
+    go !bm z = f (prefix .|. bi) (if bm' == 0 then z else go bm' z)
+      where
+        bi = countTrailingZeros bm
+        bm' = bm .&. (bm-1)
+
+foldr'Bits prefix f z0 bitmap = (go $! revWord bitmap) z0
+  where
+    go !bm !z = if bm' == 0 then z' else go bm' z'
+      where
+        bi = WORD_SIZE_IN_BITS - 1 - countTrailingZeros bm
+        !z' = f (prefix .|. bi) z
+        bm' = bm .&. (bm-1)
+
+foldMapBits prefix f bitmap = go bitmap
+  where
+    go !bm = if bm' == 0
+             then f x
 #if MIN_VERSION_base(4,11,0)
-    go !x bm = f x <> go (prefix + bi) (bm `xor` bitmask)
+             else f x <> go bm'
 #else
-    go !x bm = f x `mappend` go (prefix + bi) (bm `xor` bitmask)
+             else f x `mappend` go bm'
 #endif
       where
-        bitmask = lowestBitMask bm
-        bi = countTrailingZeros bitmask
+        bi = countTrailingZeros bm
+        x = prefix .|. bi
+        bm' = bm .&. (bm-1)
 
 takeWhileAntitoneBits prefix predicate bitmap =
   -- Binary search for the first index where the predicate returns false, but skip a predicate


### PR DESCRIPTION
* Make foldr and foldl short-circuit instead of lazily accumulating thunks.
* Switch to a non-empty style to avoid unnecessary comparisons. This also helps GHC with arity-analysis (somehow), which greatly improves performance of CPS-style foldr and foldl.
* Change the bitwise operations used from ``bitmask = bm .&. -bm; bi = ctz bitmask; bm' = bm `xor` bitmask`` to `bi = ctz bm; bm' = bm .&. (bm-1)` which is slightly faster.

---

Benchmarks with GHC 9.10.1

```
Name                          Time - - - - - - - -    Allocated - - - - -
                                   A       B     %         A       B     %
dense.foldMap_elem            5.6 μs  5.3 μs   -4%      0 B     0 B
dense.foldMap_traverseSum     6.5 μs  4.5 μs  -31%    1.0 KB  1.0 KB   +0%
dense.foldl'_sum              5.6 μs  4.3 μs  -22%      0 B     0 B
dense.foldl_cpsOneShotSum      19 μs  5.7 μs  -70%    194 KB  2.5 KB  -98%
dense.foldl_cpsSum             20 μs  6.2 μs  -69%    162 KB  5.0 KB  -96%
dense.foldl_elem               12 μs  5.7 μs  -53%    162 KB  2.0 KB  -98%
dense.foldl_traverseSum        20 μs  5.9 μs  -70%    162 KB  5.0 KB  -96%
dense.foldr'_sum              5.8 μs  5.5 μs   -6%      0 B     0 B
dense.foldr_cpsOneShotSum      20 μs  5.6 μs  -72%    194 KB  2.5 KB  -98%
dense.foldr_cpsSum             21 μs  5.9 μs  -71%    162 KB  5.0 KB  -96%
dense.foldr_elem               12 μs  4.8 μs  -60%    162 KB  2.0 KB  -98%
dense.foldr_traverseSum        21 μs  4.9 μs  -76%    162 KB  5.0 KB  -96%
sparse.foldMap_elem            19 μs   18 μs   -5%      0 B     0 B
sparse.foldMap_traverseSum     21 μs   20 μs   -5%     64 KB   64 KB   +0%
sparse.foldl'_sum              16 μs   14 μs  -14%      0 B     0 B
sparse.foldl_cpsOneShotSum     58 μs   38 μs  -34%    319 KB  160 KB  -49%
sparse.foldl_cpsSum            58 μs   60 μs   +4%    287 KB  320 KB  +11%
sparse.foldl_elem              27 μs   29 μs   +6%    287 KB  128 KB  -55%
sparse.foldl_traverseSum       58 μs   55 μs   -5%    287 KB  320 KB  +11%
sparse.foldr'_sum              27 μs   24 μs  -10%      0 B     0 B
sparse.foldr_cpsOneShotSum     66 μs   29 μs  -55%    319 KB  160 KB  -49%
sparse.foldr_cpsSum            65 μs   50 μs  -22%    287 KB  320 KB  +11%
sparse.foldr_elem              37 μs   20 μs  -47%    287 KB  128 KB  -55%
sparse.foldr_traverseSum       65 μs   44 μs  -32%    287 KB  320 KB  +11%
```

---

Fixes #666