### PR TITLE
Improve documentation grammar and usage.

### DIFF
--- a/containers/docs/map.rst
+++ b/containers/docs/map.rst
@@ -250,8 +250,8 @@ value) pairs in the map ``m`` in *descending* key order.
 Querying
 ^^^^^^^^
 
-Lookup an entry in the map (lookup)
-"""""""""""""""""""""""""""""""""""
+Look up an entry in the map (lookup)
+""""""""""""""""""""""""""""""""""""
 
 ::
 

--- a/containers/docs/sequence.rst
+++ b/containers/docs/sequence.rst
@@ -48,7 +48,7 @@ The following GHCi session shows some of the basic sequence functionality::
     > 3
 
 
-    -- Lookup an element at a certain index (since version 0.4.8).
+    -- Look up an element at a certain index (since version 0.4.8).
     Seq.lookup 2 nums
     > Just 3
 

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -594,7 +594,7 @@ member !k = go
 notMember :: Key -> IntMap a -> Bool
 notMember k m = not $ member k m
 
--- | \(O(\min(n,W))\). Lookup the value at a key in the map. See also 'Data.Map.lookup'.
+-- | \(O(\min(n,W))\). Look up the value at a key in the map. See also 'Data.Map.lookup'.
 
 -- See Note: Local 'go' functions and capturing
 lookup :: Key -> IntMap a -> Maybe a
@@ -985,7 +985,7 @@ updateWithKey f k t@(Tip ky y)
   | otherwise     = t
 updateWithKey _ _ Nil = Nil
 
--- | \(O(\min(n,W))\). Lookup and update.
+-- | \(O(\min(n,W))\). Look up and update.
 -- The function returns original value, if it is updated.
 -- This is different behavior than 'Data.Map.updateLookupWithKey'.
 -- Returns the original key value if the map entry is deleted.

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -986,7 +986,7 @@ updateWithKey f k t@(Tip ky y)
 updateWithKey _ _ Nil = Nil
 
 -- | \(O(\min(n,W))\). Look up and update.
--- The function returns original value, if it is updated.
+-- This function returns the original value, if it is updated.
 -- This is different behavior than 'Data.Map.updateLookupWithKey'.
 -- Returns the original key value if the map entry is deleted.
 --

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -534,7 +534,7 @@ updateWithKey f !k t =
       | otherwise     -> t
     Nil -> Nil
 
--- | \(O(\min(n,W))\). Lookup and update.
+-- | \(O(\min(n,W))\). Look up and update.
 -- The function returns original value, if it is updated.
 -- This is different behavior than 'Data.Map.updateLookupWithKey'.
 -- Returns the original key value if the map entry is deleted.

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -1116,7 +1116,7 @@ updateWithKey = go
 #endif
 
 -- | \(O(\log n)\). Look up and update. See also 'updateWithKey'.
--- The function returns changed value, if it is updated.
+-- This function returns the changed value, if it is updated.
 -- Returns the original key value if the map entry is deleted.
 --
 -- > let f k x = if x == "a" then Just ((show k) ++ ":new a") else Nothing

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -545,7 +545,7 @@ size (Bin sz _ _ _ _) = sz
 {-# INLINE size #-}
 
 
--- | \(O(\log n)\). Lookup the value at a key in the map.
+-- | \(O(\log n)\). Look up the value at a key in the map.
 --
 -- The function will return the corresponding value as @('Just' value)@,
 -- or 'Nothing' if the key isn't in the map.
@@ -1115,7 +1115,7 @@ updateWithKey = go
 {-# INLINE updateWithKey #-}
 #endif
 
--- | \(O(\log n)\). Lookup and update. See also 'updateWithKey'.
+-- | \(O(\log n)\). Look up and update. See also 'updateWithKey'.
 -- The function returns changed value, if it is updated.
 -- Returns the original key value if the map entry is deleted.
 --
@@ -1470,7 +1470,7 @@ findIndex = go 0
 {-# INLINABLE findIndex #-}
 #endif
 
--- | \(O(\log n)\). Lookup the /index/ of a key, which is its zero-based index in
+-- | \(O(\log n)\). Look up the /index/ of a key, which is its zero-based index in
 -- the sequence sorted by keys. The index is a number from /0/ up to, but not
 -- including, the 'size' of the map.
 --

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -739,7 +739,7 @@ updateWithKey = go
 {-# INLINE updateWithKey #-}
 #endif
 
--- | \(O(\log n)\). Lookup and update. See also 'updateWithKey'.
+-- | \(O(\log n)\). Look up and update. See also 'updateWithKey'.
 -- The function returns changed value, if it is updated.
 -- Returns the original key value if the map entry is deleted.
 --

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -740,7 +740,7 @@ updateWithKey = go
 #endif
 
 -- | \(O(\log n)\). Look up and update. See also 'updateWithKey'.
--- The function returns changed value, if it is updated.
+-- This function returns the changed value, if it is updated.
 -- Returns the original key value if the map entry is deleted.
 --
 -- > let f k x = if x == "a" then Just ((show k) ++ ":new a") else Nothing

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1477,7 +1477,7 @@ findIndex = go 0
 {-# INLINABLE findIndex #-}
 #endif
 
--- | \(O(\log n)\). Lookup the /index/ of an element, which is its zero-based index in
+-- | \(O(\log n)\). Look up the /index/ of an element, which is its zero-based index in
 -- the sorted sequence of elements. The index is a number from /0/ up to, but not
 -- including, the 'size' of the set.
 --


### PR DESCRIPTION
This PR makes a few small grammar fixes within documentation and comments.

In particular, it:
- replaces some instances of the word "lookup" with "look up" when used as a verb;
- inserts the word "the" in places where it is obviously missing;
- changes some instances of "the function" to "this function".