### PR TITLE
Improve Haddocks for partial functions

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -416,6 +416,8 @@ deriving instance Lift a => Lift (IntMap a)
 -- | \(O(\min(n,W))\). Find the value at a key.
 -- Calls 'error' when the element can not be found.
 --
+-- __Note__: This function is partial. Prefer '!?'.
+--
 -- > fromList [(5,'a'), (3,'b')] ! 1    Error: element not in the map
 -- > fromList [(5,'a'), (3,'b')] ! 5 == 'a'
 
@@ -2325,14 +2327,18 @@ minView :: IntMap a -> Maybe (a, IntMap a)
 minView t = fmap (\((_, x), t') -> (x, t')) (minViewWithKey t)
 
 -- | \(O(\min(n,W))\). Delete and find the maximal element.
--- This function throws an error if the map is empty. Use 'maxViewWithKey'
--- if the map may be empty.
+--
+-- Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'maxViewWithKey'.
 deleteFindMax :: IntMap a -> ((Key, a), IntMap a)
 deleteFindMax = fromMaybe (error "deleteFindMax: empty map has no maximal element") . maxViewWithKey
 
 -- | \(O(\min(n,W))\). Delete and find the minimal element.
--- This function throws an error if the map is empty. Use 'minViewWithKey'
--- if the map may be empty.
+--
+-- Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'minViewWithKey'.
 deleteFindMin :: IntMap a -> ((Key, a), IntMap a)
 deleteFindMin = fromMaybe (error "deleteFindMin: empty map has no minimal element") . minViewWithKey
 
