### PR TITLE
Make Int{Map,Set} folds friendlier to optimizations

### DIFF
--- a/containers-tests/benchmarks/Utils/Fold.hs
+++ b/containers-tests/benchmarks/Utils/Fold.hs
@@ -44,9 +44,11 @@ foldBenchmarks foldr foldl foldr' foldl' foldMap xs =
 
     -- foldr'
   , bench "foldr'_sum" $ whnf (foldr' (+) 0) xs
+  , bench "foldr'_maximum" $ whnf foldr'_maximum xs
 
     -- foldl'
   , bench "foldl'_sum" $ whnf (foldl' (+) 0) xs
+  , bench "foldl'_maximum" $ whnf foldl'_maximum xs
 
     -- foldMap
   , bench "foldMap_elem" $ whnf foldMap_elem xs
@@ -80,6 +82,12 @@ foldBenchmarks foldr foldl foldr' foldl' foldMap xs =
     foldl_traverseSum :: f -> Int
     foldl_traverseSum xs =
       execState (foldl (\z x -> modify' (+x) *> z) (pure ()) xs) 0
+
+    foldr'_maximum :: f -> Maybe Int
+    foldr'_maximum = foldr' (\x z -> Just $! maybe x (max x) z) Nothing
+
+    foldl'_maximum :: f -> Maybe Int
+    foldl'_maximum = foldl' (\z x -> Just $! maybe x (max x) z) Nothing
 
     foldMap_elem :: f -> Any
     foldMap_elem = foldMap (\x -> Any (x == minBound))
@@ -138,8 +146,11 @@ instance Applicative f => Monoid (Effect f) where
 --   Folding with an effect. In practice:
 --   * Folds defined using foldr, such as Data.Foldable.traverse_ and friends
 --
--- foldl', foldr'
+-- foldl'_sum, foldr'_sum
 --   Strict folds.
+--
+-- foldl'_maximum, foldr'_maximum
+--  Strict folds with a `Maybe` as accumulator which could be optimized away.
 --
 -- foldMap_elem
 --   Simple lazy fold that visits every element. In practice:

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -325,7 +325,7 @@ import Data.Bits
 import qualified Data.Foldable as Foldable
 import Data.Maybe (fromMaybe)
 import Utils.Containers.Internal.Prelude hiding
-  (lookup, map, filter, foldr, foldl, foldl', null)
+  (lookup, map, filter, foldr, foldl, foldl', foldMap, null)
 import Prelude ()
 
 import Data.IntSet.Internal (IntSet)
@@ -469,23 +469,13 @@ instance Semigroup (IntMap a) where
 
 -- | Folds in order of increasing key.
 instance Foldable.Foldable IntMap where
-  fold = go
-    where go Nil = mempty
-          go (Tip _ v) = v
-          go (Bin p l r)
-            | signBranch p = go r `mappend` go l
-            | otherwise = go l `mappend` go r
+  fold = foldMap id
   {-# INLINABLE fold #-}
   foldr = foldr
   {-# INLINE foldr #-}
   foldl = foldl
   {-# INLINE foldl #-}
-  foldMap f t = go t
-    where go Nil = mempty
-          go (Tip _ v) = f v
-          go (Bin p l r)
-            | signBranch p = go r `mappend` go l
-            | otherwise = go l `mappend` go r
+  foldMap = foldMap
   {-# INLINE foldMap #-}
   foldl' = foldl'
   {-# INLINE foldl' #-}
@@ -3012,15 +3002,18 @@ splitLookup k t =
 --
 -- > let f a len = len + (length a)
 -- > foldr f 0 (fromList [(5,"a"), (3,"bbb")]) == 4
+
+-- See Note [IntMap folds]
 foldr :: (a -> b -> b) -> b -> IntMap a -> b
 foldr f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z l) r -- put negative numbers before
       | otherwise -> go (go z r) l
     _ -> go z t
   where
-    go z' Nil         = z'
+    go _ Nil          = error "foldr.go: Nil"
     go z' (Tip _ x)   = f x z'
     go z' (Bin _ l r) = go (go z' r) l
 {-# INLINE foldr #-}
@@ -3028,15 +3021,18 @@ foldr f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
 -- | \(O(n)\). A strict version of 'foldr'. Each application of the operator is
 -- evaluated before using the result in the next application. This
 -- function is strict in the starting value.
+
+-- See Note [IntMap folds]
 foldr' :: (a -> b -> b) -> b -> IntMap a -> b
 foldr' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z l) r -- put negative numbers before
       | otherwise -> go (go z r) l
     _ -> go z t
   where
-    go !z' Nil        = z'
+    go !_ Nil         = error "foldr'.go: Nil"
     go z' (Tip _ x)   = f x z'
     go z' (Bin _ l r) = go (go z' r) l
 {-# INLINE foldr' #-}
@@ -3050,15 +3046,18 @@ foldr' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
 --
 -- > let f len a = len + (length a)
 -- > foldl f 0 (fromList [(5,"a"), (3,"bbb")]) == 4
+
+-- See Note [IntMap folds]
 foldl :: (a -> b -> a) -> a -> IntMap b -> a
 foldl f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z r) l -- put negative numbers before
       | otherwise -> go (go z l) r
     _ -> go z t
   where
-    go z' Nil         = z'
+    go _ Nil          = error "foldl.go: Nil"
     go z' (Tip _ x)   = f z' x
     go z' (Bin _ l r) = go (go z' l) r
 {-# INLINE foldl #-}
@@ -3066,18 +3065,45 @@ foldl f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
 -- | \(O(n)\). A strict version of 'foldl'. Each application of the operator is
 -- evaluated before using the result in the next application. This
 -- function is strict in the starting value.
+
+-- See Note [IntMap folds]
 foldl' :: (a -> b -> a) -> a -> IntMap b -> a
 foldl' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z r) l -- put negative numbers before
       | otherwise -> go (go z l) r
     _ -> go z t
   where
-    go !z' Nil        = z'
+    go !_ Nil         = error "foldl'.go: Nil"
     go z' (Tip _ x)   = f z' x
     go z' (Bin _ l r) = go (go z' l) r
 {-# INLINE foldl' #-}
+
+-- See Note [IntMap folds]
+foldMap :: Monoid m => (a -> m) -> IntMap a -> m
+foldMap f = \t -> -- Use lambda to be inlinable with two arguments.
+  case t of
+    Nil -> mempty
+    Bin p l r
+#if MIN_VERSION_base(4,11,0)
+      | signBranch p -> go r <> go l
+      | otherwise -> go l <> go r
+#else
+      | signBranch p -> go r `mappend` go l
+      | otherwise -> go l `mappend` go r
+#endif
+    _ -> go t
+  where
+    go Nil = error "foldMap.go: Nil"
+    go (Tip _ x) = f x
+#if MIN_VERSION_base(4,11,0)
+    go (Bin _ l r) = go l <> go r
+#else
+    go (Bin _ l r) = go l `mappend` go r
+#endif
+{-# INLINE foldMap #-}
 
 -- | \(O(n)\). Fold the keys and values in the map using the given right-associative
 -- binary operator, such that
@@ -3089,15 +3115,18 @@ foldl' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
 --
 -- > let f k a result = result ++ "(" ++ (show k) ++ ":" ++ a ++ ")"
 -- > foldrWithKey f "Map: " (fromList [(5,"a"), (3,"b")]) == "Map: (5:a)(3:b)"
+
+-- See Note [IntMap folds]
 foldrWithKey :: (Key -> a -> b -> b) -> b -> IntMap a -> b
 foldrWithKey f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z l) r -- put negative numbers before
       | otherwise -> go (go z r) l
     _ -> go z t
   where
-    go z' Nil         = z'
+    go _ Nil          = error "foldrWithKey.go: Nil"
     go z' (Tip kx x)  = f kx x z'
     go z' (Bin _ l r) = go (go z' r) l
 {-# INLINE foldrWithKey #-}
@@ -3105,15 +3134,18 @@ foldrWithKey f z = \t ->      -- Use lambda t to be inlinable with two arguments
 -- | \(O(n)\). A strict version of 'foldrWithKey'. Each application of the operator is
 -- evaluated before using the result in the next application. This
 -- function is strict in the starting value.
+
+-- See Note [IntMap folds]
 foldrWithKey' :: (Key -> a -> b -> b) -> b -> IntMap a -> b
 foldrWithKey' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z l) r -- put negative numbers before
       | otherwise -> go (go z r) l
     _ -> go z t
   where
-    go !z' Nil        = z'
+    go !_ Nil         = error "foldrWithKey'.go: Nil"
     go z' (Tip kx x)  = f kx x z'
     go z' (Bin _ l r) = go (go z' r) l
 {-# INLINE foldrWithKey' #-}
@@ -3128,15 +3160,18 @@ foldrWithKey' f z = \t ->      -- Use lambda t to be inlinable with two argument
 --
 -- > let f result k a = result ++ "(" ++ (show k) ++ ":" ++ a ++ ")"
 -- > foldlWithKey f "Map: " (fromList [(5,"a"), (3,"b")]) == "Map: (3:b)(5:a)"
+
+-- See Note [IntMap folds]
 foldlWithKey :: (a -> Key -> b -> a) -> a -> IntMap b -> a
 foldlWithKey f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z r) l -- put negative numbers before
       | otherwise -> go (go z l) r
     _ -> go z t
   where
-    go z' Nil         = z'
+    go _ Nil          = error "foldlWithKey.go: Nil"
     go z' (Tip kx x)  = f z' kx x
     go z' (Bin _ l r) = go (go z' l) r
 {-# INLINE foldlWithKey #-}
@@ -3144,15 +3179,18 @@ foldlWithKey f z = \t ->      -- Use lambda t to be inlinable with two arguments
 -- | \(O(n)\). A strict version of 'foldlWithKey'. Each application of the operator is
 -- evaluated before using the result in the next application. This
 -- function is strict in the starting value.
+
+-- See Note [IntMap folds]
 foldlWithKey' :: (a -> Key -> b -> a) -> a -> IntMap b -> a
 foldlWithKey' f z = \t ->      -- Use lambda t to be inlinable with two arguments only.
   case t of
+    Nil -> z
     Bin p l r
       | signBranch p -> go (go z r) l -- put negative numbers before
       | otherwise -> go (go z l) r
     _ -> go z t
   where
-    go !z' Nil        = z'
+    go !_ Nil         = error "foldlWithKey'.go: Nil"
     go z' (Tip kx x)  = f z' kx x
     go z' (Bin _ l r) = go (go z' l) r
 {-# INLINE foldlWithKey' #-}
@@ -3164,14 +3202,29 @@ foldlWithKey' f z = \t ->      -- Use lambda t to be inlinable with two argument
 -- This can be an asymptotically faster than 'foldrWithKey' or 'foldlWithKey' for some monoids.
 --
 -- @since 0.5.4
+
+-- See Note [IntMap folds]
 foldMapWithKey :: Monoid m => (Key -> a -> m) -> IntMap a -> m
-foldMapWithKey f = go
+foldMapWithKey f = \t -> -- Use lambda to be inlinable with two arguments.
+  case t of
+    Nil -> mempty
+    Bin p l r
+#if MIN_VERSION_base(4,11,0)
+      | signBranch p -> go r <> go l
+      | otherwise -> go l <> go r
+#else
+      | signBranch p -> go r `mappend` go l
+      | otherwise -> go l `mappend` go r
+#endif
+    _ -> go t
   where
-    go Nil           = mempty
-    go (Tip kx x)    = f kx x
-    go (Bin p l r)
-      | signBranch p = go r `mappend` go l
-      | otherwise = go l `mappend` go r
+    go Nil = error "foldMap.go: Nil"
+    go (Tip kx x) = f kx x
+#if MIN_VERSION_base(4,11,0)
+    go (Bin _ l r) = go l <> go r
+#else
+    go (Bin _ l r) = go l `mappend` go r
+#endif
 {-# INLINE foldMapWithKey #-}
 
 {--------------------------------------------------------------------
@@ -4048,3 +4101,40 @@ withEmpty bars = "   ":bars
 --
 -- The implementation is defined as a foldl' over the input list, which makes
 -- it a good consumer in list fusion.
+
+-- Note [IntMap folds]
+-- ~~~~~~~~~~~~~~~~~~~
+-- Folds on IntMap are defined in a particular way for a few reasons.
+--
+-- foldl' :: (a -> b -> a) -> a -> IntMap b -> a
+-- foldl' f z = \t ->
+--   case t of
+--     Nil -> z
+--     Bin p l r
+--       | signBranch p -> go (go z r) l
+--       | otherwise -> go (go z l) r
+--     _ -> go z t
+--   where
+--     go !_ Nil         = error "foldl'.go: Nil"
+--     go z' (Tip _ x)   = f z' x
+--     go z' (Bin _ l r) = go (go z' l) r
+-- {-# INLINE foldl' #-}
+--
+-- 1. We first check if the Bin separates negative and positive keys, and fold
+--    over the children accordingly. This check is not inside `go` because it
+--    can only happen at the top level and we don't need to check every Bin.
+-- 2. We also check for Nil at the top level instead of, say, `go z Nil = z`.
+--    That's because `Nil` is also allowed only at the top-level, but more
+--    importantly it allows for better optimizations if the `Nil` branch errors
+--    in `go`. For example, if we have
+--      maximum :: Ord a => IntMap a -> Maybe a
+--      maximum = foldl' (\m x -> Just $! maybe x (max x) m) Nothing
+--    because `go` certainly returns a `Just` (or errors), CPR analysis will
+--    optimize it to return `(# a #)` instead of `Maybe a`. This makes it
+--    satisfy the conditions for SpecConstr, which generates two specializations
+--    of `go` for `Nothing` and `Just` inputs. Now both `Maybe`s have been
+--    optimized out of `go`.
+-- 3. The `Tip` is not matched on at the top-level to avoid using `f` more than
+--    once. This allows `f` to be inlined into `go` even if `f` is big, since
+--    it's likely to be the only place `f` is used, and not inlining `f` means
+--    missing out on optimizations. See GHC #25259 for more on this.


### PR DESCRIPTION
Move the Nil branch to the top-level and error on Nil in go.
The Note [IntMap folds] added in Data.IntMap.Internal explains the details.

---

Benchmarks on GHC 9.10.1:

IntMap:

```
Name                                  Time - - - - - - - -    Allocated - - - - -
                                           A       B     %         A       B     %
folds with key.foldMap_elem            14 μs   14 μs   +0%     34 B    33 B    -2%
folds with key.foldMap_traverseSum     17 μs   12 μs  -30%     64 KB   42 B   -99%
folds with key.foldl'_maximum          30 μs   18 μs  -41%    128 KB   64 KB  -49%
folds with key.foldl'_sum              12 μs   12 μs   +0%     45 B    44 B    -2%
folds with key.foldl_cpsOneShotSum     36 μs   34 μs   -5%    320 KB  320 KB   +0%
folds with key.foldl_cpsSum            75 μs   34 μs  -54%    608 KB  320 KB  -47%
folds with key.foldl_elem              18 μs   19 μs   +2%    128 KB  128 KB   +0%
folds with key.foldl_traverseSum       66 μs   24 μs  -63%    480 KB  160 KB  -66%
folds with key.foldr'_maximum          26 μs   14 μs  -46%     65 B    60 B    -7%
folds with key.foldr'_sum              12 μs   12 μs   +0%     45 B    44 B    -2%
folds with key.foldr_cpsOneShotSum     36 μs   35 μs   -2%    320 KB  320 KB   +0%
folds with key.foldr_cpsSum            75 μs   34 μs  -54%    608 KB  320 KB  -47%
folds with key.foldr_elem              18 μs   18 μs   +0%    128 KB  128 KB   +0%
folds with key.foldr_traverseSum       66 μs   24 μs  -63%    480 KB  160 KB  -66%
folds.foldMap_elem                     14 μs   14 μs   +1%     36 B    28 B   -22%
folds.foldMap_traverseSum              17 μs   10 μs  -42%     64 KB   44 B   -99%
folds.foldl'_maximum                   28 μs   14 μs  -51%     64 KB   44 B   -99%
folds.foldl'_sum                       10 μs   10 μs   -2%     44 B    44 B    +0%
folds.foldl_cpsOneShotSum              35 μs   34 μs   -4%    288 KB  288 KB   +0%
folds.foldl_cpsSum                     61 μs   34 μs  -44%    416 KB  288 KB  -30%
folds.foldl_elem                       18 μs   18 μs   +2%    128 KB  128 KB   +0%
folds.foldl_traverseSum                51 μs   24 μs  -52%    288 KB  160 KB  -44%
folds.foldr'_maximum                   26 μs   12 μs  -51%     49 B    44 B   -10%
folds.foldr'_sum                       10 μs   10 μs   +0%     41 B    44 B    +7%
folds.foldr_cpsOneShotSum              35 μs   35 μs   +0%    288 KB  288 KB   +0%
folds.foldr_cpsSum                     61 μs   35 μs  -43%    416 KB  288 KB  -30%
folds.foldr_elem                       17 μs   18 μs   +4%    128 KB  128 KB   +0%
folds.foldr_traverseSum                51 μs   24 μs  -52%    288 KB  160 KB  -44%
```

IntSet:

```
Name                                Time - - - - - - - -    Allocated - - - - -
                                         A       B     %         A       B     %
folds:dense.foldMap_elem            5.3 μs  5.4 μs   +1%     26 B    26 B    +0%
folds:dense.foldMap_traverseSum     4.5 μs  4.4 μs   -2%    1.0 KB   42 B   -96%
folds:dense.foldl'_maximum          5.1 μs  4.9 μs   -3%    2.1 KB  2.1 KB   +0%
folds:dense.foldl'_sum              4.3 μs  4.4 μs   +1%     42 B    42 B    +0%
folds:dense.foldl_cpsOneShotSum     5.7 μs  6.1 μs   +7%    2.5 KB  2.5 KB   +0%
folds:dense.foldl_cpsSum            6.2 μs  6.1 μs   +0%    5.1 KB  2.5 KB  -49%
folds:dense.foldl_elem              5.6 μs  5.6 μs   +0%    2.0 KB  2.0 KB   +0%
folds:dense.foldl_traverseSum       5.9 μs  5.8 μs   -2%    5.1 KB  2.6 KB  -49%
folds:dense.foldr'_maximum          6.1 μs  5.9 μs   -4%    2.1 KB  2.1 KB   +0%
folds:dense.foldr'_sum              5.5 μs  5.5 μs   +1%     42 B    42 B    +0%
folds:dense.foldr_cpsOneShotSum     5.6 μs  5.6 μs   +0%    2.5 KB  2.5 KB   +0%
folds:dense.foldr_cpsSum            5.8 μs  5.6 μs   -4%    5.1 KB  2.5 KB  -49%
folds:dense.foldr_elem              4.8 μs  4.8 μs   +0%    2.0 KB  2.0 KB   +0%
folds:dense.foldr_traverseSum       4.8 μs  4.6 μs   -4%    5.1 KB  2.6 KB  -49%
folds:sparse.foldMap_elem            18 μs   19 μs   +7%     33 B    33 B    +0%
folds:sparse.foldMap_traverseSum     19 μs   14 μs  -28%     64 KB   49 B   -99%
folds:sparse.foldl'_maximum          34 μs   23 μs  -31%    128 KB  128 KB   +0%
folds:sparse.foldl'_sum              14 μs   14 μs   +1%     44 B    44 B    +0%
folds:sparse.foldl_cpsOneShotSum     38 μs   35 μs   -8%    160 KB  160 KB   +0%
folds:sparse.foldl_cpsSum            60 μs   34 μs  -42%    320 KB  160 KB  -49%
folds:sparse.foldl_elem              29 μs   30 μs   +1%    128 KB  128 KB   +0%
folds:sparse.foldl_traverseSum       54 μs   34 μs  -36%    320 KB  160 KB  -49%
folds:sparse.foldr'_maximum          40 μs   30 μs  -24%     75 B    64 KB  +87346%
folds:sparse.foldr'_sum              24 μs   24 μs   +0%     49 B    49 B    +0%
folds:sparse.foldr_cpsOneShotSum     29 μs   25 μs  -15%    160 KB  160 KB   +0%
folds:sparse.foldr_cpsSum            54 μs   25 μs  -53%    320 KB  160 KB  -50%
folds:sparse.foldr_elem              20 μs   20 μs   +2%    128 KB  128 KB   +0%
folds:sparse.foldr_traverseSum       45 μs   24 μs  -46%    320 KB  160 KB  -49%
```

The `maximum` benchmarks are new. I was not expecting this, but it also benefits `cpsSum` and `traverseSum` benchmarks.