### PR TITLE
Don't export State from Sequence.Internal

### DIFF
--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -87,8 +87,6 @@ module Data.Sequence.Internal (
 #else
     Seq (..),
 #endif
-    State(..),
-    execState,
     foldDigit,
     foldNode,
     foldWithIndexDigit,


### PR DESCRIPTION
There is no reason to export it.

It seems to have been done accidentally (https://github.com/haskell/containers/pull/500#pullrequestreview-90350740).

---

Currently this `State` is the top result for https://hoogle.haskell.org/?hoogle=State. This was confusing for someone who wanted to look up `State`, which is how I became aware of the export.