### PR TITLE
Add from{Asc,Desc}ListUpsert for Map and IntMap

### DIFF
--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -265,8 +265,10 @@ main = defaultMain $ testGroup "intmap-properties"
              , testProperty "fromAscList"          prop_fromAscList
              , testProperty "fromAscListWith"      prop_fromAscListWith
              , testProperty "fromAscListWithKey"   prop_fromAscListWithKey
+             , testProperty "fromAscListUpsert"    prop_fromAscListUpsert
              , testProperty "fromDistinctAscList"  prop_fromDistinctAscList
              , testProperty "fromDescList"         prop_fromDescList
+             , testProperty "fromDescListUpsert"   prop_fromDescListUpsert
              , testProperty "fromListWith"         prop_fromListWith
              , testProperty "fromListWithKey"      prop_fromListWithKey
              , testProperty "fromListUpsert"       prop_fromListUpsert
@@ -2173,6 +2175,14 @@ prop_fromAscListWithKey f kxs =
     sortedKxs = List.sortBy (comparing fst) kxs
     t = fromAscListWithKey (applyFun3 f) sortedKxs
 
+prop_fromAscListUpsert :: Fun (A, Maybe B) B -> [(Int, A)] -> Property
+prop_fromAscListUpsert f kxs =
+  valid t .&&.
+  t === fromListUpsert (applyFun2 f) sortedKxs
+  where
+    sortedKxs = List.sortBy (comparing fst) kxs
+    t = fromAscListUpsert (applyFun2 f) sortedKxs
+
 prop_fromDistinctAscList :: [(Int, A)] -> Property
 prop_fromDistinctAscList kxs =
   valid t .&&.
@@ -2191,6 +2201,14 @@ prop_fromDescList kxs =
   where
     sortedKxs = List.sortBy (comparing (Down . fst)) kxs
     t = fromDescList sortedKxs
+
+prop_fromDescListUpsert :: Fun (A, Maybe B) B -> [(Int, A)] -> Property
+prop_fromDescListUpsert f kxs =
+  valid t .&&.
+  t === fromListUpsert (applyFun2 f) sortedKxs
+  where
+    sortedKxs = List.sortBy (comparing (Down . fst)) kxs
+    t = fromDescListUpsert (applyFun2 f) sortedKxs
 
 prop_fromListWith :: Fun (A, A) A -> [(Int, A)] -> Property
 prop_fromListWith f kxs =

--- a/containers-tests/tests/intmap-strictness.hs
+++ b/containers-tests/tests/intmap-strictness.hs
@@ -198,6 +198,22 @@ prop_lazyFromAscListWithKey fun kvs =
     f = coerce (applyFunc3 fun)
     kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(Key, A)]
 
+prop_strictFromAscListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(Key, Bot A)] -> Property
+prop_strictFromAscListUpsert fun kvs =
+  isBottom (M.fromAscListUpsert f kvs') === isBottom (M.fromListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(Key, A)]
+
+prop_lazyFromAscListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(Key, Bot A)] -> Property
+prop_lazyFromAscListUpsert fun kvs =
+  isNotBottomProp (L.fromAscListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(Key, A)]
+
 prop_strictFromDistinctAscList :: [(Key, Bot A)] -> Property
 prop_strictFromDistinctAscList kvs =
   isBottom (M.fromDistinctAscList kvs') === isBottom (M.fromList kvs')
@@ -218,6 +234,22 @@ prop_strictFromDescList kvs =
 prop_lazyFromDescList :: [(Key, Bot A)] -> Property
 prop_lazyFromDescList kvs = isNotBottomProp (L.fromDescList kvs')
   where
+    kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(Key, A)]
+
+prop_strictFromDescListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(Key, Bot A)] -> Property
+prop_strictFromDescListUpsert fun kvs =
+  isBottom (M.fromDescListUpsert f kvs') === isBottom (M.fromListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(Key, A)]
+
+prop_lazyFromDescListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(Key, Bot A)] -> Property
+prop_lazyFromDescListUpsert fun kvs =
+  isNotBottomProp (L.fromDescListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
     kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(Key, A)]
 
 prop_strictInsert :: Key -> Bot A -> IntMap A -> Property
