### PR TITLE
Use a different strategy for Set.alterF

### DIFF
--- a/containers-tests/benchmarks/Set.hs
+++ b/containers-tests/benchmarks/Set.hs
@@ -15,10 +15,11 @@ main = do
     let s = S.fromList elems :: S.Set Int
         s_even = S.fromList elems_even :: S.Set Int
         s_odd = S.fromList elems_odd :: S.Set Int
-        strings_s = S.fromList strings
+        strings_s = S.fromList strings :: S.Set String
     evaluate $ rnf [s, s_even, s_odd]
     evaluate $ rnf
       [elems_distinct_asc, elems_distinct_desc, elems_asc, elems_desc]
+    evaluate $ rnf strings_s
     defaultMain
         [ bench "member" $ whnf (member elems) s
         , bench "insert" $ whnf (ins elems) S.empty
@@ -57,12 +58,12 @@ main = do
         , bench "null.intersection:false" $ whnf (S.null. S.intersection s) s_even
         , bench "null.intersection:true" $ whnf (S.null. S.intersection s_odd) s_even
         , bench "alterF:member" $ whnf (alterF_member elems) s
-        , bench "alterF:insert" $ whnf (alterF_ins elems) S.empty
-        , bench "alterF:delete" $ whnf (alterF_del elems) s
+        , bench "alterF:insert:absent" $ whnf (alterF_ins elems_odd) s_even
+        , bench "alterF:insert:present" $ whnf (alterF_ins elems_even) s_even
+        , bench "alterF:delete:present" $ whnf (alterF_del elems_even) s_even
+        , bench "alterF:delete:absent" $ whnf (alterF_del elems_odd) s_even
         , bench "alterF:four" $ whnf (alterF_four elems) s
         , bench "alterF:four:strings" $ whnf (alterF_four strings) strings_s
-        , bench "alterF_naive:four" $ whnf (alterF_naive_four elems) s
-        , bench "alterF_naive:four:strings" $ whnf (alterF_naive_four strings) strings_s
         , bench "powerSet (15)" $ whnf S.powerSet (S.fromList[1..15])
         , bench "powerSet (16)" $ whnf S.powerSet (S.fromList[1..16])
         , bench "member.powerSet (14)" $ whnf (\ s -> all (flip S.member s) s) (S.powerSet (S.fromList [1..14]))
@@ -114,15 +115,6 @@ alterF_del xs s0 = foldl' (\s k -> delete' k s) s0 xs
 
 alterF_four :: Ord a => [a] -> S.Set a -> S.Set a
 alterF_four xs s0 = foldl' (\s k -> S.alterF four k s `seq` s) s0 xs
-
-alterF_naive_four :: Ord a => [a] -> S.Set a -> S.Set a
-alterF_naive_four xs s0 = foldl' (\s k -> alterF_naive four k s `seq` s) s0 xs
-
-alterF_naive :: (Ord a, Functor f) => (Bool -> f Bool) -> a -> S.Set a -> f (S.Set a)
-alterF_naive f k s = fmap g (f (k `S.member` s))
-  where
-    g True  = S.insert k s
-    g False = S.delete k s
 
 four :: Bool -> Four Bool
                -- insert  delete  reinsert  toggle

--- a/containers-tests/tests/set-properties.hs
+++ b/containers-tests/tests/set-properties.hs
@@ -388,8 +388,12 @@ toggle k s =
         then delete k s
         else insert k s
 
-prop_alterF :: Fun Bool [Bool] -> Int -> Set Int -> Property
-prop_alterF f k s = fmap (member k) (alterF (apply f) k s) === apply f (member k s)
+prop_alterF :: Fun Bool Bool -> Int -> Set Int -> Property
+prop_alterF f k s = valid s' .&&. s' === expected
+  where
+    s' = runIdent (alterF (Ident . applyFun f) k s)
+    member' = applyFun f (member k s)
+    expected = if member' then insert k s else delete k s
 
 prop_alterF_insert :: Int -> Set Int -> Property
 prop_alterF_insert k s = runIdent (alterF (const (Ident True)) k s) === insert k s

--- a/containers/src/Data/Set/Internal.hs
+++ b/containers/src/Data/Set/Internal.hs
@@ -615,48 +615,47 @@ pop x0 t0 = case go x0 t0 of
 -- Note: 'alterF' is a variant of the @at@ combinator from "Control.Lens.At".
 --
 -- @since 0.6.3.1
+
+-- See Note [alterF implementation]
 alterF :: (Ord a, Functor f) => (Bool -> f Bool) -> a -> Set a -> f (Set a)
 alterF f k s = fmap choose (f member_)
   where
