### PR TITLE
Bump deepseq to >=1.4.3.0

### DIFF
--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -38,7 +38,10 @@ source-repository head
 
 Library
     default-language: Haskell2010
-    build-depends: base >= 4.10 && < 5, array >= 0.4.0.0, deepseq >= 1.2 && < 1.6
+    build-depends:
+        base >= 4.10 && < 5
+      , array >= 0.4.0.0
+      , deepseq >= 1.4.3.0 && < 1.6
     if impl(ghc)
        build-depends: template-haskell
     hs-source-dirs: src


### PR DESCRIPTION
deepseq-1.4.3.0 adds NFData1 and NFData2 which we define instances for.

See https://github.com/haskell/containers/issues/1059#issuecomment-2692904615