### PR TITLE
Improve fromAscList and friends for Set and Map 

### DIFF
--- a/containers-tests/benchmarks/Map.hs
+++ b/containers-tests/benchmarks/Map.hs
@@ -90,11 +90,19 @@ main = do
         , bench "fromList" $ whnf M.fromList elems
         , bench "fromList-desc" $ whnf M.fromList elems_desc
         , bench "fromAscList" $ whnf M.fromAscList elems_asc
+        , bench "fromAscList:fusion" $
+            whnf (\n -> M.fromAscList [(i `div` 2, i) | i <- [1..n]]) bound
         , bench "fromAscListWithKey" $
             whnf (M.fromAscListWithKey sumkv) elems_asc
+        , bench "fromAscListWithKey:fusion" $
+            whnf (\n -> M.fromAscListWithKey sumkv [(i `div` 2, i) | i <- [1..n]]) bound
         , bench "fromDescList" $ whnf M.fromDescList elems_desc
+        , bench "fromDescList:fusion" $
+            whnf (\n -> M.fromDescList [(i `div` 2, i) | i <- [n,n-1..1]]) bound
         , bench "fromDescListWithKey" $
             whnf (M.fromDescListWithKey sumkv) elems_desc
+        , bench "fromDescListWithKey:fusion" $
+            whnf (\n -> M.fromDescListWithKey sumkv [(i `div` 2, i) | i <- [n,n-1..1]]) bound
         , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems_distinct_asc
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> M.fromDistinctAscList [(i,i) | i <- [1..n]]) bound
         , bench "fromDistinctDescList" $ whnf M.fromDistinctDescList elems_distinct_desc

--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -37,9 +37,13 @@ main = do
         , bench "fromList" $ whnf S.fromList elems
         , bench "fromList-desc" $ whnf S.fromList elems_desc
         , bench "fromAscList" $ whnf S.fromAscList elems_asc
+        , bench "fromAscList:fusion" $
+            whnf (\n -> S.fromAscList [i `div` 2 | i <- [1..n]]) bound
         , bench "fromDistinctAscList" $ whnf S.fromDistinctAscList elems_distinct_asc
         , bench "fromDistinctAscList:fusion" $ whnf (\n -> S.fromDistinctAscList [1..n]) bound
         , bench "fromDescList" $ whnf S.fromDescList elems_desc
+        , bench "fromDescList:fusion" $
+            whnf (\n -> S.fromDescList [i `div` 2 | i <- [n,n-1..1]]) bound
         , bench "fromDistinctDescList" $ whnf S.fromDistinctDescList elems_distinct_desc
         , bench "fromDistinctDescList:fusion" $ whnf (\n -> S.fromDistinctDescList [n,n-1..1]) bound
         , bench "disjoint:false" $ whnf (S.disjoint s) s_even

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -60,6 +60,9 @@
 
 * Improved performance for `Data.Intset`'s `foldr`, `foldl'`, `foldl`, `foldr'`.
 
+* Improved performance for `Data.Set` and `Data.Map`'s `fromAscList*` and
+  `fromDescList*` functions.
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions


### PR DESCRIPTION
Make fromAscList, fromAscListWith, fromAscListWithKey more efficient by removing the intermediate list and making them good consumers in list fusion.

Related: #950, #1042

Closes #1032

---

Benchmarks with GHC 9.10.1

Set:

```
Name                   Time - - - - - - - -    Allocated - - - - -
                            A       B     %         A       B     %
fromAscList             47 μs   19 μs  -59%    240 KB  176 KB  -26%
fromAscList:fusion      88 μs   12 μs  -85%    527 KB  192 KB  -63%
fromDescList            48 μs   19 μs  -61%    240 KB  176 KB  -26%
fromDescList:fusion     90 μs   46 μs  -49%    558 KB  559 KB   +0%
```

Map:

```
Name                          Time - - - - - - - -    Allocated - - - - -
                                   A       B     %         A       B     %
fromAscList                    49 μs   27 μs  -45%    481 KB  209 KB  -56%
fromAscList:fusion             71 μs   15 μs  -78%    926 KB  288 KB  -68%
fromAscListWithKey             57 μs   29 μs  -48%    592 KB  288 KB  -51%
fromAscListWithKey:fusion      86 μs   16 μs  -81%    1.0 MB  297 KB  -71%
fromDescList                   49 μs   25 μs  -48%    481 KB  209 KB  -56%
fromDescList:fusion            71 μs   46 μs  -35%    958 KB  607 KB  -36%
fromDescListWithKey            55 μs   29 μs  -48%    589 KB  288 KB  -51%
fromDescListWithKey:fusion     92 μs   52 μs  -44%    1.0 MB  688 KB  -35%
```