### PR TITLE
Improve IntMap's restrictKeys and withoutKeys

### DIFF
--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`containers` package](http://github.com/haskell/containers)
 
+## Next release
+
+### Performance improvements
+
+* Improved performance for `Data.IntMap.restrictKeys` and
+  `Data.IntMap.withoutKeys`. (Soumik Sarkar)
+  ([#1131](https://github.com/haskell/containers/pull/1131))
+
 ## 0.8  *March 2025*
 
 ### Breaking changes

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -183,6 +183,8 @@ module Data.IntSet.Internal (
     -- * Internals
     , suffixBitMask
     , prefixBitMask
+    , prefixOf
+    , suffixOf
     , bitmapOf
     ) where
 


### PR DESCRIPTION
* Properly implement the early return optimization
* No need to have a separate withoutBM
* Remove the unnecessary closure in withoutKeys
* Add some benchmarks

Benchmarks improve by 98% in the dense case which benefits maximally from early return. For the random case, withoutKeys improves by 14% and restrictKeys improves by 20%.

Closes #1130.

---

Benchmarks with GHC 9.10.1

```
Name                   Time - - - - - - - -    Allocated - - - - -
                            A       B     %         A       B     %
restrictKeys            49 μs  795 ns  -98%    229 KB  4.2 KB  -98%
restrictKeys:random     41 μs   33 μs  -20%     43 KB  6.3 KB  -85%
withoutKeys             21 μs  530 ns  -97%    100 KB   32 B   -99%
withoutKeys:random      55 μs   47 μs  -14%    128 KB  110 KB  -14%
```