### PR TITLE
Modernize the cabal file

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -31,7 +31,7 @@ tested-with:
 
 source-repository head
   type:     git
-  location: http://github.com/haskell/containers.git
+  location: https://github.com/haskell/containers
 
 common deps
   build-depends:

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -1,8 +1,10 @@
+cabal-version: 2.2
 name: containers
 version: 0.7
-license: BSD3
+license: BSD-3-Clause
 license-file: LICENSE
 maintainer: libraries@haskell.org
+homepage: https://github.com/haskell/containers
 bug-reports: https://github.com/haskell/containers/issues
 synopsis: Assorted concrete container types
 category: Data Structures
@@ -20,10 +22,10 @@ description:
     remains valid even if structures are shared.
 
 build-type: Simple
-cabal-version:  >=1.10
+extra-doc-files:
+    changelog.md
 extra-source-files:
     include/containers.h
-    changelog.md
     mkappend.hs
 
 tested-with:
@@ -32,7 +34,7 @@ tested-with:
 
 source-repository head
     type:     git
-    location: http://github.com/haskell/containers.git
+    location: https://github.com/haskell/containers
 
 Library
     default-language: Haskell2010
@@ -40,7 +42,7 @@ Library
     if impl(ghc)
        build-depends: template-haskell
     hs-source-dirs: src
-    ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+    ghc-options: -O2 -Wall
 
     other-extensions: CPP, BangPatterns
 


### PR DESCRIPTION
* Set cabal-version to 2.2
* Set license to the right SPDX identifier
* Drop old -fwarn flags which are included in -Wall (since GHC 9.2)
* Move changelog.md to extra-doc-files
* Add homepage
* Tweak source repo location