### PR TITLE
Document deduplication policy for `Set`.

### DIFF
--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -998,6 +998,9 @@ partition p0 t0 = toPair $ go p0 t0
 --
 -- It's worth noting that the size of the result may be smaller if,
 -- for some @(x,y)@, @x \/= y && f x == f y@
+--
+-- If the function produces duplicate values, only one will be retained. No
+-- guarantee is made as to which.
 
 map :: Ord b => (a->b) -> Set a -> Set b
 map f t = finishB (foldl' (\b x -> insertB (f x) b) emptyB t)
@@ -1146,6 +1149,9 @@ foldlFB = foldl
 --
 -- If the elements are in non-decreasing order, this function takes \(O(n)\)
 -- time.
+--
+-- If the list contains duplicate elements, only one will be retained. No
+-- guarantee is made as to which.
 fromList :: Ord a => [a] -> Set a
 fromList xs = finishB (Foldable.foldl' (flip insertB) emptyB xs)
 {-# INLINE fromList #-}  -- INLINE for fusion
@@ -1157,6 +1163,9 @@ fromList xs = finishB (Foldable.foldl' (flip insertB) emptyB xs)
     fromAscList xs == fromList xs
 --------------------------------------------------------------------}
 -- | \(O(n)\). Build a set from an ascending list in linear time.
+--
+-- If the list contains duplicate elements, only one will be retained. No
+-- guarantee is made as to which.
 --
 -- __Warning__: This function should be used only if the elements are in
 -- non-decreasing order. This precondition is not checked. Use 'fromList' if the
@@ -1173,6 +1182,9 @@ fromAscList xs = ascLinkAll (Foldable.foldl' next Nada xs)
 {-# INLINE fromAscList #-}  -- INLINE for fusion
 
 -- | \(O(n)\). Build a set from a descending list in linear time.
+--
+-- If the list contains duplicate elements, only one will be retained. No
+-- guarantee is made as to which.
 --
 -- __Warning__: This function should be used only if the elements are in
 -- non-increasing order. This precondition is not checked. Use 'fromList' if the


### PR DESCRIPTION
Related Issue: #1118

This PR documents the policy for removing duplicate elements in the following functions of `Set`:
- `fromList`
- `fromAscList`
- `fromDescList`
- `map`