### PR TITLE
Use `SPECIALIZE` consistently

### DIFF
--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -4311,7 +4311,7 @@ balance_ k x l r = case l of
                    (_, _) -> error "Failure in Data.Map.balance"
 {-# NOINLINE balance_ #-}
 
--- Functions balanceL and balanceR are specialised versions of balance.
+-- Functions balanceL and balanceR are specialized versions of balance.
 -- balanceL only checks whether the left subtree is too big,
 -- balanceR only checks whether the right subtree is too big.
 

--- a/containers/src/Data/Sequence/Internal/Sorting.hs
+++ b/containers/src/Data/Sequence/Internal/Sorting.hs
@@ -407,8 +407,8 @@ foldToMaybeWithIndexTree :: (b -> b -> b)
                          -> Maybe b
 foldToMaybeWithIndexTree = foldToMaybeWithIndexTree'
   where
-    {-# SPECIALISE foldToMaybeWithIndexTree' :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> FingerTree (Elem y) -> Maybe b #-}
-    {-# SPECIALISE foldToMaybeWithIndexTree' :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> FingerTree (Node y) -> Maybe b #-}
+    {-# SPECIALIZE foldToMaybeWithIndexTree' :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> FingerTree (Elem y) -> Maybe b #-}
+    {-# SPECIALIZE foldToMaybeWithIndexTree' :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> FingerTree (Node y) -> Maybe b #-}
     foldToMaybeWithIndexTree'
         :: Sized a
         => (b -> b -> b) -> (Int -> a -> b) -> Int -> FingerTree a -> Maybe b
@@ -422,14 +422,14 @@ foldToMaybeWithIndexTree = foldToMaybeWithIndexTree'
         m' = foldToMaybeWithIndexTree' (<+>) (node (<+>) f) sPspr m
         !sPspr = s + size pr
         !sPsprm = sPspr + size m
-    {-# SPECIALISE digit :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> Digit (Elem y) -> b #-}
-    {-# SPECIALISE digit :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> Digit (Node y) -> b #-}
+    {-# SPECIALIZE digit :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> Digit (Elem y) -> b #-}
+    {-# SPECIALIZE digit :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> Digit (Node y) -> b #-}
     digit
         :: Sized a
         => (b -> b -> b) -> (Int -> a -> b) -> Int -> Digit a -> b
     digit = foldWithIndexDigit
-    {-# SPECIALISE node :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> Node (Elem y) -> b #-}
-    {-# SPECIALISE node :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> Node (Node y) -> b #-}
+    {-# SPECIALIZE node :: (b -> b -> b) -> (Int -> Elem y -> b) -> Int -> Node (Elem y) -> b #-}
+    {-# SPECIALIZE node :: (b -> b -> b) -> (Int -> Node y -> b) -> Int -> Node (Node y) -> b #-}
     node
         :: Sized a
         => (b -> b -> b) -> (Int -> a -> b) -> Int -> Node a -> b

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -1957,7 +1957,7 @@ ratio = 2
 -- Only balanceL and balanceR are needed at the moment, so balance is not here anymore.
 -- In case it is needed, it can be found in Data.Map.
 
--- Functions balanceL and balanceR are specialised versions of balance.
+-- Functions balanceL and balanceR are specialized versions of balance.
 -- balanceL only checks whether the left subtree is too big,
 -- balanceR only checks whether the right subtree is too big.
 


### PR DESCRIPTION
- consistent terminology is important (e.g. if you write a paper you don't want variation in your terminology)
- most people are not native English speakers, having everybody deal with two dialects of English just does not check out in terms of fairness
- it's also an issue for assistive technologies / search / `grep`