### PR TITLE
Remove unnecessary return definitions

### DIFF
--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -587,8 +587,6 @@ newtype SetM s a = SetM { runSetM :: STArray  s Vertex Bool -> ST s a }
 #endif
 
 instance Monad (SetM s) where
-    return = pure
-    {-# INLINE return #-}
     SetM v >>= f = SetM $ \s -> do { x <- v s; runSetM (f x) s }
     {-# INLINE (>>=) #-}
 
@@ -621,7 +619,6 @@ include v     = SetM $ \ m -> writeArray m v True
 newtype SetM s a = SetM { runSetM :: IntSet -> (a, IntSet) }
 
 instance Monad (SetM s) where
-    return x     = SetM $ \s -> (x, s)
     SetM v >>= f = SetM $ \s -> case v s of (x, s') -> runSetM (f x) s'
 
 instance Functor (SetM s) where

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -521,7 +521,6 @@ instance NFData1 Seq where
     liftRnf rnfx (Seq xs) = liftRnf (liftRnf rnfx) xs
 
 instance Monad Seq where
-    return = pure
     xs >>= f = foldl' add empty xs
       where add ys x = ys >< f x
     (>>) = (*>)

--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -171,7 +171,6 @@ instance Applicative Tree where
         Node y (tys ++ map (*> ty) txs)
 
 instance Monad Tree where
-    return = pure
     Node x ts >>= f = case f x of
         Node x' ts' -> Node x' (ts' ++ map (>>= f) ts)
 

--- a/containers/src/Utils/Containers/Internal/State.hs
+++ b/containers/src/Utils/Containers/Internal/State.hs
@@ -16,9 +16,7 @@ instance Functor (State s) where
     fmap = liftA
 
 instance Monad (State s) where
-    {-# INLINE return #-}
     {-# INLINE (>>=) #-}
-    return = pure
     m >>= k = State $ \ s -> case runState m s of
         (s', x) -> runState (k x) s'
 


### PR DESCRIPTION
The default return=pure works and we are long past the Functor-Applicative-Monad Proposal.