### PR TITLE
Guard redundant mappend definitions with CPP

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -447,7 +447,9 @@ infixl 9 !?,\\{-This comment teaches CPP correct behaviour -}
 instance Monoid (IntMap a) where
     mempty  = empty
     mconcat = unions
+#if !MIN_VERSION_base(4,11,0)
     mappend = (<>)
+#endif
 
 -- | @(<>)@ = 'union'
 --

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -315,7 +315,9 @@ deriving instance Lift IntSet
 instance Monoid IntSet where
     mempty  = empty
     mconcat = unions
+#if !MIN_VERSION_base(4,11,0)
     mappend = (<>)
+#endif
 
 -- | @(<>)@ = 'union'
 --

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -488,7 +488,9 @@ deriving instance (Lift k, Lift a) => Lift (Map k a)
 instance (Ord k) => Monoid (Map k v) where
     mempty  = empty
     mconcat = unions
+#if !MIN_VERSION_base(4,11,0)
     mappend = (<>)
+#endif
 
 -- | @(<>)@ = 'union'
 --

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -1001,7 +1001,9 @@ instance Read1 Seq where
 -- | @mempty@ = 'empty'
 instance Monoid (Seq a) where
     mempty = empty
+#if !MIN_VERSION_base(4,11,0)
     mappend = (Semigroup.<>)
+#endif
 
 -- | @(<>)@ = '(><)'
 --

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -293,7 +293,9 @@ deriving instance Lift a => Lift (Set a)
 instance Ord a => Monoid (Set a) where
     mempty  = empty
     mconcat = unions
+#if !MIN_VERSION_base(4,11,0)
     mappend = (<>)
+#endif
 
 -- | @(<>)@ = 'union'
 --
@@ -2099,8 +2101,9 @@ instance Semigroup (MergeSet a) where
 
 instance Monoid (MergeSet a) where
   mempty = MergeSet empty
-
+#if !MIN_VERSION_base(4,11,0)
   mappend = (<>)
+#endif
 
 -- | \(O(n+m)\). Calculate the disjoint union of two sets.
 --


### PR DESCRIPTION
This is motivated by the proposed removal of mappend from Monoid in the final phase of the Semigroup-Monoid proposal.
We cannot remove mappend references completely yet because we support base-4.10 which is pre-Semigroup-Monoid.

See https://github.com/haskell/core-libraries-committee/issues/328

Related: Redundant `return` definitions were removed in #1095.