### PR TITLE
Fix Haddock documentation for fromAscListWithKey functions

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -3466,7 +3466,7 @@ fromListWith f xs
   = fromListWithKey (\_ x y -> f x y) xs
 {-# INLINE fromListWith #-} -- Inline for list fusion
 
--- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also fromAscListWithKey'.
+-- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWithKey'.
 --
 -- If the keys are in sorted order, ascending or descending, this function
 -- takes \(O(n)\) time.
@@ -3498,7 +3498,7 @@ fromAscList xs =
 {-# INLINE fromAscList #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
--- the keys are in ascending order, with a combining function on equal keys.
+-- the keys are in ascending order, with a combining function for equal keys.
 --
 -- __Warning__: This function should be used only if the keys are in
 -- non-decreasing order. This precondition is not checked. Use 'fromListWith' if
@@ -3513,14 +3513,16 @@ fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
 {-# INLINE fromAscListWith #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
--- the keys are in ascending order, with a combining function on equal keys.
+-- the keys are in ascending order, with a combining function that receives
+-- the key for equal keys.
 --
 -- __Warning__: This function should be used only if the keys are in
 -- non-decreasing order. This precondition is not checked. Use 'fromListWithKey'
 -- if the precondition may not hold.
 --
--- > let f key new_value old_value = (show key) ++ ":" ++ new_value ++ "|" ++ old_value
--- > fromAscListWithKey f [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "5:b|a")]
+-- > let f key new_value old_value = show key ++ ":" ++ new_value ++ "|" ++ old_value
+-- > fromAscListWithKey f [(3,"b"), (3,"a"), (5,"a"), (5,"b"), (5,"c")] == fromList [(3, "3:a|b"), (5, "5:c|5:b|a")]
+-- > fromAscListWithKey f [] == empty
 --
 -- Also see the performance note on 'fromListWith'.
 

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -1136,7 +1136,7 @@ fromListWith f xs
   = fromListWithKey (\_ x y -> f x y) xs
 {-# INLINE fromListWith #-} -- Inline for list fusion
 
--- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also fromAscListWithKey'.
+-- | \(O(n \min(n,W))\). Build a map from a list of key\/value pairs with a combining function. See also 'fromAscListWithKey'.
 --
 -- If the keys are in sorted order, ascending or descending, this function
 -- takes \(O(n)\) time.
@@ -1167,7 +1167,7 @@ fromAscList xs = fromAscListWithKey (\_ x _ -> x) xs
 {-# INLINE fromAscList #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
--- the keys are in ascending order, with a combining function on equal keys.
+-- the keys are in ascending order, with a combining function for equal keys.
 --
 -- __Warning__: This function should be used only if the keys are in
 -- non-decreasing order. This precondition is not checked. Use 'fromListWith' if
@@ -1182,13 +1182,16 @@ fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
 {-# INLINE fromAscListWith #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
--- the keys are in ascending order, with a combining function on equal keys.
+-- the keys are in ascending order, with a combining function that receives
+-- the key for equal keys.
 --
 -- __Warning__: This function should be used only if the keys are in
 -- non-decreasing order. This precondition is not checked. Use 'fromListWithKey'
 -- if the precondition may not hold.
 --
--- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
+-- > let f key new_value old_value = show key ++ ":" ++ new_value ++ "|" ++ old_value
+-- > fromAscListWithKey f [(3,"b"), (3,"a"), (5,"a"), (5,"b"), (5,"c")] == fromList [(3, "3:a|b"), (5, "5:c|5:b|a")]
+-- > fromAscListWithKey f [] == empty
 --
 -- Also see the performance note on 'fromListWith'.
 


### PR DESCRIPTION
**Overview**
This PR fixes Haddock documentation issues in the `fromAscListWithKey` function documentation.

**Correction details**
- Fix missing backticks in 'fromAscListWithKey' reference in `fromListWithKey` documentation
- Improve English phrasing: "on equal keys" → "for equal keys"
- Clarify that the combining function receives the key: "with a combining function that receives the key for equal keys"
- Enhance examples with more comprehensive test cases including empty list
- Apply consistent changes to both Strict and Lazy versions

**Modified files**
- `containers/src/Data/IntMap/Internal.hs`
- `containers/src/Data/IntMap/Strict/Internal.hs`

**Test**
- [x] Documentation builds without errors
- [x] Changes are consistent between Strict and Lazy versions
- [x] Examples are syntactically correct

This is my first OSS contribution and I'm not a native English speaker. Please let me know if there are any issues with the documentation changes.

Fixes #1154 