### PR TITLE
Tweak IntSet.alterF

### DIFF
--- a/containers-tests/benchmarks/IntSet.hs
+++ b/containers-tests/benchmarks/IntSet.hs
@@ -91,6 +91,11 @@ main = do
         , bench "compareSize:sparse:2" $ whnf (flip IS.compareSize 2) s_sparse
         , bench "compareSize:n" $ whnf (flip IS.compareSize bound) s
         , bench "compareSize:sparse:n" $ whnf (flip IS.compareSize bound) s_sparse
+        , bench "alterF:member" $ whnf (alterF_memberMany elems) s
+        , bench "alterF:insert:absent" $ whnf (alterF_insertMany elems_odd) s_even
+        , bench "alterF:insert:present" $ whnf (alterF_insertMany elems_even) s_even
+        , bench "alterF:delete:present" $ whnf (alterF_deleteMany elems_even) s_even
+        , bench "alterF:delete:absent" $ whnf (alterF_deleteMany elems_odd) s_even
         , bgroup "folds:dense" $ foldBenchmarks IS.foldr IS.foldl IS.foldr' IS.foldl' IS.foldMap s
         , bgroup "folds:sparse" $ foldBenchmarks IS.foldr IS.foldl IS.foldr' IS.foldl' IS.foldMap s_sparse
         ]
@@ -125,6 +130,29 @@ ins xs s0 = foldl' (\s a -> IS.insert a s) s0 xs
 
 del :: [Int] -> IS.IntSet -> IS.IntSet
 del xs s0 = foldl' (\s k -> IS.delete k s) s0 xs
+
+alterF_memberMany :: [Int] -> IS.IntSet -> ()
+alterF_memberMany xs s0 = foldl' (\_ x -> member' x s0 `seq` ()) () xs
+  where
+    member' k s = getConsty (IS.alterF Consty k s)
+
+alterF_insertMany :: [Int] -> IS.IntSet -> IS.IntSet
+alterF_insertMany xs s0 = foldl' (flip insert') s0 xs
+  where
+    insert' k s = runIdent (IS.alterF (\_ -> Ident True) k s)
+
+alterF_deleteMany :: [Int] -> IS.IntSet -> IS.IntSet
+alterF_deleteMany xs s0 = foldl' (flip delete') s0 xs
+  where
+    delete' k s = runIdent (IS.alterF (\_ -> Ident False) k s)
+
+newtype Consty a b = Consty { getConsty :: a }
+instance Functor (Consty a) where
+  fmap _ (Consty a) = Consty a
+
+newtype Ident a = Ident { runIdent :: a }
+instance Functor Ident where
+  fmap f (Ident a) = Ident (f a)
 
 -- NOINLINE to work around an issue where the inlined function doesn't get
 -- optimized (see GHC #25878).

--- a/containers-tests/tests/intset-properties.hs
+++ b/containers-tests/tests/intset-properties.hs
@@ -91,6 +91,7 @@ main = defaultMain $ testGroup "intset-properties"
                    , testProperty "takeWhileAntitone" prop_takeWhileAntitone
                    , testProperty "dropWhileAntitone" prop_dropWhileAntitone
                    , testProperty "spanAntitone" prop_spanAntitone
+                   , testProperty "prop_alterF" prop_alterF
                    , testProperty "prop_alterF_list" prop_alterF_list
                    , testProperty "prop_alterF_const" prop_alterF_const
                    , testProperty "intersections" prop_intersections
@@ -513,6 +514,17 @@ prop_spanAntitone x ys =
       valid r .&&.
       l === fromList (List.filter (<x) ys) .&&.
       r === fromList (List.filter (>=x) ys)
+
+prop_alterF :: Fun Bool Bool -> Int -> IntSet -> Property
+prop_alterF f k s = valid s' .&&. s' === expected
+  where
+    s' = runIdent (alterF (Ident . applyFun f) k s)
+    member' = applyFun f (member k s)
+    expected = if member' then insert k s else delete k s
+
+newtype Ident a = Ident { runIdent :: a }
+instance Functor Ident where
+  fmap f (Ident a) = Ident (f a)
 
 prop_alterF_list
     :: Fun Bool [Bool]

--- a/containers/src/Data/IntSet/Internal.hs
+++ b/containers/src/Data/IntSet/Internal.hs
@@ -239,7 +239,6 @@ import Language.Haskell.TH ()
 #endif
 
 import qualified Data.Foldable as Foldable
-import Data.Functor.Identity (Identity(..))
 
 infixl 9 \\{-This comment teaches CPP correct behaviour -}
 
@@ -614,22 +613,17 @@ alterF :: Functor f => (Bool -> f Bool) -> Key -> IntSet -> f IntSet
 alterF f k s = fmap choose (f member_)
   where
     member_ = member k s
-
-    (inserted, deleted)
-      | member_   = (s         , delete k s)
-      | otherwise = (insert k s, s         )
-
+    inserted = if member_ then s else insert k s
+    deleted = if member_ then delete k s else s
     choose True  = inserted
     choose False = deleted
 #ifdef __GLASGOW_HASKELL__
-{-# INLINABLE [2] alterF #-}
+{-# INLINE [2] alterF #-}
 
 {-# RULES
 "alterF/Const" forall k (f :: Bool -> Const a Bool) . alterF f k = \s -> Const . getConst . f $ member k s
  #-}
 #endif
-
-{-# SPECIALIZE alterF :: (Bool -> Identity Bool) -> Key -> IntSet -> Identity IntSet #-}
 
 {--------------------------------------------------------------------
   Union


### PR DESCRIPTION
* Simplify the implementation slightly. This is not expected to affect performance.
* Inline the definition since it is a small definition and it allows optimization based on the altering function.
* Remove the Identity specialization since it will now be inlined.
* Add a property test.
* Add some benchmarks.

For #1209.