### PR TITLE
Export Key from IntMap.Internal, IntSet.Internal

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -67,6 +67,7 @@
 module Data.IntMap.Internal (
     -- * Map type
       IntMap(..)          -- instance Eq,Show
+    , Key
 
     -- * Operators
     , (!), (!?), (\\)

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -237,5 +237,4 @@ module Data.IntMap.Lazy (
     , maxViewWithKey
     ) where
 
-import Data.IntSet.Internal.IntTreeCommons (Key)
 import Data.IntMap.Internal as IM

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -160,5 +160,4 @@ module Data.IntSet (
             , showTreeWith
             ) where
 
-import Data.IntSet.Internal.IntTreeCommons (Key)
 import Data.IntSet.Internal as IS

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -92,6 +92,7 @@
 module Data.IntSet.Internal (
     -- * Set type
       IntSet(..) -- instance Eq,Show
+    , Key
     , BitMap
 
     -- * Operators


### PR DESCRIPTION
These two exports were removed in 8562003 but there is no strong reason to do so. They remain exported from IntMap.Strict.Internal and the non-internal modules.

See https://github.com/haskell/containers/issues/1059#issuecomment-2676425222