### PR TITLE
Use the TESTING macro less

### DIFF
--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -4,6 +4,7 @@ import Data.List (nub, sort, sortBy)
 import qualified Data.List as List
 import Data.Maybe
 import Data.Set
+import Data.Set.Internal (link, merge)
 import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl', all, take, drop, splitAt)
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -7,8 +7,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-#endif
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Trustworthy #-}
 #endif
 

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 
@@ -70,11 +70,7 @@
 
 module Data.IntMap.Lazy (
     -- * Map type
-#if !defined(TESTING)
     IntMap, Key          -- instance Eq,Show
-#else
-    IntMap(..), Key          -- instance Eq,Show
-#endif
 
     -- * Construction
     , empty

--- a/containers/src/Data/IntMap/Merge/Lazy.hs
+++ b/containers/src/Data/IntMap/Merge/Lazy.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/containers/src/Data/IntMap/Merge/Strict.hs
+++ b/containers/src/Data/IntMap/Merge/Strict.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Trustworthy #-}
 #endif
 

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Trustworthy #-}
 #endif
 
@@ -88,11 +88,7 @@
 
 module Data.IntMap.Strict (
     -- * Map type
-#if !defined(TESTING)
     IntMap, Key          -- instance Eq,Show
-#else
-    IntMap(..), Key          -- instance Eq,Show
-#endif
 
     -- * Construction
     , empty

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -86,11 +86,7 @@
 
 module Data.IntMap.Strict.Internal (
     -- * Map type
-#if !defined(TESTING)
     IntMap, Key          -- instance Eq,Show
-#else
-    IntMap(..), Key          -- instance Eq,Show
-#endif
 
     -- * Construction
     , empty

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 
@@ -66,11 +66,7 @@
 
 module Data.IntSet (
             -- * Set type
-#if !defined(TESTING)
               IntSet          -- instance Eq,Show
-#else
-              IntSet(..)      -- instance Eq,Show
-#endif
             , Key
 
             -- * Construction

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-#endif
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
 {-# LANGUAGE Trustworthy #-}
 #endif
 

--- a/containers/src/Data/Map.hs
+++ b/containers/src/Data/Map.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/containers/src/Data/Map/Merge/Strict.hs
+++ b/containers/src/Data/Map/Merge/Strict.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 
@@ -72,11 +72,7 @@
 
 module Data.Set (
             -- * Set type
-#if !defined(TESTING)
               Set          -- instance Eq,Ord,Show,Read,Data
-#else
-              Set(..)
-#endif
 
             -- * Construction
             , empty
@@ -179,14 +175,6 @@ module Data.Set (
             , showTree
             , showTreeWith
             , valid
-
-#if defined(TESTING)
-            -- Internals (for testing)
-            , bin
-            , balanced
-            , link
-            , merge
-#endif
             ) where
 
 import Data.Set.Internal as S

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE PatternGuards #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
-{-# LANGUAGE Trustworthy #-}
-#endif
 #ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/containers/src/Utils/Containers/Internal/StrictPair.hs
+++ b/containers/src/Utils/Containers/Internal/StrictPair.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(TESTING) && defined(__GLASGOW_HASKELL__)
+#ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Safe #-}
 #endif
 

--- a/containers/src/Utils/Containers/Internal/TypeError.hs
+++ b/containers/src/Utils/Containers/Internal/TypeError.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds, FlexibleInstances, FlexibleContexts, UndecidableInstances,
      KindSignatures, TypeFamilies, CPP #-}
-
-#if !defined(TESTING)
 {-# LANGUAGE Safe #-}
-#endif
 
 -- | Unsatisfiable constraints for functions being removed.
 
+-- This module is GHC-only.
 module Utils.Containers.Internal.TypeError where
-#ifdef __GLASGOW_HASKELL__
+
 import GHC.TypeLits
 
 -- | The constraint @Whoops s@ is unsatisfiable for every 'Symbol' @s@.  Trying
@@ -43,7 +41,3 @@ instance TypeError ('Text a) => Whoops a
 -- reducing the constraint because it knows someone could (theoretically)
 -- define an overlapping instance of Whoops. It doesn't commit to
 -- the polymorphic one until it has to, at the call site.
-
-#else
-class Whoops (a :: Symbol)
-#endif


### PR DESCRIPTION
It's not necessary to use it for conditional exports or SafeHaskell.

---

The only remaining usages of `TESTING` are in `Sequence.Internal` for alternate `Show` definitions. Existing issue for that: #363.