### PR TITLE
Copy IntMap notes to IntMap.{Lazy.Strict} and IntSet

### DIFF
--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -25,6 +25,9 @@
 -- >  import Data.IntMap (IntMap)
 -- >  import qualified Data.IntMap as IntMap
 --
+--
+-- == Implementation
+--
 -- The implementation is based on /big-endian patricia trees/.  This data
 -- structure performs especially well on binary operations like 'union'
 -- and 'intersection'. Additionally, benchmarks show that it is also
@@ -40,6 +43,9 @@
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
 --      Journal of the ACM, 15(4), October 1968, pages 514-534,
 --      <https://doi.org/10.1145/321479.321481>.
+--
+--
+-- == Performance information
 --
 -- Operation comments contain the operation time complexity in
 -- the Big-O notation <http://en.wikipedia.org/wiki/Big_O_notation>.

--- a/containers/src/Data/IntMap.hs
+++ b/containers/src/Data/IntMap.hs
@@ -48,7 +48,9 @@
 -- == Performance information
 --
 -- Operation comments contain the operation time complexity in
--- the Big-O notation <http://en.wikipedia.org/wiki/Big_O_notation>.
+-- [big-O notation](http://en.wikipedia.org/wiki/Big_O_notation), with \(n\)
+-- referring to the number of entries in the map and \(W\) referring to the
+-- number of bits in an 'Int' (32 or 64).
 --
 -- Many operations have a worst-case complexity of \(O(\min(n,W))\).
 -- This means that the operation can become linear in the number of

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -38,16 +38,6 @@
 -- prefer the values in the first argument to those in the second.
 --
 --
--- == Detailed performance information
---
--- The running time is given for each operation, with \(n\) referring to
--- the number of entries in the map and \(W\) referring to the number of bits in
--- an 'Int' (32 or 64).
---
--- Benchmarks comparing "Data.IntMap.Lazy" with other dictionary
--- implementations can be found at https://github.com/haskell-perf/dictionaries.
---
---
 -- == Implementation
 --
 -- The implementation is based on /big-endian patricia trees/.  This data
@@ -65,6 +55,39 @@
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
 --      Journal of the ACM, 15(4), October 1968, pages 514-534,
 --      <https://doi.org/10.1145/321479.321481>.
+--
+--
+-- == Performance information
+--
+-- Operation comments contain the operation time complexity in the Big-O
+-- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
+-- to the number of entries in the map and \(W\) referring to the number of bits
+-- in an 'Int' (32 or 64).
+--
+-- Many operations have a worst-case complexity of \(O(\min(n,W))\).
+-- This means that the operation can become linear in the number of
+-- elements with a maximum of \(W\) -- the number of bits in an 'Int'
+-- (32 or 64). These peculiar asymptotics are determined by the depth
+-- of the Patricia trees:
+--
+-- * even for an extremely unbalanced tree, the depth cannot be larger than
+--   the number of elements \(n\),
+-- * each level of a Patricia tree determines at least one more bit
+--   shared by all subelements, so there could not be more
+--   than \(W\) levels.
+--
+-- If all \(n\) keys in the tree are between 0 and \(N\) (or, say, between
+-- \(-N\) and \(N\)), the estimate can be refined to \(O(\min(n, \log N))\). If
+-- the set of keys is sufficiently "dense", this becomes \(O(\min(n, \log n))\)
+-- or simply the familiar \(O(\log n)\), matching balanced binary trees.
+--
+-- The most performant scenario for 'IntMap' are keys from a contiguous subset,
+-- in which case the complexity is proportional to \(\log n\), capped by \(W\).
+-- The worst scenario are exponentially growing keys \(1,2,4,\ldots,2^n\),
+-- for which complexity grows as fast as \(n\) but again is capped by \(W\).
+--
+-- Benchmarks comparing "Data.IntMap.Lazy" with other dictionary
+-- implementations can be found at https://github.com/haskell-perf/dictionaries.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -59,10 +59,10 @@
 --
 -- == Performance information
 --
--- Operation comments contain the operation time complexity in the Big-O
--- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
--- to the number of entries in the map and \(W\) referring to the number of bits
--- in an 'Int' (32 or 64).
+-- Operation comments contain the operation time complexity in
+-- [big-O notation](http://en.wikipedia.org/wiki/Big_O_notation), with \(n\)
+-- referring to the number of entries in the map and \(W\) referring to the
+-- number of bits in an 'Int' (32 or 64).
 --
 -- Many operations have a worst-case complexity of \(O(\min(n,W))\).
 -- This means that the operation can become linear in the number of

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -75,10 +75,10 @@
 --
 -- == Performance information
 --
--- Operation comments contain the operation time complexity in the Big-O
--- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
--- to the number of entries in the map and \(W\) referring to the number of bits
--- in an 'Int' (32 or 64).
+-- Operation comments contain the operation time complexity in
+-- [big-O notation](http://en.wikipedia.org/wiki/Big_O_notation), with \(n\)
+-- referring to the number of entries in the map and \(W\) referring to the
+-- number of bits in an 'Int' (32 or 64).
 --
 -- Many operations have a worst-case complexity of \(O(\min(n,W))\).
 -- This means that the operation can become linear in the number of

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -45,16 +45,6 @@
 -- prefer the values in the first argument to those in the second.
 --
 --
--- == Detailed performance information
---
--- The running time is given for each operation, with \(n\) referring to
--- the number of entries in the map and \(W\) referring to the number of bits in
--- an 'Int' (32 or 64).
---
--- Benchmarks comparing "Data.IntMap.Strict" with other dictionary
--- implementations can be found at https://github.com/haskell-perf/dictionaries.
---
---
 -- == Warning
 --
 -- The 'IntMap' type is shared between the lazy and strict modules, meaning that
@@ -81,6 +71,39 @@
 --      \"/PATRICIA -- Practical Algorithm To Retrieve Information Coded In Alphanumeric/\",
 --      Journal of the ACM, 15(4), October 1968, pages 514-534,
 --      <https://doi.org/10.1145/321479.321481>.
+--
+--
+-- == Performance information
+--
+-- Operation comments contain the operation time complexity in the Big-O
+-- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
+-- to the number of entries in the map and \(W\) referring to the number of bits
+-- in an 'Int' (32 or 64).
+--
+-- Many operations have a worst-case complexity of \(O(\min(n,W))\).
+-- This means that the operation can become linear in the number of
+-- elements with a maximum of \(W\) -- the number of bits in an 'Int'
+-- (32 or 64). These peculiar asymptotics are determined by the depth
+-- of the Patricia trees:
+--
+-- * even for an extremely unbalanced tree, the depth cannot be larger than
+--   the number of elements \(n\),
+-- * each level of a Patricia tree determines at least one more bit
+--   shared by all subelements, so there could not be more
+--   than \(W\) levels.
+--
+-- If all \(n\) keys in the tree are between 0 and \(N\) (or, say, between
+-- \(-N\) and \(N\)), the estimate can be refined to \(O(\min(n, \log N))\). If
+-- the set of keys is sufficiently "dense", this becomes \(O(\min(n, \log n))\)
+-- or simply the familiar \(O(\log n)\), matching balanced binary trees.
+--
+-- The most performant scenario for 'IntMap' are keys from a contiguous subset,
+-- in which case the complexity is proportional to \(\log n\), capped by \(W\).
+-- The worst scenario are exponentially growing keys \(1,2,4,\ldots,2^n\),
+-- for which complexity grows as fast as \(n\) but again is capped by \(W\).
+--
+-- Benchmarks comparing "Data.IntMap.Strict" with other dictionary
+-- implementations can be found at https://github.com/haskell-perf/dictionaries.
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -15,8 +15,20 @@
 -- Maintainer  :  libraries@haskell.org
 -- Portability :  portable
 --
+-- = WARNING
 --
--- = Finite Int Maps (strict interface)
+-- This module is considered __internal__.
+--
+-- The Package Versioning Policy __does not apply__.
+--
+-- The contents of this module may change __in any way whatsoever__
+-- and __without any warning__ between minor versions of this package.
+--
+-- Authors importing this module are expected to track development
+-- closely.
+--
+--
+-- = Description
 --
 -- The @'IntMap' v@ type represents a finite map (sometimes called a dictionary)
 -- from key of type @Int@ to values of type @v@.
@@ -44,16 +56,6 @@
 -- Note that the implementation is generally /left-biased/. Functions that take
 -- two maps as arguments and combine them, such as `union` and `intersection`,
 -- prefer the values in the first argument to those in the second.
---
---
--- == Detailed performance information
---
--- The running time is given for each operation, with \(n\) referring to
--- the number of entries in the map and \(W\) referring to the number of bits in
--- an 'Int' (32 or 64).
---
--- Benchmarks comparing "Data.IntMap.Strict" with other dictionary
--- implementations can be found at https://github.com/haskell-perf/dictionaries.
 --
 --
 -- == Warning

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -57,10 +57,10 @@
 --
 -- == Performance information
 --
--- Operation comments contain the operation time complexity in the Big-O
--- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
--- to the number of entries in the map and \(W\) referring to the number of bits
--- in an 'Int' (32 or 64).
+-- Operation comments contain the operation time complexity in
+-- [big-O notation](http://en.wikipedia.org/wiki/Big_O_notation), with \(n\)
+-- referring to the number of entries in the map and \(W\) referring to the
+-- number of bits in an 'Int' (32 or 64).
 --
 -- Many operations have a worst-case complexity of \(O(\min(n,W))\).
 -- This means that the operation can become linear in the number of

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -30,14 +30,6 @@
 -- >  import qualified Data.IntSet as IntSet
 --
 --
--- == Performance information
---
--- Many operations have a worst-case complexity of \(O(\min(n,W))\).
--- This means that the operation can become linear in the number of
--- elements with a maximum of \(W\) -- the number of bits in an 'Int'
--- (32 or 64).
---
---
 -- == Implementation
 --
 -- The implementation is based on /big-endian patricia trees/.  This data
@@ -61,6 +53,36 @@
 -- reduces the memory footprint and execution times for dense sets, e.g. sets
 -- where it is likely that many values lie close to each other. The asymptotics
 -- are not affected by this optimization.
+--
+--
+-- == Performance information
+--
+-- Operation comments contain the operation time complexity in the Big-O
+-- notation <http://en.wikipedia.org/wiki/Big_O_notation>, with \(n\) referring
+-- to the number of entries in the map and \(W\) referring to the number of bits
+-- in an 'Int' (32 or 64).
+--
+-- Many operations have a worst-case complexity of \(O(\min(n,W))\).
+-- This means that the operation can become linear in the number of
+-- elements with a maximum of \(W\) -- the number of bits in an 'Int'
+-- (32 or 64). These peculiar asymptotics are determined by the depth
+-- of the Patricia trees:
+--
+-- * even for an extremely unbalanced tree, the depth cannot be larger than
+--   the number of elements \(n\),
+-- * each level of a Patricia tree determines at least one more bit
+--   shared by all subelements, so there could not be more
+--   than \(W\) levels.
+--
+-- If all \(n\) elements in the tree are between 0 and \(N\) (or, say, between
+-- \(-N\) and \(N\)), the estimate can be refined to \(O(\min(n, \log N))\). If
+-- the set is sufficiently "dense", this becomes \(O(\min(n, \log n))\) or
+-- simply the familiar \(O(\log n)\), matching balanced binary trees.
+--
+-- The most performant scenario for 'IntSet' are keys from a contiguous subset,
+-- in which case the complexity is proportional to \(\log n\), capped by \(W\).
+-- The worst scenario are exponentially growing elements \(1,2,4,\ldots,2^n\),
+-- for which complexity grows as fast as \(n\) but again is capped by \(W\).
 --
 -----------------------------------------------------------------------------
 

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -44,6 +44,9 @@
 -- >  import Data.IntSet (IntSet)
 -- >  import qualified Data.IntSet as IntSet
 --
+--
+-- == Implementation
+--
 -- The implementation is based on /big-endian patricia trees/.  This data
 -- structure performs especially well on binary operations like 'union'
 -- and 'intersection'.  However, my benchmarks show that it is also
@@ -62,11 +65,6 @@
 -- reduce memory footprint and execution times for dense sets, e.g. sets where
 -- it is likely that many values lie close to each other. The asymptotics are
 -- not affected by this optimization.
---
--- Many operations have a worst-case complexity of \(O(\min(n,W))\).
--- This means that the operation can become linear in the number of
--- elements with a maximum of \(W\) -- the number of bits in an 'Int'
--- (32 or 64).
 --
 -- @since 0.5.9
 -----------------------------------------------------------------------------


### PR DESCRIPTION
These were added in 8f6ef9a and are relevant in these other modules too. Also add the missing internal module warning to IntMap.Strict.Internal.