@@ -1075,9 +1107,11 @@ tests =
       , testPropStrictLazy "fromListUpsert" prop_strictFromListUpsert prop_lazyFromListUpsert
       , testPropStrictLazy "fromAscList" prop_strictFromAscList prop_lazyFromAscList
       , testPropStrictLazy "fromAscListWith" prop_strictFromAscListWith prop_lazyFromAscListWith
+      , testPropStrictLazy "fromAscListUpsert" prop_strictFromAscListUpsert prop_lazyFromAscListUpsert
       , testPropStrictLazy "fromAscListWithKey" prop_strictFromAscListWithKey prop_lazyFromAscListWithKey
       , testPropStrictLazy "fromDistinctAscList" prop_strictFromDistinctAscList prop_lazyFromDistinctAscList
       , testPropStrictLazy "fromDescList" prop_strictFromDescList prop_lazyFromDescList
+      , testPropStrictLazy "fromDescListUpsert" prop_strictFromDescListUpsert prop_lazyFromDescListUpsert
       , testPropStrictLazy "insert" prop_strictInsert prop_lazyInsert
       , testPropStrictLazy "insertWith" prop_strictInsertWith prop_lazyInsertWith
       , testPropStrictLazy "insertWithKey" prop_strictInsertWithKey prop_lazyInsertWithKey

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -201,10 +201,12 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "fromAscList"          prop_fromAscList
          , testProperty "fromAscListWith"      prop_fromAscListWith
          , testProperty "fromAscListWithKey"   prop_fromAscListWithKey
+         , testProperty "fromAscListUpsert"    prop_fromAscListUpsert
          , testProperty "fromDistinctAscList"  prop_fromDistinctAscList
          , testProperty "fromDescList"         prop_fromDescList
          , testProperty "fromDescListWith"     prop_fromDescListWith
          , testProperty "fromDescListWithKey"  prop_fromDescListWithKey
+         , testProperty "fromDescListUpsert"   prop_fromDescListUpsert
          , testProperty "fromDistinctDescList" prop_fromDistinctDescList
          , testProperty "fromList then toList" prop_list
          , testProperty "toDescList"           prop_descList
@@ -1419,6 +1421,14 @@ prop_fromDistinctDescList kxs =
       List.sortBy (comparing (Down . fst)) kxs
     t = fromDistinctDescList nubDownSortedKxs
 
+prop_fromDescListUpsert :: Fun (A, Maybe B) B -> [(Int, A)] -> Property
+prop_fromDescListUpsert f kxs =
+  valid t .&&.
+  t === fromListUpsert (applyFun2 f) downSortedKxs
+  where
+    downSortedKxs = List.sortBy (comparing (Down . fst)) kxs
+    t = fromDescListUpsert (applyFun2 f) downSortedKxs
+
 prop_ascDescList :: [Int] -> Bool
 prop_ascDescList xs = toAscList m == reverse (toDescList m)
   where m = fromList $ zip xs $ repeat ()
@@ -1453,6 +1463,14 @@ prop_fromAscListWithKey f kxs =
   where
     sortedKxs = List.sortBy (comparing fst) kxs
     t = fromAscListWithKey (apply3 f) sortedKxs
+
+prop_fromAscListUpsert :: Fun (A, Maybe B) B -> [(Int, A)] -> Property
+prop_fromAscListUpsert f kxs =
+  valid t .&&.
+  t === fromListUpsert (applyFun2 f) sortedKxs
+  where
+    sortedKxs = List.sortBy (comparing fst) kxs
+    t = fromAscListUpsert (applyFun2 f) sortedKxs
 
 prop_fromDistinctAscList :: [(Int, A)] -> Property
 prop_fromDistinctAscList kxs =

