### PR TITLE
Improve fromList for IntSet and IntMap 

### DIFF
--- a/containers-tests/benchmarks/IntMap.hs
+++ b/containers-tests/benchmarks/IntMap.hs
@@ -9,7 +9,8 @@ import qualified Data.IntMap as M
 import qualified Data.IntMap.Strict as MS
 import qualified Data.IntSet as S
 import Data.Maybe (fromMaybe)
-import System.Random (StdGen, mkStdGen, randoms, randomRs)
+import Data.Word (Word8)
+import System.Random (StdGen, mkStdGen, randoms)
 import Prelude hiding (lookup)
 
 import Utils.Fold (foldBenchmarks, foldWithKeyBenchmarks)
@@ -23,7 +24,8 @@ main = do
         m_random = M.fromList elems_random
         s = S.fromList keys
         s_random2 = S.fromList keys_random2
-    evaluate $ rnf [elems_asc, elems_random, elems_randomDups]
+    evaluate $
+      rnf [elems_asc, elems_random, elems_randomDups, elems_fromListWorstCase]
     evaluate $ rnf [m, m', m'', m''', m'''']
     evaluate $ rnf m_random
     evaluate $ rnf [s, s_random2]
@@ -58,9 +60,17 @@ main = do
         , bench "fromList:random" $ whnf M.fromList elems_random
         , bench "fromList:random:fusion" $
             whnf (\(n,g) -> M.fromList (take n (unitValues (randoms g)))) (bound,gen)
-        , bench "fromListWith:randomDups" $ whnf (M.fromListWith const) elems_randomDups
+        , bench "fromList:randomDups" $ whnf M.fromList elems_randomDups
+        , bench "fromList:randomDups:fusion" $
+            whnf
+              (\(n,g) -> M.fromList (take n (unitValues (map word8ToInt (randoms g)))))
+              (bound,gen)
+        , bench "fromListWith:randomDups" $ whnf (M.fromListWith seq) elems_randomDups
         , bench "fromListWith:randomDups:fusion" $
-            whnf (\(n,g) -> M.fromListWith const (take n (unitValues (randomRs (0,255) g)))) (bound,gen)
+            whnf
+              (\(n,g) -> M.fromListWith seq (take n (unitValues (map word8ToInt (randoms g)))))
+              (bound,gen)
+        , bench "fromList:worstCase" $ whnf M.fromList elems_fromListWorstCase
         , bench "fromAscList" $ whnf M.fromAscList elems_asc
         , bench "fromAscList:fusion" $
             whnf (\n -> M.fromAscList (unitValues [1..n])) bound
@@ -93,7 +103,17 @@ main = do
     elems_random = take bound (unitValues (randoms gen))
     elems_asc = unitValues [1..bound]
     -- Random elements in a small range to produce duplicates
-    elems_randomDups = take bound (unitValues (randomRs (0,255) gen))
+    elems_randomDups = take bound (unitValues (map word8ToInt (randoms gen)))
+    -- Worst case for the current fromList algorithm. Consider removing this
+    -- test case if the algorithm changes.
+    elems_fromListWorstCase =
+      unitValues $
+      take bound $
+      concat
+        [ take 63 (iterate (*2) 1)
+        , take 63 (map negate (iterate (*2) 1))
+        , interleave [1..] (map negate [1..])
+        ]
 
     --------------------------------------------------------
     !bound = 2^12
@@ -167,3 +187,6 @@ unitValues = map (flip (,) ())
 gen, gen2 :: StdGen
 gen = mkStdGen 42
 gen2 = mkStdGen 90
+
+word8ToInt :: Word8 -> Int
+word8ToInt = fromIntegral

--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -14,7 +14,8 @@ import qualified Data.IntSet as IS
 import qualified Data.Set as S
 import qualified Data.IntMap as IM
 import qualified Data.Map.Strict as M
-import System.Random (StdGen, mkStdGen, randoms)
+import Data.Word (Word8)
+import System.Random (StdGen, mkStdGen, randoms, randomRs)
 
 import Utils.Fold (foldBenchmarks)
 
@@ -23,7 +24,14 @@ main = do
         s_even = IS.fromAscList elems_even :: IS.IntSet
         s_odd = IS.fromAscList elems_odd :: IS.IntSet
         s_sparse = IS.fromAscList elems_sparse :: IS.IntSet
-    evaluate $ rnf [elems_asc, elems_asc_sparse, elems_random]
+    evaluate $
+      rnf
+        [ elems_asc
+        , elems_asc_sparse
+        , elems_random
+        , elems_randomDups
+        , elems_fromListWorstCase
+        ]
     evaluate $ rnf [s, s_even, s_odd, s_sparse]
     defaultMain
         [ bench "member" $ whnf (member elems) s
@@ -40,14 +48,18 @@ main = do
         , bench "union" $ whnf (IS.union s_even) s_odd
         , bench "difference" $ whnf (IS.difference s) s_even
         , bench "intersection" $ whnf (IS.intersection s) s_even
-        , bench "fromList:asc" $ whnf IS.fromList elems_asc
+        , bench "fromList:asc" $ whnf fromListNoinline elems_asc
         , bench "fromList:asc:fusion" $ whnf (\n -> IS.fromList [1..n]) bound
-        , bench "fromList:asc:sparse" $ whnf IS.fromList elems_asc_sparse
+        , bench "fromList:asc:sparse" $ whnf fromListNoinline elems_asc_sparse
         , bench "fromList:asc:sparse:fusion" $
             whnf (\n -> IS.fromList (map (*64) [1..n])) bound
-        , bench "fromList:random" $ whnf IS.fromList elems_random
+        , bench "fromList:random" $ whnf fromListNoinline elems_random
         , bench "fromList:random:fusion" $
             whnf (\(n,g) -> IS.fromList (take n (randoms g))) (bound,gen)
+        , bench "fromList:randomDups" $ whnf fromListNoinline elems_randomDups
+        , bench "fromList:randomDups:fusion" $
+            whnf (\(n,g) -> IS.fromList (take n (map word8ToInt (randoms g)))) (bound,gen)
+        , bench "fromList:worstCase" $ whnf fromListNoinline elems_fromListWorstCase
         , bench "fromRange" $ whnf IS.fromRange (1,bound)
         , bench "fromRange:small" $ whnf IS.fromRange (-1,0)
         , bench "fromAscList" $ whnf fromAscListNoinline elems
@@ -86,6 +98,17 @@ main = do
     elems_asc = elems
     elems_asc_sparse = elems_sparse
     elems_random = take bound (randoms gen)
+    -- Random elements in a small range to produce duplicates
+    elems_randomDups = take bound (map word8ToInt (randoms gen))
+    -- Worst case for the current fromList algorithm. Consider removing this
+    -- test case if the algorithm changes.
+    elems_fromListWorstCase =
+      take bound $
+      concat
+        [ take 63 (iterate (*2) 1)
+        , take 63 (map negate (iterate (*2) 1))
+        , interleave [1..] (map negate [1..])
+        ]
 
 member :: [Int] -> IS.IntSet -> Int
 member xs s = foldl' (\n x -> if IS.member x s then n + 1 else n) 0 xs
@@ -102,8 +125,19 @@ fromAscListNoinline :: [Int] -> IS.IntSet
 fromAscListNoinline = IS.fromAscList
 {-# NOINLINE fromAscListNoinline #-}
 
+fromListNoinline :: [Int] -> IS.IntSet
+fromListNoinline = IS.fromList
+{-# NOINLINE fromListNoinline #-}
+
+interleave :: [a] -> [a] -> [a]
+interleave [] ys = ys
+interleave (x:xs) (y:ys) = x : y : interleave xs ys
+
 gen :: StdGen
 gen = mkStdGen 42
+
+word8ToInt :: Word8 -> Int
+word8ToInt = fromIntegral
 
 -- | Automata contain just the transitions
 type NFA = IM.IntMap (IM.IntMap IS.IntSet)

--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -1426,15 +1426,15 @@ prop_ascDescList :: [Int] -> Bool
 prop_ascDescList xs = toAscList m == reverse (toDescList m)
   where m = fromList $ zip xs $ repeat ()
 
-prop_fromList :: [Int] -> Property
+prop_fromList :: [(Int, A)] -> Property
 prop_fromList xs
-  = case fromList (zip xs xs) of
+  = case fromList xs of
       t -> valid t .&&.
-           t === fromAscList (zip sort_xs sort_xs) .&&.
-           t === fromDistinctAscList (zip nub_sort_xs nub_sort_xs) .&&.
-           t === List.foldr (uncurry insert) empty (zip xs xs)
-  where sort_xs = sort xs
-        nub_sort_xs = List.map List.head $ List.group sort_xs
+           t === fromAscList sort_xs .&&.
+           t === fromDistinctAscList nub_sort_xs .&&.
+           t === List.foldl' (\t' (k,x) -> insert k x t') empty xs
+  where sort_xs = List.sortBy (comparing fst) xs
+        nub_sort_xs = List.map NE.last $ NE.groupBy ((==) `on` fst) sort_xs
 
 ----------------------------------------------------------------
 

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -3571,9 +3571,11 @@ data MoveResult a
       !(BStack a)
 
 moveToB :: Key -> Key -> a -> BStack a -> MoveResult a
-moveToB ky kx x stk
+moveToB !ky !kx x !stk
   | kx == ky = MoveResult (Just x) stk
   | otherwise = moveUpB ky kx (Tip kx x) stk
+-- Don't inline this; there is no benefit according to benchmarks.
+{-# NOINLINE moveToB #-}
 
 moveUpB :: Key -> Key -> IntMap a -> BStack a -> MoveResult a
 moveUpB !ky !kx !tx stk = case stk of

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1363,11 +1363,11 @@ foldlFB = foldl
 
 
 -- | \(O(n \min(n,W))\). Create a set from a list of integers.
+--
+-- If the keys are in sorted order, ascending or descending, this function
+-- takes \(O(n)\) time.
 fromList :: [Key] -> IntSet
-fromList xs
-  = Foldable.foldl' ins empty xs
-  where
-    ins t x  = insert x t
+fromList xs = finishB (Foldable.foldl' (flip insertB) emptyB xs)
 {-# INLINE fromList #-} -- Inline for list fusion
 
 -- | \(O(n / W)\). Create a set from a range of integers.
@@ -1486,6 +1486,83 @@ ascLinkStack stk !rk r = case stk of
     | otherwise -> ascLinkStack stk' rk (Bin p l r)
     where
       p = mask rk m
+
+{--------------------------------------------------------------------
+  IntSetBuilder
+--------------------------------------------------------------------}
+
+-- See Note [IntMapBuilder] in Data.IntMap.Internal.
+
+data IntSetBuilder
+  = BNil
+  | BTip {-# UNPACK #-} !Int {-# UNPACK #-} !BitMap !BStack
+
+-- BLeft: the IntMap is the left child
+-- BRight: the IntMap is the right child
+data BStack
+  = BNada
+  | BLeft {-# UNPACK #-} !Prefix !IntSet !BStack
+  | BRight {-# UNPACK #-} !Prefix !IntSet !BStack
+
+-- Empty builder.
+emptyB :: IntSetBuilder
+emptyB = BNil
+
+-- Insert an element.
+insertB :: Key -> IntSetBuilder -> IntSetBuilder
+insertB !ky b = case b of
+  BNil -> BTip py bmy BNada
+  BTip px bmx stk
+    | px == py -> BTip py (bmx .|. bmy) stk
+    | otherwise -> insertUpB py bmy px (Tip px bmx) stk
+  where
+    py = prefixOf ky
+    bmy = bitmapOf ky
+{-# INLINE insertB #-}
+
+insertUpB :: Int -> BitMap -> Int -> IntSet -> BStack -> IntSetBuilder
+insertUpB !py !bmy !px !tx stk = case stk of
+  BNada -> BTip py bmy (linkB py px tx BNada)
+  BLeft p l stk'
+    | nomatch py p -> insertUpB py bmy px (Bin p l tx) stk'
+    | left py p -> insertDownB py bmy l (BRight p tx stk')
+    | otherwise -> BTip py bmy (linkB py px tx stk)
+  BRight p r stk'
+    | nomatch py p -> insertUpB py bmy px (Bin p tx r) stk'
+    | left py p -> BTip py bmy (linkB py px tx stk)
+    | otherwise -> insertDownB py bmy r (BLeft p tx stk')
+
+insertDownB :: Int -> BitMap -> IntSet -> BStack -> IntSetBuilder
+insertDownB !py !bmy tx !stk = case tx of
+  Bin p l r
+    | nomatch py p -> BTip py bmy (linkB py (unPrefix p) tx stk)
+    | left py p -> insertDownB py bmy l (BRight p r stk)
+    | otherwise -> insertDownB py bmy r (BLeft p l stk)
+  Tip px bmx
+    | px == py -> BTip py (bmx .|. bmy) stk
+    | otherwise -> BTip py bmy (linkB py px tx stk)
+  Nil -> error "insertDownB Tip"
+
+linkB :: Key -> Key -> IntSet -> BStack -> BStack
+linkB ky kx tx stk
+  | i2w ky < i2w kx = BRight p tx stk
+  | otherwise = BLeft p tx stk
+  where
+    p = branchPrefix ky kx
+{-# INLINE linkB #-}
+
+-- Finalize the builder into an IntSet.
+finishB :: IntSetBuilder -> IntSet
+finishB b = case b of
+  BNil -> Nil
+  BTip px bmx stk -> finishUpB (Tip px bmx) stk
+{-# INLINABLE finishB #-}
+
+finishUpB :: IntSet -> BStack -> IntSet
+finishUpB !t stk = case stk of
+  BNada -> t
+  BLeft p l stk' -> finishUpB (Bin p l t) stk'
+  BRight p r stk' -> finishUpB (Bin p t r) stk'
 
 {--------------------------------------------------------------------
   Eq


### PR DESCRIPTION
Implement a fusion-friendly version of the smarter algorithm proposed in #653.

For #1128.

---

Benchmarks on GHC 9.10.1:

IntSet:

```
Name                          Time - - - - - - - -    Allocated - - - - -
                                   A       B     %         A       B     %
fromList:asc                   46 μs   18 μs  -60%    480 KB  5.5 KB  -98%
fromList:asc:fusion            39 μs  4.1 μs  -89%    480 KB  5.5 KB  -98%
fromList:asc:sparse            95 μs   47 μs  -50%    864 KB  352 KB  -59%
fromList:asc:sparse:fusion     87 μs   41 μs  -52%    864 KB  352 KB  -59%
fromList:random               459 μs  467 μs   +1%    1.5 MB  2.4 MB  +67%
fromList:random:fusion        450 μs  459 μs   +1%    1.5 MB  2.4 MB  +67%
fromList:randomDups            57 μs   48 μs  -16%    352 KB  300 KB  -14%
fromList:randomDups:fusion     52 μs   48 μs   -7%    352 KB  300 KB  -14%
fromList:worstCase            711 μs  824 μs  +15%    6.9 MB   14 MB  +96%
```

IntMap:

```
Name                              Time - - - - - - - -    Allocated - - - - -
                                       A       B     %         A       B     %
fromList:asc                      100 μs   48 μs  -52%    864 KB  352 KB  -59%
fromList:asc:fusion                88 μs   37 μs  -57%    864 KB  352 KB  -59%
fromList:random                   480 μs  463 μs   -3%    1.5 MB  2.4 MB  +67%
fromList:random:fusion            452 μs  448 μs   +0%    1.5 MB  2.4 MB  +67%
fromList:randomDups               309 μs  263 μs  -15%    1.1 MB  1.7 MB  +57%
fromList:randomDups:fusion        296 μs  247 μs  -16%    1.1 MB  1.7 MB  +57%
fromList:worstCase                982 μs  1.1 ms  +16%    7.3 MB   14 MB  +97%
fromListWith:randomDups           316 μs  302 μs   -4%    1.3 MB  1.9 MB  +54%
fromListWith:randomDups:fusion    321 μs  335 μs   +4%    1.3 MB  2.3 MB  +86%
```