### PR TITLE
Add `catMaybes` and `mapMaybe` to sets, maps and `Seq`

### DIFF
--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -18,7 +18,7 @@ import Control.Monad ((<=<))
 import qualified Data.Either as Either
 import qualified Data.Foldable as Foldable
 import Data.Monoid
-import Data.Maybe hiding (mapMaybe)
+import Data.Maybe hiding (catMaybes, mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
 import Data.Ord
 import Data.Foldable (foldMap)
@@ -110,6 +110,7 @@ main = defaultMain $ testGroup "intmap-properties"
              , testCase "filterWithKey" test_filterWithKey
              , testCase "partition" test_partition
              , testCase "partitionWithKey" test_partitionWithKey
+             , testCase "catMaybes" test_catMaybes
              , testCase "mapMaybe" test_mapMaybe
              , testCase "mapMaybeWithKey" test_mapMaybeWithKey
              , testCase "mapEither" test_mapEither
@@ -189,6 +190,8 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "filterKeys"           prop_filterKeys
              , testProperty "filterWithKey"        prop_filterWithKey
              , testProperty "partition"            prop_partition
+             , testProperty "catMaybes"            prop_catMaybes
+             , testProperty "mapMaybe"             prop_mapMaybe
              , testProperty "takeWhileAntitone"    prop_takeWhileAntitone
              , testProperty "dropWhileAntitone"    prop_dropWhileAntitone
              , testProperty "spanAntitone"         prop_spanAntitone
@@ -940,6 +943,10 @@ test_partitionWithKey = do
     partitionWithKey (\ k _ -> k < 7) (fromList [(5,"a"), (-3,"b")]) @?= (fromList [(-3, "b"), (5, "a")], empty)
     partitionWithKey (\ k _ -> k > 7) (fromList [(5,"a"), (-3,"b")]) @?= (empty, fromList [(-3, "b"), (5, "a")])
 
+test_catMaybes :: Assertion
+test_catMaybes = do
+    catMaybes (fromList [(5,Just "a"), (3,Nothing)])  @?= singleton 5 "a"
+
 test_mapMaybe :: Assertion
 test_mapMaybe = do
     mapMaybe f (fromList [(5,"a"), (3,"b")])  @?= singleton 5 "new a"
@@ -1551,6 +1558,20 @@ prop_filterWithKey fun m =
   valid m' .&&. toList m' === Prelude.filter (apply fun) (toList m)
   where
     m' = filterWithKey (applyFun2 fun) m
+
+prop_catMaybes :: IntMap (Maybe A) -> Property
+prop_catMaybes m =
+  valid m' .&&.
+  toList m' === Maybe.mapMaybe (\(k,x) -> (,) k <$> x) (toList m)
+  where
+    m' = catMaybes m
+
+prop_mapMaybe :: Fun Int (Maybe Bool) -> IMap -> Property
+prop_mapMaybe f m =
+  valid m' .&&.
+  toList m' === Maybe.mapMaybe (\(k,x) -> (,) k <$> applyFun f x) (toList m)
+  where
+    m' = mapMaybe (applyFun f) m
 
 prop_partition :: Fun Int Bool -> [(Int, Int)] -> Property
 prop_partition p ys = length ys > 0 ==>

--- a/containers-tests/tests/intmap-strictness.hs
+++ b/containers-tests/tests/intmap-strictness.hs
@@ -618,6 +618,12 @@ prop_lazyMapKeysWith fun kfun m = isNotBottomProp (L.mapKeysWith f kf m)
     f = coerce (applyFunc2 fun) :: A -> A -> A
     kf = applyFunc kfun
 
+prop_strictCatMaybes :: IntMap (Maybe (Bot A)) -> Property
+prop_strictCatMaybes m = isBottom (M.catMaybes m) === isBottom (M.mapMaybe id m)
+
+prop_lazyCatMaybes :: IntMap (Maybe (Bot A)) -> Property
+prop_lazyCatMaybes m = isNotBottomProp (L.catMaybes m)
+
 prop_strictMapMaybe :: Func A (Maybe (Bot B)) -> IntMap A -> Property
 prop_strictMapMaybe fun m =
   isBottom (M.mapMaybe f m) === isBottom (M.mapMaybeWithKey (const f) m)
@@ -1050,6 +1056,7 @@ tests =
       , testPropStrictLazy "mapAccumWithKey" prop_strictMapAccumWithKey prop_lazyMapAccumWithKey
       , testPropStrictLazy "mapAccumRWithKey" prop_strictMapAccumRWithKey prop_lazyMapAccumRWithKey
       , testPropStrictLazy "mapKeysWith" prop_strictMapKeysWith prop_lazyMapKeysWith
+      , testPropStrictLazy "catMaybes" prop_strictCatMaybes prop_lazyCatMaybes
       , testPropStrictLazy "mapMaybe" prop_strictMapMaybe prop_lazyMapMaybe
       , testPropStrictLazy "mapMaybeWithKey" prop_strictMapMaybeWithKey prop_lazyMapMaybeWithKey
       , testPropStrictLazy "mapEither" prop_strictMapEither prop_lazyMapEither

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -6,6 +6,7 @@ import Data.IntSet
 import Data.List (nub,sort)
 import qualified Data.List as List
 import Data.Maybe (listToMaybe)
+import qualified Data.Maybe as Maybe
 import Data.Monoid (mempty)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
@@ -79,6 +80,7 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "prop_splitRoot" prop_splitRoot
                    , testProperty "prop_partition" prop_partition
                    , testProperty "prop_filter" prop_filter
+                   , testProperty "prop_mapMaybe" prop_mapMaybe
                    , testProperty "takeWhileAntitone" prop_takeWhileAntitone
                    , testProperty "dropWhileAntitone" prop_dropWhileAntitone
                    , testProperty "spanAntitone" prop_spanAntitone
@@ -456,6 +458,12 @@ prop_filter s i =
   in valid odds .&&.
      valid evens .&&.
      parts === (odds, evens)
+
+prop_mapMaybe :: IntSet -> Property
+prop_mapMaybe s =
+  let f n = if odd n then Just n else Nothing
+      odds = mapMaybe f s
+  in valid odds .&&. toList odds === Maybe.mapMaybe f (toList s)
 
 prop_takeWhileAntitone :: Int -> [Int] -> Property
 prop_takeWhileAntitone x ys =

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -18,7 +18,7 @@ import Control.Monad ((<=<))
 import qualified Data.Either as Either
 import Data.Functor.Identity (Identity(Identity, runIdentity))
 import Data.Monoid
-import Data.Maybe hiding (mapMaybe)
+import Data.Maybe hiding (catMaybes, mapMaybe)
 import qualified Data.Maybe as Maybe (mapMaybe)
 import Data.Ord
 import Data.Semigroup (Arg(..))
@@ -124,6 +124,7 @@ main = defaultMain $ testGroup "map-properties"
          , testCase "filterWithKey" test_filterWithKey
          , testCase "partition" test_partition
          , testCase "partitionWithKey" test_partitionWithKey
+         , testCase "catMaybes" test_catMaybes
          , testCase "mapMaybe" test_mapMaybe
          , testCase "mapMaybeWithKey" test_mapMaybeWithKey
          , testCase "mapEither" test_mapEither
@@ -296,6 +297,7 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "differenceWith"       prop_differenceWith
          , testProperty "differenceWithKey"    prop_differenceWithKey
          , testProperty "partitionWithKey"     prop_partitionWithKey
+         , testProperty "catMaybes"            prop_catMaybes
          , testProperty "mapMaybe"             prop_mapMaybe
          , testProperty "mapMaybeWithKey"      prop_mapMaybeWithKey
          , testProperty "traverseMaybeWithKey" prop_traverseMaybeWithKey
@@ -861,6 +863,9 @@ test_partitionWithKey = do
     partitionWithKey (\ k _ -> k > 3) (fromList [(5,"a"), (3,"b")]) @?= (singleton 5 "a", singleton 3 "b")
     partitionWithKey (\ k _ -> k < 7) (fromList [(5,"a"), (3,"b")]) @?= (fromList [(3, "b"), (5, "a")], empty)
     partitionWithKey (\ k _ -> k > 7) (fromList [(5,"a"), (3,"b")]) @?= (empty, fromList [(3, "b"), (5, "a")])
+
+test_catMaybes :: Assertion
+test_catMaybes = catMaybes (fromList [(5,Just "a"), (3,Nothing)]) @?= singleton 5 "a"
 
 test_mapMaybe :: Assertion
 test_mapMaybe = mapMaybe f (fromList [(5,"a"), (3,"b")]) @?= singleton 5 "new a"
@@ -1959,6 +1964,13 @@ prop_partitionWithKey f m =
   (toList m1, toList m2) === List.partition (applyFun f) (toList m)
   where
     (m1, m2) = partitionWithKey (applyFun2 f) m
+
+prop_catMaybes :: Map Int (Maybe A) -> Property
+prop_catMaybes m =
+  valid m' .&&.
+  toList m' === Maybe.mapMaybe (\(k,x) -> (,) k <$> x) (toList m)
+  where
+    m' = catMaybes m
 
 prop_mapMaybe :: Fun A (Maybe B) -> Map Int A -> Property
 prop_mapMaybe f m =

--- a/containers-tests/tests/map-strictness.hs
+++ b/containers-tests/tests/map-strictness.hs
@@ -755,6 +755,12 @@ prop_lazyMapKeysWith fun kfun m = isNotBottomProp (L.mapKeysWith f kf m)
     f = coerce (applyFunc2 fun) :: A -> A -> A
     kf = applyFunc kfun
 
+prop_strictCatMaybes :: Map OrdA (Maybe (Bot A)) -> Property
+prop_strictCatMaybes m = isBottom (M.catMaybes m) === isBottom (M.mapMaybe id m)
+
+prop_lazyCatMaybes :: Map OrdA (Maybe (Bot A)) -> Property
+prop_lazyCatMaybes m = isNotBottomProp (L.catMaybes m)
+
 prop_strictMapMaybe :: Func A (Maybe (Bot B)) -> Map OrdA A -> Property
 prop_strictMapMaybe fun m =
   isBottom (M.mapMaybe f m) === isBottom (M.mapMaybeWithKey (const f) m)
@@ -1193,6 +1199,7 @@ tests =
       , testPropStrictLazy "mapAccumWithKey" prop_strictMapAccumWithKey prop_lazyMapAccumWithKey
       , testPropStrictLazy "mapAccumRWithKey" prop_strictMapAccumRWithKey prop_lazyMapAccumRWithKey
       , testPropStrictLazy "mapKeysWith" prop_strictMapKeysWith prop_lazyMapKeysWith
+      , testPropStrictLazy "catMaybes" prop_strictCatMaybes prop_lazyCatMaybes
       , testPropStrictLazy "mapMaybe" prop_strictMapMaybe prop_lazyMapMaybe
       , testPropStrictLazy "mapMaybeWithKey" prop_strictMapMaybeWithKey prop_lazyMapMaybeWithKey
       , testPropStrictLazy "mapEither" prop_strictMapEither prop_lazyMapEither

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -24,7 +24,8 @@ import Data.Array (listArray)
 import Data.Coerce (coerce)
 import Data.Foldable (Foldable(foldl, foldl1, foldr, foldr1, foldMap, fold), toList, all, sum, foldl', foldr')
 import Data.Functor ((<$>), (<$))
-import Data.Maybe
+import Data.Maybe (listToMaybe)
+import qualified Data.Maybe as Maybe
 import Data.Function (on)
 import Data.Monoid (Monoid(..), All(..), Endo(..), Dual(..))
 import Data.Semigroup (stimes, stimesMonoid)
@@ -100,6 +101,8 @@ main = defaultMain $ testGroup "seq-properties"
        , testProperty "breakr" prop_breakr
        , testProperty "partition" prop_partition
        , testProperty "filter" prop_filter
+       , testProperty "catMaybes" prop_catMaybes
+       , testProperty "mapMaybe" prop_mapMaybe
        , testProperty "sort" prop_sort
        , testProperty "sortStable" prop_sortStable
        , testProperty "sortBy" prop_sortBy
@@ -552,6 +555,15 @@ prop_filter :: Positive Int -> Seq Int -> Bool
 prop_filter (Positive n) xs =
     toList' (filter p xs) ~= Prelude.filter p (toList xs)
   where p x = x `mod` n == 0
+
+prop_catMaybes :: Seq (Maybe Int) -> Bool
+prop_catMaybes xs =
+    toList' (catMaybes xs) ~= Maybe.catMaybes (toList xs)
+
+prop_mapMaybe :: Positive Int -> Seq Int -> Bool
+prop_mapMaybe (Positive n) xs =
+    toList' (mapMaybe f xs) ~= Maybe.mapMaybe f (toList xs)
+  where f x = if x `mod` n == 0 then Just x else Nothing
 
 -- * Sorting
 

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -250,6 +250,7 @@ module Data.IntMap.Internal (
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -2876,6 +2877,15 @@ spanAntitone predicate t =
       | predicate' ky = (t' :*: Nil)
       | otherwise     = (Nil :*: t')
     go _ Nil = (Nil :*: Nil)
+
+-- | \(O(n)\). Remove 'Nothing's and retain the 'Just' values.
+--
+-- > catMaybes (fromList [(5,Just "a"), (3,Nothing)]) == singleton 5 "a"
+--
+-- @since FIXME
+
+catMaybes :: IntMap (Maybe a) -> IntMap a
+catMaybes = mapMaybe id
 
 -- | \(O(n)\). Map values and collect the 'Just' results.
 --

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -234,6 +234,7 @@ module Data.IntMap.Lazy (
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -252,6 +252,7 @@ module Data.IntMap.Strict (
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -195,6 +195,7 @@ module Data.IntMap.Strict.Internal (
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -989,6 +990,15 @@ mapKeysWith c f t =
 {--------------------------------------------------------------------
   Filter
 --------------------------------------------------------------------}
+-- | \(O(n)\). Remove 'Nothing's and retain the 'Just' values.
+--
+-- > catMaybes (fromList [(5,Just "a"), (3,Nothing)]) == singleton 5 "a"
+--
+-- @since FIXME
+
+catMaybes :: IntMap (Maybe a) -> IntMap a
+catMaybes = mapMaybe id
+
 -- | \(O(n)\). Map values and collect the 'Just' results.
 --
 -- > let f x = if x == "a" then Just "new a" else Nothing

--- a/containers/src/Data/IntSet.hs
+++ b/containers/src/Data/IntSet.hs
@@ -145,6 +145,8 @@ module Data.IntSet (
             , dropWhileAntitone
             , spanAntitone
 
+            , mapMaybe
+
             , split
             , splitMember
             , splitRoot

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -134,6 +134,8 @@ module Data.IntSet.Internal (
     , dropWhileAntitone
     , spanAntitone
 
+    , mapMaybe
+
     , split
     , splitMember
     , splitRoot
@@ -879,6 +881,18 @@ filter predicate t
   where bitPred kx bm bi | predicate (kx + bi) = bm .|. bitmapOfSuffix bi
                          | otherwise           = bm
         {-# INLINE bitPred #-}
+
+-- | \( O(n \log n) \). Map values and collect the 'Just' results.
+--
+-- If the function is monotonically non-decreasing or monotonically
+-- non-increasing, 'mapMaybe' takes \(O(n)\) time.
+--
+-- @since FIXME
+mapMaybe :: (Key -> Maybe Key) -> IntSet -> IntSet
+mapMaybe f t = finishB (foldl' go emptyB t)
+  where go b x = case f x of
+          Nothing -> b
+          Just x' -> insertB x' b
 
 -- | \(O(n)\). partition the set according to some predicate.
 partition :: (Key -> Bool) -> IntSet -> (IntSet,IntSet)

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -304,6 +304,7 @@ module Data.Map.Internal (
     , partition
     , partitionWithKey
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -3113,6 +3114,15 @@ partitionWithKey p0 t0 = toPair $ go p0 t0
       where
         (l1 :*: l2) = go p l
         (r1 :*: r2) = go p r
+
+-- | \(O(n)\). Remove 'Nothing's and retain the 'Just' values.
+--
+-- > catMaybes (fromList [(5,Just "a"), (3,Nothing)]) == singleton 5 "a"
+--
+-- @since FIXME
+
+catMaybes :: Map k (Maybe a) -> Map k a
+catMaybes = mapMaybe id
 
 -- | \(O(n)\). Map values and collect the 'Just' results.
 --

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -247,6 +247,7 @@ module Data.Map.Lazy (
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -262,6 +262,7 @@ module Data.Map.Strict
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -246,6 +246,7 @@ module Data.Map.Strict.Internal
     , dropWhileAntitone
     , spanAntitone
 
+    , catMaybes
     , mapMaybe
     , mapMaybeWithKey
     , mapEither
@@ -1245,6 +1246,15 @@ mergeWithKey f g1 g2 = go
 {--------------------------------------------------------------------
   Filter and partition
 --------------------------------------------------------------------}
+
+-- | \(O(n)\). Remove 'Nothing's and retain the 'Just' values.
+--
+-- > catMaybes (fromList [(5,Just "a"), (3,Nothing)]) == singleton 5 "a"
+--
+-- @since FIXME
+
+catMaybes :: Map k (Maybe a) -> Map k a
+catMaybes = mapMaybe id
 
 -- | \(O(n)\). Map values and collect the 'Just' results.
 --

--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -192,6 +192,8 @@ module Data.Sequence (
     breakr,         -- :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
     partition,      -- :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
     filter,         -- :: (a -> Bool) -> Seq a -> Seq a
+    catMaybes,      -- :: Seq (Maybe a) -> Seq a
+    mapMaybe,       -- :: (a -> Maybe b) -> Seq a -> Seq b
     -- * Sorting
     sort,           -- :: Ord a => Seq a -> Seq a
     sortBy,         -- :: (a -> a -> Ordering) -> Seq a -> Seq a

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -128,6 +128,8 @@ module Data.Sequence.Internal (
     breakr,         -- :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
     partition,      -- :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
     filter,         -- :: (a -> Bool) -> Seq a -> Seq a
+    catMaybes,      -- :: Seq (Maybe a) -> Seq a
+    mapMaybe,       -- :: (a -> Maybe b) -> Seq a -> Seq b
     -- * Indexing
     lookup,         -- :: Int -> Seq a -> Maybe a
     (!?),           -- :: Seq a -> Int -> Maybe a
@@ -4198,6 +4200,22 @@ partition p = toPair . foldl' part (empty :*: empty)
 -- predicate.
 filter :: (a -> Bool) -> Seq a -> Seq a
 filter p = foldl' (\ xs x -> if p x then xs `snoc'` x else xs) empty
+
+-- | \( O(n) \). Take a sequence of 'Maybe's and return a sequence of all the
+-- 'Just' values.
+--
+-- @since FIXME
+catMaybes :: Seq (Maybe a) -> Seq a
+catMaybes = mapMaybe id
+
+-- | \( O(n) \). Map values and collect the 'Just' results.
+--
+-- @since FIXME
+mapMaybe :: (a -> Maybe b) -> Seq a -> Seq b
+mapMaybe f = foldl' go empty
+  where go xs x = case f x of
+          Nothing -> xs
+          Just x' -> xs `snoc'` x'
 
 -- Indexing sequences
 

--- a/containers/src/Data/Set.hs
+++ b/containers/src/Data/Set.hs
@@ -137,6 +137,8 @@ module Data.Set (
             , takeWhileAntitone
             , dropWhileAntitone
             , spanAntitone
+            , catMaybes
+            , mapMaybe
             , partition
             , split
             , splitMember

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -162,6 +162,8 @@ module Data.Set.Internal (
             , takeWhileAntitone
             , dropWhileAntitone
             , spanAntitone
+            , catMaybes
+            , mapMaybe
             , partition
             , split
             , splitMember
@@ -239,6 +241,7 @@ import Data.Functor.Identity (Identity)
 import qualified Data.Foldable as Foldable
 import Control.DeepSeq (NFData(rnf),NFData1(liftRnf))
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Maybe as Maybe
 
 import Utils.Containers.Internal.StrictPair
 import Utils.Containers.Internal.PtrEquality
@@ -992,6 +995,25 @@ partition p0 t0 = toPair $ go p0 t0
                        (if l2 `ptrEq` l && r2 `ptrEq` r
                         then t
                         else link x l2 r2)
+
+{--------------------------------------------------------------------
+  Maybes
+--------------------------------------------------------------------}
+
+-- | \(O(n)\). Drop 'Nothing' if it's in the set, and retain the 'Just' values.
+--
+-- @since FIXME
+catMaybes :: Set (Maybe a) -> Set a
+catMaybes = mapMonotonic Maybe.fromJust . dropWhileAntitone Maybe.isNothing
+
+-- | \(O(n \log n)\). Map values and collect the 'Just' results.
+--
+-- If the function is monotonically non-decreasing, this function takes \(O(n)\)
+-- time.
+--
+-- @since FIXME
+mapMaybe :: Ord b => (a -> Maybe b) -> Set a -> Set b
+mapMaybe f = fromList . Maybe.mapMaybe f . toList
 
 {----------------------------------------------------------------------
   Map


### PR DESCRIPTION
As discussed in #346. We now have `mapMaybe` in all of `Seq`, `Set`, `IntSet`, strict and lazy `Map`, and strict and lazy `IntMap`. And `catMaybes` in all of those except `IntSet` (where it doesn't make sense). The issue doesn't mention all of them, but I figured it would be good to have a consistent API.