### PR TITLE
Don't expose internal util modules

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -72,6 +72,12 @@
 
 * Improved performance for `IntSet` and `IntMap`'s `Ord` instances.
 
+### Miscellaneous/internal
+
+* Internal modules `Utils.Containers.Internal.BitUtil`,
+  `Utils.Containers.Internal.BitQueue`, `Utils.Containers.Internal.StrictPair`
+  are no longer exposed.
+
 ## Unreleased with `@since` annotation for 0.7.1:
 
 ### Additions

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -74,9 +74,6 @@ Library
         Data.Sequence.Internal
         Data.Sequence.Internal.Sorting
         Data.Tree
-        Utils.Containers.Internal.BitUtil
-        Utils.Containers.Internal.BitQueue
-        Utils.Containers.Internal.StrictPair
 
     other-modules:
         Utils.Containers.Internal.Prelude
@@ -84,6 +81,9 @@ Library
         Utils.Containers.Internal.StrictMaybe
         Utils.Containers.Internal.PtrEquality
         Utils.Containers.Internal.EqOrdUtil
+        Utils.Containers.Internal.BitUtil
+        Utils.Containers.Internal.BitQueue
+        Utils.Containers.Internal.StrictPair
     if impl(ghc)
       other-modules:
         Utils.Containers.Internal.TypeError


### PR DESCRIPTION
We don't have a good enough reason to expose these modules. They do not offer internals of containers (Set, Map, etc.) and are not required to use other exposed internals.

Closes #1096