### PR TITLE
Improve Int{Map,Set} construction from asc lists 

### DIFF
--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -46,7 +46,8 @@ main = do
         , bench "mapMaybeWithKey" $ whnf (M.mapMaybeWithKey (const maybeDel)) m
         , bench "fromList" $ whnf M.fromList elems
         , bench "fromAscList" $ whnf M.fromAscList elems
-        , bench "fromDistinctAscList" $ whnf M.fromDistinctAscList elems
+        , bench "fromAscList:fusion" $
+            whnf (\n -> M.fromAscList [(i,()) | i <- [1..n]]) bound
         , bench "minView" $ whnf (maybe 0 (\((k,v), m) -> k+v+M.size m) . M.minViewWithKey)
                     (M.fromList $ zip [1..10] [1..10])
         , bench "spanAntitone" $ whnf (M.spanAntitone (<key_mid)) m
@@ -61,17 +62,18 @@ main = do
   where
     elems = elems_hits
     elems_hits   = zip keys values
-    elems_mid    = zip (map (+ (2^12 `div` 2)) keys) values
-    elems_most   = zip (map (+ (2^12 `div` 10)) keys) values
+    elems_mid    = zip (map (+ (bound `div` 2)) keys) values
+    elems_most   = zip (map (+ (bound `div` 10)) keys) values
     elems_misses = zip (map (\x-> x * 2 + 1) keys) values
     elems_mixed = zip mixedKeys values
     --------------------------------------------------------
-    keys = [1..2^12]
+    bound = 2^12
+    keys = [1..bound]
     keys' = fmap (+ 1000000) keys
-    keys'' = fmap (* 2) [1..2^12]
+    keys'' = fmap (* 2) [1..bound]
     mixedKeys = interleave keys keys'
-    values = [1..2^12]
-    key_mid = 2^11
+    values = [1..bound]
+    key_mid = bound `div` 2
     --------------------------------------------------------
     sum k v1 v2 = k + v1 + v2
     consPair k v xs = (k, v) : xs

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -46,7 +46,6 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_difference" prop_difference
                    , testProperty "prop_intersection" prop_intersection
                    , testProperty "prop_symmetricDifference" prop_symmetricDifference
-                   , testProperty "prop_Ordered" prop_Ordered
                    , testProperty "prop_List" prop_List
                    , testProperty "prop_DescList" prop_DescList
                    , testProperty "prop_AscDescList" prop_AscDescList
@@ -90,6 +89,8 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "delete" prop_delete
                    , testProperty "deleteMin" prop_deleteMin
                    , testProperty "deleteMax" prop_deleteMax
+                   , testProperty "fromAscList" prop_fromAscList
+                   , testProperty "fromDistinctAscList" prop_fromDistinctAscList
                    ]
 
 ----------------------------------------------------------------
@@ -281,10 +282,6 @@ prop_disjoint a b = a `disjoint` b == null (a `intersection` b)
 {--------------------------------------------------------------------
   Lists
 --------------------------------------------------------------------}
-prop_Ordered
-  = forAll (choose (5,100)) $ \n ->
-    let xs = concat [[i-n,i-n]|i<-[0..2*n :: Int]]
-    in fromAscList xs == fromList xs
 
 prop_List :: [Int] -> Bool
 prop_List xs
@@ -521,3 +518,20 @@ prop_deleteMin s = toList (deleteMin s) === if null s then [] else tail (toList 
 
 prop_deleteMax :: IntSet -> Property
 prop_deleteMax s = toList (deleteMax s) === if null s then [] else init (toList s)
+
+prop_fromAscList :: [Int] -> Property
+prop_fromAscList xs =
+    valid t .&&.
+    toList t === nubSortedXs
+  where
+    sortedXs = sort xs
+    nubSortedXs = List.map NE.head $ NE.group sortedXs
+    t = fromAscList sortedXs
+
+prop_fromDistinctAscList :: [Int] -> Property
+prop_fromDistinctAscList xs =
+    valid t .&&.
+    toList t === nubSortedXs
+  where
+    nubSortedXs = List.map NE.head $ NE.group $ sort xs
+    t = fromDistinctAscList nubSortedXs


### PR DESCRIPTION
* Switch to an explicit stack based approach, like we had before 77c8e5f, and like we have for Set and Map today.
* This is a little faster (-13%) on in-memory lists, but much faster (-43%) when list fusion applies because we are now a good consumer. For a dense IntSet in the fusion case it is greatly faster (-81%).
* Avoid a case of undefined behavior in IntMap.fromDistinctAscList due to calling branchMask on equal keys if the caller did not follow the distinct precondition.
* Add property tests for the functions

Closes #951

---

Benchmarks on GHC 9.10.1:

IntSet:

```
Name                         Time - - - - - - - -    Allocated - - - - -
                                  A       B     %         A       B     %
fromAscList                   16 μs   17 μs   +0%    3.6 KB  5.6 KB  +56%
fromAscList:fusion            25 μs  4.7 μs  -81%    292 KB  5.5 KB  -98%
fromAscList:sparse            44 μs   38 μs  -13%    224 KB  352 KB  +57%
fromAscList:sparse:fusion     63 μs   35 μs  -43%    512 KB  352 KB  -31%
```

IntMap:

```
Name                  Time - - - - - - - -    Allocated - - - - -
                           A       B     %         A       B     %
fromAscList            47 μs   39 μs  -17%    224 KB  352 KB  +57%
fromAscList:fusion     65 μs   31 μs  -52%    608 KB  352 KB  -42%
```