-    (member_, inserted, deleted) = case alteredSet k s of
-        Deleted d           -> (True , s, d)
-        Inserted i          -> (False, i, s)
-
+    MemberIndex member_ i = memberIndex k s
+    inserted = if member_ then s else insertAt i k s
+    deleted = if member_ then deleteAt i s else s
     choose True  = inserted
     choose False = deleted
 #ifdef __GLASGOW_HASKELL__
-{-# INLINABLE [2] alterF #-}
+{-# INLINE [2] alterF #-}
 
 {-# RULES
 "alterF/Const" forall k (f :: Bool -> Const a Bool) . alterF f k = \s -> Const . getConst . f $ member k s
  #-}
 #endif
 
-{-# SPECIALIZE alterF :: Ord a => (Bool -> Identity Bool) -> a -> Set a -> Identity (Set a) #-}
+data MemberIndex = MemberIndex !Bool {-# UNPACK #-} !Int
 
-data AlteredSet a
-      -- | The needle is present in the original set.
-      -- We return the set where the needle is deleted.
-    = Deleted !(Set a)
-
-      -- | The needle is not present in the original set.
-      -- We return the set with the needle inserted.
-    | Inserted !(Set a)
-
-alteredSet :: Ord a => a -> Set a -> AlteredSet a
-alteredSet x0 s0 = go x0 s0
+-- Whether the element is a member of the set along with its index.
+-- If it is not a member, the index is the index it would have if inserted.
+memberIndex :: Ord a => a -> Set a -> MemberIndex
+memberIndex = go 0
   where
-    go :: Ord a => a -> Set a -> AlteredSet a
-    go x Tip           = Inserted (singleton x)
-    go x (Bin _ y l r) = case compare x y of
-        LT -> case go x l of
-            Deleted d           -> Deleted (balanceR y d r)
-            Inserted i          -> Inserted (balanceL y i r)
-        GT -> case go x r of
-            Deleted d           -> Deleted (balanceL y l d)
-            Inserted i          -> Inserted (balanceR y l i)
-        EQ -> Deleted (glue l r)
-{-# INLINABLE alteredSet #-}
+    go !i !_ Tip = MemberIndex False i
+    go !i !x (Bin _ y l r) = case compare x y of
+      LT -> go i x l
+      EQ -> MemberIndex True (i + size l)
+      GT -> go (i + size l + 1) x r
+{-# INLINABLE memberIndex #-}
+
+-- Insert the element at the given index. The caller must ensure that the index
+-- is correct and will not violate Set invariants.
+insertAt :: Int -> a -> Set a -> Set a
+insertAt !_ !x Tip = singleton x
+insertAt !i !x (Bin _ y l r)
+  | i <= sizeL = balanceL y (insertAt i x l) r
+  | otherwise = balanceR y l (insertAt (i - sizeL - 1) x r)
+  where
+    !sizeL = size l
 
 {--------------------------------------------------------------------
   Subset
@@ -2625,3 +2624,34 @@ validsize t
 -- = O(\sum_{i=2}^m k_i - k_{i-1})
 -- = O(k_m - k_1)
 -- = O(log n)
+
+-- Note [alterF implementation]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- When implementing alterF, there are various costs to consider:
+--
+-- 1. The number of times we travel down the tree to the target
+-- 2. The number of times we travel back up the tree
+-- 3. The number of element comparisons we perform
+-- 4. The number of times we apply fmap
+-- 5. The amount of allocations we perform
+--
+-- The weights of these further depend on the Ord instance of the element type,
+-- the Functor used, and GHC optimizations. Unfortunately, there is no clear
+-- winning implementation which performs best in all situations. The current
+-- implementation is chosen for its good characteristics:
+--
+-- 1. It travels down the tree once if the membership is demanded, and once more
+--    if the changed Set is demanded.
+-- 2. It travels up the tree once if the changed Set is demanded.
+-- 3. It compares the given element against stored elements on the path to the
+--    target at most once.
+-- 4. It applies fmap exactly once.
+-- 5. It allocates the changed Set if it is demanded. It does not allocate any
+--    intermediate structure.
+--
+-- Note that 2,3,4,5 are all optimal. As for 1, implementations that travel down
+-- the tree at most once are possible, but they are worse in at least one of the
+-- other categories.
+-- See https://github.com/haskell/containers/issues/1209#issuecomment-4530740850
+-- for some other implementations and benchmarks.


### PR DESCRIPTION
This is an improvement over the previous implementation in many (but not
all) scenarios. Most importantly it avoids allocating a Set when the Set
doesn't need to be changed. See Note [alterF implementation] for more
about the choice of implementation.

alterF also gets an INLINE since it's a small definition and inlining
permits further GHC optimizations based on the altering function.

For #1209.