@@ -2366,6 +2372,8 @@ lookupMin (Bin p l r) =
 {-# INLINE lookupMin #-} -- See Note [Inline lookupMin] in Data.Set.Internal
 
 -- | \(O(\min(n,W))\). The minimal key of the map. Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMin'.
 findMin :: IntMap a -> (Key, a)
 findMin t
   | Just r <- lookupMin t = r
@@ -2385,6 +2393,8 @@ lookupMax (Bin p l r) =
 {-# INLINE lookupMax #-} -- See Note [Inline lookupMin] in Data.Set.Internal
 
 -- | \(O(\min(n,W))\). The maximal key of the map. Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMax'.
 findMax :: IntMap a -> (Key, a)
 findMax t
   | Just r <- lookupMax t = r

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -249,12 +249,8 @@ module Data.IntMap.Lazy (
     -- * Min\/Max
     , lookupMin
     , lookupMax
-    , findMin
-    , findMax
     , deleteMin
     , deleteMax
-    , deleteFindMin
-    , deleteFindMax
     , updateMin
     , updateMax
     , updateMinWithKey
@@ -263,6 +259,10 @@ module Data.IntMap.Lazy (
     , maxView
     , minViewWithKey
     , maxViewWithKey
+    , findMin
+    , findMax
+    , deleteFindMin
+    , deleteFindMax
     ) where
 
 import Data.IntMap.Internal as IM

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -267,12 +267,8 @@ module Data.IntMap.Strict (
     -- * Min\/Max
     , lookupMin
     , lookupMax
-    , findMin
-    , findMax
     , deleteMin
     , deleteMax
-    , deleteFindMin
-    , deleteFindMax
     , updateMin
     , updateMax
     , updateMinWithKey
@@ -281,6 +277,10 @@ module Data.IntMap.Strict (
     , maxView
     , minViewWithKey
     , maxViewWithKey
+    , findMin
+    , findMax
+    , deleteFindMin
+    , deleteFindMax
     ) where
 
 import Data.IntMap.Strict.Internal

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -166,14 +166,14 @@ module Data.IntSet (
             -- * Min\/Max
             , lookupMin
             , lookupMax
-            , findMin
-            , findMax
             , deleteMin
             , deleteMax
-            , deleteFindMin
-            , deleteFindMax
             , maxView
             , minView
+            , findMin
+            , findMax
+            , deleteFindMin
+            , deleteFindMax
 
             -- * Conversion
 

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -1099,13 +1099,17 @@ minView t =
 
 -- | \(O(\min(n,W))\). Delete and find the minimal element.
 --
--- > deleteFindMin set = (findMin set, deleteMin set)
+-- Calls 'error' if the set is empty.
+--
+-- __Note__: This function is partial. Prefer 'minView'.
 deleteFindMin :: IntSet -> (Key, IntSet)
 deleteFindMin = fromMaybe (error "deleteFindMin: empty set has no minimal element") . minView
 
 -- | \(O(\min(n,W))\). Delete and find the maximal element.
 --
--- > deleteFindMax set = (findMax set, deleteMax set)
+-- Calls 'error' if the set is empty.
+--
+-- __Note__: This function is partial. Prefer 'maxView'.
 deleteFindMax :: IntSet -> (Key, IntSet)
 deleteFindMax = fromMaybe (error "deleteFindMax: empty set has no maximal element") . maxView
 
@@ -1126,6 +1130,8 @@ lookupMin (Bin p l r) = Just $! lookupMinSure (if signBranch p then r else l)
 
 -- | \(O(\min(n,W))\). The minimal element of the set. Calls 'error' if the set
 -- is empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMin'.
 findMin :: IntSet -> Key
 findMin t
   | Just r <- lookupMin t = r
@@ -1148,6 +1154,8 @@ lookupMax (Bin p l r) = Just $! lookupMaxSure (if signBranch p then l else r)
 
 -- | \(O(\min(n,W))\). The maximal element of the set. Calls 'error' if the set
 -- is empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMax'.
 findMax :: IntSet -> Key
 findMax t
   | Just r <- lookupMax t = r

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -434,6 +434,8 @@ infixl 9 !,!?,\\ --
 -- | \(O(\log n)\). Find the value at a key.
 -- Calls 'error' when the element can not be found.
 --
+-- __Note__: This function is partial. Prefer '!?'.
+--
 -- > fromList [(5,'a'), (3,'b')] ! 1    Error: element not in the map
 -- > fromList [(5,'a'), (3,'b')] ! 5 == 'a'
 
@@ -621,8 +623,6 @@ notMember k m = not $ member k m
 {-# INLINE notMember #-}
 #endif
 
--- | \(O(\log n)\). Find the value at a key.
--- Calls 'error' when the element can not be found.
 find :: Ord k => k -> Map k a -> a
 find = go
   where
@@ -1454,6 +1454,8 @@ alterFYoneda = go
 -- including, the 'size' of the map. Calls 'error' when the key is not
 -- a 'member' of the map.
 --
+-- __Note__: This function is partial. Prefer 'lookupIndex'.
+--
 -- > findIndex 2 (fromList [(5,"a"), (3,"b")])    Error: element is not in the map
 -- > findIndex 3 (fromList [(5,"a"), (3,"b")]) == 0
 -- > findIndex 5 (fromList [(5,"a"), (3,"b")]) == 1
@@ -1499,6 +1501,8 @@ lookupIndex = go 0
 -- | \(O(\log n)\). Retrieve an element by its /index/, i.e. by its zero-based
 -- index in the sequence sorted by keys. If the /index/ is out of range (less
 -- than zero, greater or equal to 'size' of the map), 'error' is called.
+--
+-- __Note__: This function is partial.
 --
 -- > elemAt 0 (fromList [(5,"a"), (3,"b")]) == (3,"b")
 -- > elemAt 1 (fromList [(5,"a"), (3,"b")]) == (5, "a")
@@ -1584,6 +1588,8 @@ splitAt i0 m0
 -- the sequence sorted by keys. If the /index/ is out of range (less than zero,
 -- greater or equal to 'size' of the map), 'error' is called.
 --
+-- __Note__: This function is partial.
+--
 -- > updateAt (\ _ _ -> Just "x") 0    (fromList [(5,"a"), (3,"b")]) == fromList [(3, "x"), (5, "a")]
 -- > updateAt (\ _ _ -> Just "x") 1    (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "x")]
 -- > updateAt (\ _ _ -> Just "x") 2    (fromList [(5,"a"), (3,"b")])    Error: index out of range
@@ -1609,6 +1615,8 @@ updateAt f !i t =
 -- | \(O(\log n)\). Delete the element at /index/, i.e. by its zero-based index in
 -- the sequence sorted by keys. If the /index/ is out of range (less than zero,
 -- greater or equal to 'size' of the map), 'error' is called.
+--
+-- __Note__: This function is partial.
 --
 -- > deleteAt 0  (fromList [(5,"a"), (3,"b")]) == singleton 5 "a"
 -- > deleteAt 1  (fromList [(5,"a"), (3,"b")]) == singleton 3 "b"
@@ -1667,6 +1675,8 @@ lookupMin (Bin _ k x l _) = Just $! kvToTuple (lookupMinSure k x l)
 
 -- | \(O(\log n)\). The minimal key of the map. Calls 'error' if the map is empty.
 --
+-- __Note__: This function is partial. Prefer 'lookupMin'.
+--
 -- > findMin (fromList [(5,"a"), (3,"b")]) == (3,"b")
 -- > findMin empty                            Error: empty map has no minimal element
 
@@ -1692,6 +1702,8 @@ lookupMax (Bin _ k x _ r) = Just $! kvToTuple (lookupMaxSure k x r)
 {-# INLINE lookupMax #-} -- See Note [Inline lookupMin] in Data.Set.Internal
 
 -- | \(O(\log n)\). The maximal key of the map. Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMax'.
 --
 -- > findMax (fromList [(5,"a"), (3,"b")]) == (5,"a")
 -- > findMax empty                            Error: empty map has no maximal element
@@ -4105,9 +4117,9 @@ maxViewSure !k x !l r = case r of
 
 -- | \(O(\log n)\). Delete and find the minimal element.
 --
--- > deleteFindMin (fromList [(5,"a"), (3,"b"), (10,"c")]) == ((3,"b"), fromList[(5,"a"), (10,"c")])
--- > deleteFindMin empty                                      Error: can not return the minimal element of an empty map
-
+-- Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'minViewWithKey'.
 deleteFindMin :: Map k a -> ((k,a),Map k a)
 deleteFindMin t = case minViewWithKey t of
   Nothing -> (error "Map.deleteFindMin: can not return the minimal element of an empty map", Tip)
@@ -4115,9 +4127,9 @@ deleteFindMin t = case minViewWithKey t of
 
 -- | \(O(\log n)\). Delete and find the maximal element.
 --
--- > deleteFindMax (fromList [(5,"a"), (3,"b"), (10,"c")]) == ((10,"c"), fromList [(3,"b"), (5,"a")])
--- > deleteFindMax empty                                      Error: can not return the maximal element of an empty map
-
+-- Calls 'error' if the map is empty.
+--
+-- __Note__: This function is partial. Prefer 'maxViewWithKey'.
 deleteFindMax :: Map k a -> ((k,a),Map k a)
 deleteFindMax t = case maxViewWithKey t of
   Nothing -> (error "Map.deleteFindMax: can not return the maximal element of an empty map", Tip)

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -272,12 +272,8 @@ module Data.Map.Lazy (
     -- * Min\/Max
     , lookupMin
     , lookupMax
-    , findMin
-    , findMax
     , deleteMin
     , deleteMax
-    , deleteFindMin
-    , deleteFindMax
     , updateMin
     , updateMax
     , updateMinWithKey
@@ -286,6 +282,10 @@ module Data.Map.Lazy (
     , maxView
     , minViewWithKey
     , maxViewWithKey
+    , findMin
+    , findMax
+    , deleteFindMin
+    , deleteFindMax
 
     -- * Debugging
     , valid

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -287,12 +287,8 @@ module Data.Map.Strict
     -- * Min\/Max
     , lookupMin
     , lookupMax
-    , findMin
-    , findMax
     , deleteMin
     , deleteMax
-    , deleteFindMin
-    , deleteFindMax
     , updateMin
     , updateMax
     , updateMinWithKey
@@ -301,6 +297,10 @@ module Data.Map.Strict
     , maxView
     , minViewWithKey
     , maxViewWithKey
+    , findMin
+    , findMax
+    , deleteFindMin
+    , deleteFindMax
 
     -- * Debugging
     , valid

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -838,6 +838,8 @@ atKeyIdentity k f t = Identity $ atKeyPlain Strict k (coerce f) t
 -- | \(O(\log n)\). Update the element at /index/. Calls 'error' when an
 -- invalid index is used.
 --
+-- __Note__: This function is partial.
+--
 -- > updateAt (\ _ _ -> Just "x") 0    (fromList [(5,"a"), (3,"b")]) == fromList [(3, "x"), (5, "a")]
 -- > updateAt (\ _ _ -> Just "x") 1    (fromList [(5,"a"), (3,"b")]) == fromList [(3, "b"), (5, "x")]
 -- > updateAt (\ _ _ -> Just "x") 2    (fromList [(5,"a"), (3,"b")])    Error: index out of range

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -1758,6 +1758,10 @@ singleton       :: a -> Seq a
 singleton x     =  Seq (Single (Elem x))
 
 -- | \( O(\log n) \). @replicate n x@ is a sequence consisting of @n@ copies of @x@.
+--
+-- Calls 'error' if @n < 0@.
+--
+-- __Note__: This function is partial.
 replicate       :: Int -> a -> Seq a
 replicate n x
   | n >= 0      = runIdentity (replicateA n (Identity x))
@@ -1766,6 +1770,10 @@ replicate n x
 -- | 'replicateA' is an 'Applicative' version of 'replicate', and makes
 -- \( O(\log n) \) calls to 'liftA2' and 'pure'.
 --
+-- Calls 'error' if @n < 0@.
+--
+-- __Note__: This function is partial.
+--
 -- > replicateA n x = sequenceA (replicate n x)
 replicateA :: Applicative f => Int -> f a -> f (Seq a)
 replicateA n x
@@ -1773,13 +1781,9 @@ replicateA n x
   | otherwise   = error "replicateA takes a nonnegative integer argument"
 {-# SPECIALIZE replicateA :: Int -> State a b -> State a (Seq b) #-}
 
--- | 'replicateM' is the @Seq@ counterpart of
--- @Control.Monad.'Control.Monad.replicateM'@.
+-- | Synonym for 'replicateA'.
 --
--- > replicateM n x = sequence (replicate n x)
---
--- For @base >= 4.8.0@ and @containers >= 0.5.11@, 'replicateM'
--- is a synonym for 'replicateA'.
+-- This definition exists for backwards compatibility.
 replicateM :: Applicative m => Int -> m a -> m (Seq a)
 replicateM = replicateA
 
@@ -1788,10 +1792,14 @@ replicateM = replicateA
 -- @k@ is 0.
 --
 -- prop> cycleTaking k = fromList . take k . cycle . toList
-
+--
 -- If you wish to concatenate a possibly empty sequence @xs@ with
--- itself precisely @k@ times, use @'stimes' k xs@ instead of this
--- function.
+-- itself precisely @k@ times, use @'Data.Semigroup.stimes' k xs@ instead of
+-- this function.
+--
+-- Calls 'error' if @k > 0@ and @null xs@.
+--
+-- __Note__: This function is partial.
 --
 -- @since 0.5.8
 cycleTaking :: Int -> Seq a -> Seq a
@@ -2205,7 +2213,9 @@ unfoldl f = unfoldl' empty
 -- | \( O(n) \).  Constructs a sequence by repeated application of a function
 -- to a seed value.
 --
--- > iterateN n f x = fromList (Prelude.take n (Prelude.iterate f x))
+-- Calls 'error' if @n < 0@.
+--
+-- __Note__: This function is partial.
 iterateN :: Int -> (a -> a) -> a -> Seq a
 iterateN n f x
   | n >= 0      = replicateA n (State (\ y -> (f y, y))) `execState` x
@@ -2384,6 +2394,10 @@ scanl f z0 xs = z0 <| snd (mapAccumL (\ x z -> let x' = f x z in (x', x')) z0 xs
 
 -- | 'scanl1' is a variant of 'scanl' that has no starting value argument:
 --
+-- Calls 'error' if the sequence is empty.
+--
+-- __Note__: This function is partial.
+--
 -- > scanl1 f (fromList [x1, x2, ...]) = fromList [x1, x1 `f` x2, ...]
 scanl1 :: (a -> a -> a) -> Seq a -> Seq a
 scanl1 f xs = case viewl xs of
@@ -2395,6 +2409,10 @@ scanr :: (a -> b -> b) -> b -> Seq a -> Seq b
 scanr f z0 xs = snd (mapAccumR (\ z x -> let z' = f x z in (z', z')) z0 xs) |> z0
 
 -- | 'scanr1' is a variant of 'scanr' that has no starting value argument.
+--
+-- Calls 'error' if the sequence is empty.
+--
+-- __Note__: This function is partial.
 scanr1 :: (a -> a -> a) -> Seq a -> Seq a
 scanr1 f xs = case viewr xs of
     EmptyR          -> error "scanr1 takes a nonempty sequence as an argument"
@@ -2409,7 +2427,9 @@ scanr1 f xs = case viewr xs of
 --
 -- prop> xs `index` i = toList xs !! i
 --
--- Caution: 'index' necessarily delays retrieving the requested
+-- __Note__: This function is partial. Prefer 'lookup'.
+--
+-- __Note__: 'index' necessarily delays retrieving the requested
 -- element until the result is forced. It can therefore lead to a space
 -- leak if the result is stored, unforced, in another structure. To retrieve
 -- an element immediately without forcing it, use 'lookup' or '(!?)'.
@@ -3380,6 +3400,10 @@ valid.
 -- | \( O(n) \). Convert a given sequence length and a function representing that
 -- sequence into a sequence.
 --
+-- Calls 'error' if @n < 0@.
+--
+-- __Note__: This function is partial.
+--
 -- @since 0.5.6.2
 fromFunction :: Int -> (Int -> a) -> Seq a
 fromFunction len f | len < 0 = error "Data.Sequence.fromFunction called with negative len"
@@ -3957,6 +3981,10 @@ splitSuffixN i s pr m (Four a b c d)
 -- really affect edge cases. Performance degrades smoothly from \( O(1) \) (for
 -- \( c = n \)) to \( O(n) \) (for \( c = 1 \)). The true bound is more like
 -- \( O \Bigl( \bigl(\frac{n}{c} - 1\bigr) (\log (c + 1)) + 1 \Bigr) \)
+--
+-- Calls 'error' if @n <= 0@ and @not (null xs)@.
+--
+-- __Note__: This function is partial.
 --
 -- @since 0.5.8
 chunksOf :: Int -> Seq a -> Seq (Seq a)

--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -167,14 +167,14 @@ module Data.Set (
             -- * Min\/Max
             , lookupMin
             , lookupMax
-            , findMin
-            , findMax
             , deleteMin
             , deleteMax
-            , deleteFindMin
-            , deleteFindMax
             , maxView
             , minView
+            , findMin
+            , findMax
+            , deleteFindMin
+            , deleteFindMax
 
             -- * Conversion
 

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -774,6 +774,8 @@ lookupMin (Bin _ x l _) = Just $! lookupMinSure x l
 
 -- | \(O(\log n)\). The minimal element of the set. Calls 'error' if the set is
 -- empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMin'.
 findMin :: Set a -> a
 findMin t
   | Just r <- lookupMin t = r
@@ -795,6 +797,8 @@ lookupMax (Bin _ x _ r) = Just $! lookupMaxSure x r
 
 -- | \(O(\log n)\). The maximal element of the set. Calls 'error' if the set is
 -- empty.
+--
+-- __Note__: This function is partial. Prefer 'lookupMax'.
 findMax :: Set a -> a
 findMax t
   | Just r <- lookupMax t = r
@@ -1441,6 +1445,8 @@ splitMember x (Bin _ y l r)
 -- to, but not including, the 'size' of the set. Calls 'error' when the element
 -- is not a 'member' of the set.
 --
+-- __Note__: This function is partial. Prefer 'lookupIndex'.
+--
 -- > findIndex 2 (fromList [5,3])    Error: element is not in the set
 -- > findIndex 3 (fromList [5,3]) == 0
 -- > findIndex 5 (fromList [5,3]) == 1
@@ -1491,6 +1497,8 @@ lookupIndex = go 0
 -- index in the sorted sequence of elements. If the /index/ is out of range (less
 -- than zero, greater or equal to 'size' of the set), 'error' is called.
 --
+-- __Note__: This function is partial.
+--
 -- > elemAt 0 (fromList [5,3]) == 3
 -- > elemAt 1 (fromList [5,3]) == 5
 -- > elemAt 2 (fromList [5,3])    Error: index out of range
@@ -1510,6 +1518,8 @@ elemAt i (Bin _ x l r)
 -- | \(O(\log n)\). Delete the element at /index/, i.e. by its zero-based index in
 -- the sorted sequence of elements. If the /index/ is out of range (less than zero,
 -- greater or equal to 'size' of the set), 'error' is called.
+--
+-- __Note__: This function is partial.
 --
 -- > deleteAt 0    (fromList [5,3]) == singleton 5
 -- > deleteAt 1    (fromList [5,3]) == singleton 3
@@ -1772,8 +1782,9 @@ glue l@(Bin sl xl ll lr) r@(Bin sr xr rl rr)
 
 -- | \(O(\log n)\). Delete and find the minimal element.
 --
--- > deleteFindMin set = (findMin set, deleteMin set)
-
+-- Calls 'error' if the set is empty.
+--
+-- __Note__: This function is partial. Prefer 'minView'.
 deleteFindMin :: Set a -> (a,Set a)
 deleteFindMin t
   | Just r <- minView t = r
@@ -1781,7 +1792,9 @@ deleteFindMin t
 
 -- | \(O(\log n)\). Delete and find the maximal element.
 --
--- > deleteFindMax set = (findMax set, deleteMax set)
+-- Calls 'error' if the set is empty.
+--
+-- __Note__: This function is partial. Prefer 'maxView'.
 deleteFindMax :: Set a -> (a,Set a)
 deleteFindMax t
   | Just r <- maxView t = r


### PR DESCRIPTION
Document partial functions in a consistent manner. Specify the error condition and mention total alternatives, if any.