### PR TITLE
Fix haddocks of Data.IntMap.compose

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -811,9 +811,8 @@ disjoint t1@(Bin p1 l1 r1) t2@(Bin p2 l2 r2) = case treeTreeBranch p1 p2 of
 {--------------------------------------------------------------------
   Compose
 --------------------------------------------------------------------}
--- | Relate the keys of one map to the values of
--- the other, by using the values of the former as keys for lookups
--- in the latter.
+-- | Given maps @bc@ and @ab@, relate the keys of @ab@ to the values of @bc@,
+-- by using the values of @ab@ as keys for lookups in @bc@.
 --
 -- Complexity: \( O(n * \min(m,W)) \), where \(m\) is the size of the first argument
 --

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -2168,9 +2168,8 @@ disjoint (Bin _ k _ l r) t
 {--------------------------------------------------------------------
   Compose
 --------------------------------------------------------------------}
--- | Relate the keys of one map to the values of
--- the other, by using the values of the former as keys for lookups
--- in the latter.
+-- | Given maps @bc@ and @ab@, relate the keys of @ab@ to the values of @bc@,
+-- by using the values of @ab@ as keys for lookups in @bc@.
 --
 -- Complexity: \( O (n \log m) \), where \(m\) is the size of the first argument
 --


### PR DESCRIPTION
The words "former" and "latter" in the documentation of `compose` on `IntMap` were swapped. This PR puts them the right way round.