--- a/containers-tests/tests/map-strictness.hs
+++ b/containers-tests/tests/map-strictness.hs
@@ -278,6 +278,22 @@ prop_lazyFromAscListWithKey fun kvs =
     f = coerce (applyFunc3 fun)
     kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(OrdA, A)]
 
+prop_strictFromAscListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(OrdA, Bot A)] -> Property
+prop_strictFromAscListUpsert fun kvs =
+  isBottom (M.fromAscListUpsert f kvs') === isBottom (M.fromListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(OrdA, A)]
+
+prop_lazyFromAscListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(OrdA, Bot A)] -> Property
+prop_lazyFromAscListUpsert fun kvs =
+  isNotBottomProp (L.fromAscListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing fst) (coerce kvs) :: [(OrdA, A)]
+
 prop_strictFromDistinctAscList :: [(OrdA, Bot A)] -> Property
 prop_strictFromDistinctAscList kvs =
   isBottom (M.fromDistinctAscList kvs') === isBottom (M.fromList kvs')
@@ -328,6 +344,22 @@ prop_lazyFromDescListWithKey fun kvs =
   isNotBottomProp (L.fromDescListWithKey f kvs')
   where
     f = coerce (applyFunc3 fun)
+    kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(OrdA, A)]
+
+prop_strictFromDescListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(OrdA, Bot A)] -> Property
+prop_strictFromDescListUpsert fun kvs =
+  isBottom (M.fromDescListUpsert f kvs') === isBottom (M.fromListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
+    kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(OrdA, A)]
+
+prop_lazyFromDescListUpsert
+  :: Func2 A (Maybe B) (Bot B) -> [(OrdA, Bot A)] -> Property
+prop_lazyFromDescListUpsert fun kvs =
+  isNotBottomProp (L.fromDescListUpsert f kvs')
+  where
+    f = coerce (applyFunc2 fun) :: A -> Maybe B -> B
     kvs' = List.sortBy (comparing (Down . fst)) (coerce kvs) :: [(OrdA, A)]
 
 prop_strictFromDistinctDescList :: [(OrdA, Bot A)] -> Property
@@ -1204,10 +1236,12 @@ tests =
       , testPropStrictLazy "fromAscList" prop_strictFromAscList prop_lazyFromAscList
       , testPropStrictLazy "fromAscListWith" prop_strictFromAscListWith prop_lazyFromAscListWith
       , testPropStrictLazy "fromAscListWithKey" prop_strictFromAscListWithKey prop_lazyFromAscListWithKey
+      , testPropStrictLazy "fromAscListUpsert" prop_strictFromAscListUpsert prop_lazyFromAscListUpsert
       , testPropStrictLazy "fromDistinctAscList" prop_strictFromDistinctAscList prop_lazyFromDistinctAscList
       , testPropStrictLazy "fromDescList" prop_strictFromDescList prop_lazyFromDescList
       , testPropStrictLazy "fromDescListWith" prop_strictFromDescListWith prop_lazyFromDescListWith
       , testPropStrictLazy "fromDescListWithKey" prop_strictFromDescListWithKey prop_lazyFromDescListWithKey
+      , testPropStrictLazy "fromDescListUpsert" prop_strictFromDescListUpsert prop_lazyFromDescListUpsert
       , testPropStrictLazy "fromDistinctDescList" prop_strictFromDistinctDescList prop_lazyFromDistinctDescList
       , testPropStrictLazy "insert" prop_strictInsert prop_lazyInsert
       , testPropStrictLazy "insertWith" prop_strictInsertWith prop_lazyInsertWith

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -237,8 +237,10 @@ module Data.IntMap.Internal (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
+    , fromDescListUpsert
 
     -- * Filter
     , filter
@@ -3588,6 +3590,8 @@ fromAscList xs =
 -- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
@@ -3605,6 +3609,8 @@ fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
 -- > fromAscListWithKey f [] == empty
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 -- See Note [fromAscList implementation]
 fromAscListWithKey :: (Key -> a -> a -> a) -> [(Key,a)] -> IntMap a
@@ -3617,6 +3623,29 @@ fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next MSNada xs)
         | otherwise -> let m = branchMask kx ky
                        in MSPush ky y (ascLinkTop stk kx (Tip kx x) m)
 {-# INLINE fromAscListWithKey #-} -- Inline for list fusion
+
+-- | \(O(n)\). Build a map from an ascending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-decreasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromAscListUpsert f [(3,'a'), (3,'b'), (5,'c'), (5,'d'), (5,'e')] == fromList [(3,"ba"), (5,"edc")]
+--
+-- @since FIXME
+fromAscListUpsert :: (a -> Maybe b -> b) -> [(Key, a)] -> IntMap b
+fromAscListUpsert f xs = ascLinkAll (Foldable.foldl' next MSNada xs)
+  where
+    next s (!ky, y) = case s of
+      MSNada -> MSPush ky (f y Nothing) Nada
+      MSPush kx x stk
+        | kx == ky -> MSPush ky (f y (Just x)) stk
+        | otherwise ->
+            let m = branchMask kx ky
+            in MSPush ky (f y Nothing) (ascLinkTop stk kx (Tip kx x) m)
+{-# INLINE fromAscListUpsert #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
 -- the keys are in ascending order and all distinct.
@@ -3651,6 +3680,29 @@ fromDescList :: [(Key,a)] -> IntMap a
 fromDescList xs =
   descLinkAll (Foldable.foldl' (\s (ky, y) -> descInsert ky y s) MSNada xs)
 {-# INLINE fromDescList #-} -- Inline for list fusion
+
+-- | \(O(n)\). Build a map from a descending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-increasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromDescListUpsert f [(5,'a'), (5,'b'), (5,'c'), (3,'d'), (3,'e')] == fromList [(3,"ed"), (5,"cba")]
+--
+-- @since FIXME
+fromDescListUpsert :: (a -> Maybe b -> b) -> [(Key, a)] -> IntMap b
+fromDescListUpsert f xs = descLinkAll (Foldable.foldl' next MSNada xs)
+  where
+    next s (!ky, y) = case s of
+      MSNada -> MSPush ky (f y Nothing) Nada
+      MSPush kx x stk
+        | kx == ky -> MSPush ky (f y (Just x)) stk
+        | otherwise ->
+            let m = branchMask kx ky
+            in MSPush ky (f y Nothing) (descLinkTop kx (Tip kx x) m stk)
+{-# INLINE fromDescListUpsert #-} -- Inline for list fusion
 
 data Stack a
   = Nada

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -115,8 +115,10 @@ module Data.IntMap.Lazy (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
+    , fromDescListUpsert
 
     -- * Insertion
     , insert

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -133,8 +133,10 @@ module Data.IntMap.Strict (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
+    , fromDescListUpsert
 
     -- * Insertion
     , insert

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -74,8 +74,10 @@ module Data.IntMap.Strict.Internal (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
+    , fromDescListUpsert
 
     -- * Insertion
     , insert
@@ -249,6 +251,7 @@ import Data.IntMap.Internal
   , ascLinkTop
   , ascLinkAll
   , descInsert
+  , descLinkTop
   , descLinkAll
   , IntMapBuilder(..)
   , BStack(..)
@@ -1254,6 +1257,8 @@ fromAscList xs = fromAscListWithKey (\_ x _ -> x) xs
 -- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWith :: (a -> a -> a) -> [(Key,a)] -> IntMap a
 fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
@@ -1271,6 +1276,8 @@ fromAscListWith f xs = fromAscListWithKey (\_ x y -> f x y) xs
 -- > fromAscListWithKey f [] == empty
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 -- See Note [fromAscList implementation] in Data.IntMap.Internal.
 fromAscListWithKey :: (Key -> a -> a -> a) -> [(Key,a)] -> IntMap a
@@ -1284,6 +1291,30 @@ fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next MSNada xs)
                        in msPush' ky y (ascLinkTop stk kx (Tip kx x) m)
     msPush' ky !y = MSPush ky y
 {-# INLINE fromAscListWithKey #-} -- Inline for list fusion
+
+-- | \(O(n)\). Build a map from an ascending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-decreasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromAscListUpsert f [(3,'a'), (3,'b'), (5,'c'), (5,'d'), (5,'e')] == fromList [(3,"ba"), (5,"edc")]
+--
+-- @since FIXME
+fromAscListUpsert :: (a -> Maybe b -> b) -> [(Key, a)] -> IntMap b
+fromAscListUpsert f xs = ascLinkAll (Foldable.foldl' next MSNada xs)
+  where
+    next s (!ky, y) = case s of
+      MSNada -> msPush' ky (f y Nothing) Nada
+      MSPush kx x stk
+        | kx == ky -> msPush' ky (f y (Just x)) stk
+        | otherwise ->
+            let m = branchMask kx ky
+            in msPush' ky (f y Nothing) (ascLinkTop stk kx (Tip kx x) m)
+    msPush' ky !y = MSPush ky y
+{-# INLINE fromAscListUpsert #-} -- Inline for list fusion
 
 -- | \(O(n)\). Build a map from a list of key\/value pairs where
 -- the keys are in ascending order and all distinct.
@@ -1314,6 +1345,30 @@ fromDescList :: [(Key,a)] -> IntMap a
 fromDescList xs =
   descLinkAll (Foldable.foldl' (\s (!ky, !y) -> descInsert ky y s) MSNada xs)
 {-# INLINE fromDescList #-} -- Inline for list fusion
+
+-- | \(O(n)\). Build a map from a descending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-increasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromDescListUpsert f [(5,'a'), (5,'b'), (5,'c'), (3,'d'), (3,'e')] == fromList [(3,"ed"), (5,"cba")]
+--
+-- @since FIXME
+fromDescListUpsert :: (a -> Maybe b -> b) -> [(Key, a)] -> IntMap b
+fromDescListUpsert f xs = descLinkAll (Foldable.foldl' next MSNada xs)
+  where
+    next s (!ky, y) = case s of
+      MSNada -> msPush' ky (f y Nothing) Nada
+      MSPush kx x stk
+        | kx == ky -> msPush' ky (f y (Just x)) stk
+        | otherwise ->
+            let m = branchMask kx ky
+            in msPush' ky (f y Nothing) (descLinkTop kx (Tip kx x) m stk)
+    msPush' ky !y = MSPush ky y
+{-# INLINE fromDescListUpsert #-} -- Inline for list fusion
 
 {--------------------------------------------------------------------
   IntMapBuilder

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -284,10 +284,12 @@ module Data.Map.Internal (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
+    , fromDescListUpsert
     , fromDistinctDescList
 
     -- * Filter
@@ -3661,6 +3663,8 @@ fromDescList xs = fromDescListWithKey (\_ x _ -> x) xs
 -- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
 -- > valid (fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")]) == True
 -- > valid (fromAscListWith (++) [(5,"a"), (3,"b"), (5,"b")]) == False
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWith :: Eq k => (a -> a -> a) -> [(k,a)] -> Map k a
 fromAscListWith f xs
@@ -3678,6 +3682,8 @@ fromAscListWith f xs
 -- > valid (fromDescListWith (++) [(5,"a"), (3,"b"), (5,"b")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromDescListUpsert'
 --
 -- @since 0.5.8
 
@@ -3699,6 +3705,8 @@ fromDescListWith f xs
 -- > valid (fromAscListWithKey f [(5,"a"), (3,"b"), (5,"b"), (5,"c")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
 fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next Nada xs)
@@ -3724,6 +3732,8 @@ fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next Nada xs)
 -- > valid (fromDescListWithKey f [(5,"a"), (3,"b"), (5,"b"), (5,"b")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromDescListUpsert'
 
 fromDescListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
 fromDescListWithKey f xs = descLinkAll (Foldable.foldl' next Nada xs)
@@ -3736,6 +3746,49 @@ fromDescListWithKey f xs = descLinkAll (Foldable.foldl' next Nada xs)
       Nada -> Push ky y Tip stk
 {-# INLINE fromDescListWithKey #-}  -- INLINE for fusion
 
+-- | \(O(n)\). Build a map from an ascending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-decreasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromAscListUpsert f [(3,'a'), (3,'b'), (5,'c'), (5,'d'), (5,'e')] == fromList [(3,"ba"), (5,"edc")]
+--
+-- @since FIXME
+fromAscListUpsert :: Eq k => (a -> Maybe b -> b) -> [(k, a)] -> Map k b
+fromAscListUpsert f xs = ascLinkAll (Foldable.foldl' next Nada xs)
+  where
+    next stk (!ky, y) = case stk of
+      Push kx x l stk'
+        | ky == kx -> Push ky (f y (Just x)) l stk'
+        | Tip <- l -> ascLinkTop stk' 1 (singleton kx x) ky (f y Nothing)
+        | otherwise -> Push ky (f y Nothing) Tip stk
+      Nada -> Push ky (f y Nothing) Tip stk
+{-# INLINE fromAscListUpsert #-}  -- INLINE for fusion
+
+-- | \(O(n)\). Build a map from a descending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-increasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromDescListUpsert f [(5,'a'), (5,'b'), (5,'c'), (3,'d'), (3,'e')] == fromList [(3,"ed"), (5,"cba")]
+--
+-- @since FIXME
+fromDescListUpsert :: Eq k => (a -> Maybe b -> b) -> [(k, a)] -> Map k b
+fromDescListUpsert f xs = descLinkAll (Foldable.foldl' next Nada xs)
+  where
+    next stk (!ky, y) = case stk of
+      Push kx x r stk'
+        | ky == kx -> Push ky (f y (Just x)) r stk'
+        | Tip <- r -> descLinkTop ky (f y Nothing) 1 (singleton kx x) stk'
+        | otherwise -> Push ky (f y Nothing) Tip stk
+      Nada -> Push ky (f y Nothing) Tip stk
+{-# INLINE fromDescListUpsert #-}  -- INLINE for fusion
 
 -- | \(O(n)\). Build a map from an ascending list of distinct elements in linear time.
 --

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -123,12 +123,14 @@ module Data.Map.Lazy (
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
 
     -- ** From Descending Lists
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
+    , fromDescListUpsert
     , fromDistinctDescList
 
     -- * Insertion

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -137,12 +137,14 @@ module Data.Map.Strict
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
 
     -- ** From Descending Lists
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
+    , fromDescListUpsert
     , fromDistinctDescList
 
     -- * Insertion

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -231,10 +231,12 @@ module Data.Map.Strict.Internal
     , fromAscList
     , fromAscListWith
     , fromAscListWithKey
+    , fromAscListUpsert
     , fromDistinctAscList
     , fromDescList
     , fromDescListWith
     , fromDescListWithKey
+    , fromDescListUpsert
     , fromDistinctDescList
 
     -- * Filter
@@ -1585,6 +1587,8 @@ fromDescList xs
 -- > valid (fromAscListWith (++) [(5,"a"), (3,"b"), (5,"b")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWith :: Eq k => (a -> a -> a) -> [(k,a)] -> Map k a
 fromAscListWith f xs
@@ -1602,6 +1606,8 @@ fromAscListWith f xs
 -- > valid (fromDescListWith (++) [(5,"a"), (3,"b"), (5,"b")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromDescListUpsert'
 
 fromDescListWith :: Eq k => (a -> a -> a) -> [(k,a)] -> Map k a
 fromDescListWith f xs
@@ -1621,6 +1627,8 @@ fromDescListWith f xs
 -- > valid (fromAscListWithKey f [(5,"a"), (3,"b"), (5,"b"), (5,"c")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromAscListUpsert'
 
 fromAscListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
 fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next Nada xs)
@@ -1647,6 +1655,8 @@ fromAscListWithKey f xs = ascLinkAll (Foldable.foldl' next Nada xs)
 -- > valid (fromDescListWithKey f [(5,"a"), (3,"b"), (5,"b"), (5,"b")]) == False
 --
 -- Also see the performance note on 'fromListWith'.
+--
+-- See also: 'fromDescListUpsert'
 
 fromDescListWithKey :: Eq k => (k -> a -> a -> a) -> [(k,a)] -> Map k a
 fromDescListWithKey f xs = descLinkAll (Foldable.foldl' next Nada xs)
@@ -1659,6 +1669,54 @@ fromDescListWithKey f xs = descLinkAll (Foldable.foldl' next Nada xs)
       Nada -> push ky y Tip stk
     push kx !x = Push kx x
 {-# INLINE fromDescListWithKey #-}  -- INLINE for fusion
+
+-- | \(O(n)\). Build a map from an ascending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-decreasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromAscListUpsert f [(3,'a'), (3,'b'), (5,'c'), (5,'d'), (5,'e')] == fromList [(3,"ba"), (5,"edc")]
+--
+-- @since FIXME
+fromAscListUpsert :: Eq k => (a -> Maybe b -> b) -> [(k, a)] -> Map k b
+fromAscListUpsert f xs = ascLinkAll (Foldable.foldl' next Nada xs)
+  where
+    next stk (!ky, y) = case stk of
+      Push kx x l stk'
+        | ky == kx -> push' ky (f y (Just x)) l stk'
+        | Tip <- l -> let !y' = f y Nothing
+                      in ascLinkTop stk' 1 (singleton kx x) ky y'
+        | otherwise -> push' ky (f y Nothing) Tip stk
+      Nada -> push' ky (f y Nothing) Tip stk
+    push' kx !x = Push kx x
+{-# INLINE fromAscListUpsert #-}  -- INLINE for fusion
+
+-- | \(O(n)\). Build a map from a descending list in linear time with a
+-- combining function for equal keys.
+--
+-- __Warning__: This function should be used only if the keys are in
+-- non-increasing order. This precondition is not checked. Use 'fromListUpsert'
+-- if the precondition may not hold.
+--
+-- > let f x = maybe [x] (x:)
+-- > fromDescListUpsert f [(5,'a'), (5,'b'), (5,'c'), (3,'d'), (3,'e')] == fromList [(3,"ed"), (5,"cba")]
+--
+-- @since FIXME
+fromDescListUpsert :: Eq k => (a -> Maybe b -> b) -> [(k, a)] -> Map k b
+fromDescListUpsert f xs = descLinkAll (Foldable.foldl' next Nada xs)
+  where
+    next stk (!ky, y) = case stk of
+      Push kx x r stk'
+        | ky == kx -> push' ky (f y (Just x)) r stk'
+        | Tip <- r -> let !y' = f y Nothing
+                      in descLinkTop ky y' 1 (singleton kx x) stk'
+        | otherwise -> push' ky (f y Nothing) Tip stk
+      Nada -> push' ky (f y Nothing) Tip stk
+    push' kx !x = Push kx x
+{-# INLINE fromDescListUpsert #-}  -- INLINE for fusion
 
 -- | \(O(n)\). Build a map from an ascending list of distinct elements in linear time.
 --


### PR DESCRIPTION
As with fromList, this is a less error-prone alternative to from{Asc,Desc}ListWith functions.

Follows #1194.
Closes #758.