### PR TITLE
Switch from template-haskell to template-haskell-lift

### DIFF
--- a/containers-tests/containers-tests.cabal
+++ b/containers-tests/containers-tests.cabal
@@ -38,7 +38,11 @@ common deps
       array    >=0.4.0.0
     , base     >=4.10    && <5
     , deepseq >= 1.4.3.0 && < 1.6
-    , template-haskell
+
+  if impl(ghc >= 9.14)
+      build-depends: template-haskell-lift >= 0.1 && <0.2
+  elif impl(ghc)
+      build-depends: template-haskell
 
 common warnings
   ghc-options:

--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -46,14 +46,18 @@ import Control.DeepSeq (deepseq)
 import Control.Monad.Fix (MonadFix (..))
 import Test.Tasty.HUnit
 import Test.ChasingBottoms.IsBottom (isBottom)
+#if __GLASGOW_HASKELL__ >= 914
+import qualified Language.Haskell.TH.Lift as TH
+#else
 import qualified Language.Haskell.TH.Syntax as TH
+#endif
 
 import Utils.Strictness (Bot(..), Func2, applyFunc2)
 
 main :: IO ()
 main = defaultMain $ testGroup "seq-properties"
        [ test_lift
-#if MIN_VERSION_template_haskell(2,16,0)
+#if __GLASGOW_HASKELL__ >= 810
        , test_liftTyped
 #endif
        , testProperty "fmap" prop_fmap
@@ -987,7 +991,7 @@ test_lift = testCase "lift" $ do
   (mempty :: Seq Int) @=? $([| $(TH.lift (fromList [] :: Seq Integer)) |])
   fromList [1..3 :: Int] @=? $([| $(TH.lift (fromList [1..3 :: Integer])) |])
 
-#if MIN_VERSION_template_haskell(2,16,0)
+#if __GLASGOW_HASKELL__ >= 810
 test_liftTyped :: TestTree
 test_liftTyped = testCase "liftTyped" $ do
   (mempty :: Seq Int) @=? $$([|| $$(TH.liftTyped (fromList [])) ||])

--- a/containers/containers.cabal
+++ b/containers/containers.cabal
@@ -42,7 +42,12 @@ Library
         base >= 4.10 && < 5
       , array >= 0.4.0.0
       , deepseq >= 1.4.3.0 && < 1.6
-    if impl(ghc)
+    -- template-haskell-lift was added as a boot library in GHC-9.14
+    -- once we no longer wish to backport releases to older major releases,
+    -- this conditional can be dropped
+    if impl(ghc >= 9.14)
+       build-depends: template-haskell-lift >= 0.1 && <0.2
+    elif impl(ghc)
        build-depends: template-haskell
     hs-source-dirs: src
     ghc-options: -O2 -Wall

--- a/containers/src/Data/Graph.hs
+++ b/containers/src/Data/Graph.hs
@@ -143,9 +143,13 @@ import Data.Semigroup (Semigroup (..))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics (Generic, Generic1)
 import Data.Data (Data)
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift(..))
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #endif
 
 -- Make sure we don't use Integer by mistake.
@@ -191,7 +195,7 @@ deriving instance Generic1 SCC
 deriving instance Generic (SCC vertex)
 
 -- There is no instance Lift (NonEmpty v) before template-haskell-2.15.
-#if MIN_VERSION_template_haskell(2,15,0)
+#if __GLASGOW_HASKELL__ > 808
 -- | @since 0.6.6
 deriving instance Lift vertex => Lift (SCC vertex)
 #else

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -358,9 +358,13 @@ import Data.Data (Data(..), Constr, mkConstr, constrIndex,
 import qualified Data.Data as Data
 import GHC.Exts (build)
 import qualified GHC.Exts as GHCExts
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #endif
 #if defined(__GLASGOW_HASKELL__) || defined(__MHS__)
 import Text.Read

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -230,9 +230,13 @@ import Data.Coerce (coerce)
 
 #if __GLASGOW_HASKELL__
 import qualified GHC.Exts
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #endif
 
 import qualified Data.Foldable as Foldable

--- a/containers/src/Data/IntSet/Internal/IntTreeCommons.hs
+++ b/containers/src/Data/IntSet/Internal/IntTreeCommons.hs
@@ -44,9 +44,13 @@ import Data.Bits (Bits(..), countLeadingZeros)
 import Utils.Containers.Internal.BitUtil (iShiftRL)
 
 #ifdef __GLASGOW_HASKELL__
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #endif
 
 

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -413,9 +413,13 @@ import Utils.Containers.Internal.BitUtil (wordSize)
 
 #if __GLASGOW_HASKELL__
 import GHC.Exts (build, lazy)
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #  ifdef USE_MAGIC_PROXY
 import GHC.Exts (Proxy#, proxy# )
 #  endif

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -214,9 +214,13 @@ import Text.Read (Lexeme(Ident), lexP, parens, prec,
 import GHC.Exts (build)
 import Data.Data
 import Data.String (IsString(..))
+#  if __GLASGOW_HASKELL__ >= 914
+import qualified Language.Haskell.TH.Lift as TH
+#  else
 import qualified Language.Haskell.TH.Syntax as TH
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 import GHC.Generics (Generic, Generic1)
 
 -- Array stuff, with GHC.Arr on GHC
@@ -331,7 +335,8 @@ newtype Seq a = Seq (FingerTree (Elem a))
 #ifdef __GLASGOW_HASKELL__
 -- | @since 0.6.6
 instance TH.Lift a => TH.Lift (Seq a) where
-#  if MIN_VERSION_template_haskell(2,16,0)
+-- template-haskell >= 2.16
+#  if __GLASGOW_HASKELL__ >= 810
   liftTyped t = [|| coerceFT z ||]
 #  else
   lift t = [| coerceFT z |]

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -255,9 +255,13 @@ import Text.Read ( readPrec, Read (..), Lexeme (..), parens, prec
 import GHC.Exts ( build, lazy )
 import qualified GHC.Exts as GHCExts
 import Data.Data
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 import Data.Coerce (coerce)
 #endif
 

--- a/containers/src/Data/Tree.hs
+++ b/containers/src/Data/Tree.hs
@@ -75,9 +75,13 @@ import Control.DeepSeq (NFData(rnf),NFData1(liftRnf))
 import Data.Data (Data)
 import GHC.Generics (Generic, Generic1)
 import qualified GHC.Exts
+#  if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#  else
 import Language.Haskell.TH.Syntax (Lift)
 -- See Note [ Template Haskell Dependencies ]
 import Language.Haskell.TH ()
+#  endif
 #endif
 
 import Control.Monad.Zip (MonadZip (..))


### PR DESCRIPTION
This new boot library should be more stable than template-haskell and
should eventually allow us to remove much of the CPP around TH.

It will also make it easier for end-users to reinstall template-haskell
as it will no longer be used by any boot libraries

This GHC MR tests this PR against GHC-HEAD: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14978