### PR TITLE
Add light weight union ptr equality check 

### DIFF
--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -831,7 +831,8 @@ unions = Foldable.foldl' union empty
 -- | \(O\bigl(m \log\bigl(\frac{n}{m}+1\bigr)\bigr), \; 0 < m \leq n\). The union of two sets, preferring the first set when
 -- equal elements are encountered.
 union :: Ord a => Set a -> Set a -> Set a
-union t1 Tip  = t1
+union t1 t2 | t1 `ptrEq` t2 = t1
+union t1 Tip = t1
 union t1 (Bin 1 x _ _) = insertR x t1
 union (Bin 1 x _ _) t2 = insert x t2
 union Tip t2  = t2

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -836,10 +836,8 @@ union t1 Tip = t1
 union t1 (Bin 1 x _ _) = insertR x t1
 union (Bin 1 x _ _) t2 = insert x t2
 union Tip t2  = t2
-union t1@(Bin _ x l1 r1) t2 = case splitS x t2 of
-  (l2 :*: r2)
-    | l1l2 `ptrEq` l1 && r1r2 `ptrEq` r1 -> t1
-    | otherwise -> link x l1l2 r1r2
+union (Bin _ x l1 r1) t2 = case splitS x t2 of
+  (l2 :*: r2) -> link x l1l2 r1r2
     where !l1l2 = union l1 l2
           !r1r2 = union r1 r2
 #if __GLASGOW_HASKELL__


### PR DESCRIPTION
It's not unusual when building compilers to do transformations which require collecting sets over an AST – but you'll often need to do branching and unions across very similar sets, for example, one side added 2 items into a set of 1000. This is currently quite slow.

Adding a light weight pointer equality check can actually help quite a lot in these cases.

If I add some small additional benchmarks to union as such:
```haskell
defaultMain
      [ bench "union_same" $ whnf (S.union s_even) s_even
      , bench "union_minor_diff" $ whnf (S.union s_even) (S.insert 1 s_even)
      , bench "union" $ whnf (S.union s_even) s_odd
      ]
```


I'll see these results:

```
Before:
  union_same:       OK
    11.4 μs ± 863 ns
  union_minor_diff: OK
    11.3 μs ± 850 ns
  union:            OK
    77.9 μs ± 7.0 μs

After:
  union_same:       OK
    2.02 ns ± 138 ps
  union_minor_diff: OK
    137  ns ± 7.2 ns
  union:            OK
    77.4 μs ± 6.9 μs
```






