### PR TITLE
Inline Int{Map,Set}.fromList* for list fusion

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -140,7 +140,8 @@ benchmark intmap-benchmarks
     Utils.Fold
 
   build-depends:
-    transformers
+      transformers
+    , random >=1.0 && <1.3
 
 benchmark intset-benchmarks
   import: benchmark-deps, warnings
@@ -154,7 +155,8 @@ benchmark intset-benchmarks
     Utils.Fold
 
   build-depends:
-    transformers
+      transformers
+    , random >=1.0 && <1.3
 
 benchmark map-benchmarks
   import: benchmark-deps, warnings

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -252,6 +252,8 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "fromAscListWith"      prop_fromAscListWith
              , testProperty "fromAscListWithKey"   prop_fromAscListWithKey
              , testProperty "fromDistinctAscList"  prop_fromDistinctAscList
+             , testProperty "fromListWith"         prop_fromListWith
+             , testProperty "fromListWithKey"      prop_fromListWithKey
              ]
 
 {--------------------------------------------------------------------
@@ -2017,3 +2019,17 @@ prop_fromDistinctAscList kxs =
       NE.groupBy ((==) `on` fst) $
       List.sortBy (comparing fst) kxs
     t = fromDistinctAscList nubSortedKxs
+
+prop_fromListWith :: Fun (A, A) A -> [(Int, A)] -> Property
+prop_fromListWith f kxs =
+  valid m .&&.
+  m === List.foldl' (\m' (k,x) -> insertWith (applyFun2 f) k x m') empty kxs
+  where
+    m = fromListWith (applyFun2 f) kxs
+
+prop_fromListWithKey :: Fun (Int, A, A) A -> [(Int, A)] -> Property
+prop_fromListWithKey f kxs =
+  valid m .&&.
+  m === List.foldl' (\m' (k,x) -> insertWith (applyFun3 f k) k x m') empty kxs
+  where
+    m = fromListWithKey (applyFun3 f) kxs

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -3322,6 +3322,7 @@ fromList xs
   = Foldable.foldl' ins empty xs
   where
     ins t (k,x)  = insert k x t
+{-# INLINE fromList #-} -- Inline for list fusion
 
 -- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
 --
@@ -3362,6 +3363,7 @@ fromList xs
 fromListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromListWith f xs
   = fromListWithKey (\_ x y -> f x y) xs
+{-# INLINE fromListWith #-} -- Inline for list fusion
 
 -- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also fromAscListWithKey'.
 --
@@ -3376,6 +3378,7 @@ fromListWithKey f xs
   = Foldable.foldl' ins empty xs
   where
     ins t (k,x) = insertWithKey f k x t
+{-# INLINE fromListWithKey #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
 -- the keys are in ascending order.

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -1056,6 +1056,7 @@ fromList xs
   = Foldable.foldl' ins empty xs
   where
     ins t (k,x)  = insert k x t
+{-# INLINE fromList #-} -- Inline for list fusion
 
 -- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWith'.
 --
@@ -1096,6 +1097,7 @@ fromList xs
 fromListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromListWith f xs
   = fromListWithKey (\_ x y -> f x y) xs
+{-# INLINE fromListWith #-} -- Inline for list fusion
 
 -- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also fromAscListWithKey'.
 --
@@ -1110,6 +1112,7 @@ fromListWithKey f xs
   = Foldable.foldl' ins empty xs
   where
     ins t (k,x) = insertWithKey f k x t
+{-# INLINE fromListWithKey #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
 -- the keys are in ascending order.

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1345,6 +1345,7 @@ fromList xs
   = Foldable.foldl' ins empty xs
   where
     ins t x  = insert x t
+{-# INLINE fromList #-} -- Inline for list fusion
 
 -- | \(O(n / W)\). Create a set from a range of integers.
 --


### PR DESCRIPTION
Also add benchmarks and property tests.

Fixes #288, fixes #842.

This will be the baseline for #1128, I have an implementation in progress.

---

Benchmarks on GHC 9.10.1:

IntSet:

```
Name                          Time - - - - - - - -    Allocated - - - - -
                                   A       B     %         A       B     %
fromList:asc                   45 μs   45 μs   +0%    480 KB  480 KB   +0%
fromList:asc:fusion            56 μs   39 μs  -30%    768 KB  480 KB  -37%
fromList:asc:sparse            94 μs   92 μs   -2%    864 KB  864 KB   +0%
fromList:asc:sparse:fusion    106 μs   84 μs  -20%    1.1 MB  864 KB  -24%
fromList:random               458 μs  463 μs   +1%    1.5 MB  1.5 MB   +0%
fromList:random:fusion        484 μs  448 μs   -7%    1.8 MB  1.5 MB  -17%
```

IntMap:

```
Name                              Time - - - - - - - -    Allocated - - - - -
                                       A       B     %         A       B     %
fromList:asc                      100 μs   97 μs   -3%    864 KB  864 KB   +0%
fromList:asc:fusion               117 μs   88 μs  -24%    1.2 MB  864 KB  -30%
fromList:random                   471 μs  464 μs   -1%    1.5 MB  1.5 MB   +0%
fromList:random:fusion            497 μs  444 μs  -10%    1.9 MB  1.5 MB  -21%
fromListWith:randomDups           320 μs  312 μs   -2%    1.3 MB  1.3 MB   +0%
fromListWith:randomDups:fusion    338 μs  319 μs   -5%    1.7 MB  1.3 MB  -24%
```