### PR TITLE
Avoid some allocations with Map.alterF

### DIFF
--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -1201,7 +1201,7 @@ alterF :: (Functor f, Ord k)
 alterF f k m = atKeyImpl Lazy k f m
 
 #ifdef __GLASGOW_HASKELL__
-{-# INLINABLE [2] alterF #-}
+{-# INLINE [2] alterF #-}
 
 -- We can save a little time by recognizing the special case of
 -- `Control.Applicative.Const` and just doing a lookup.
@@ -1254,7 +1254,14 @@ alterFCutoff = case wordSize of
 #endif
 #endif
 
-data TraceResult a = TraceResult (Maybe a) {-# UNPACK #-} !BitQueue
+-- On GHC >=9.6 we can unpack sum types, so we unbox the Maybe to avoid the
+-- allocation.
+data TraceResult a = TraceResult
+#if __GLASGOW_HASKELL__ >= 906
+  {-# UNPACK #-}
+#endif
+  !(Maybe a)
+  {-# UNPACK #-} !BitQueue
 
 -- Look up a key and return a result indicating whether it was found
 -- and what path was taken.

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -785,7 +785,7 @@ alterF :: (Functor f, Ord k)
 alterF f k m = atKeyImpl Strict k f m
 
 #ifdef __GLASGOW_HASKELL__
-{-# INLINABLE [2] alterF #-}
+{-# INLINE [2] alterF #-}
 
 -- We can save a little time by recognizing the special case of
 -- `Control.Applicative.Const` and just doing a lookup.


### PR DESCRIPTION
Inline the function so that GHC can optimize it based on the altering function. Also unpack the Maybe in TraceResult. Both of these result in less allocations.

For #1209.