### PR TITLE
Adds takeR, dropR, splitAtR for seq, issue #159

### DIFF
--- a/containers-tests/tests/seq-properties.hs
+++ b/containers-tests/tests/seq-properties.hs
@@ -126,6 +126,9 @@ main = defaultMain $ testGroup "seq-properties"
        , testProperty "take" prop_take
        , testProperty "drop" prop_drop
        , testProperty "splitAt" prop_splitAt
+       , testProperty "takeR" prop_takeR
+       , testProperty "dropR" prop_dropR
+       , testProperty "splitAtR" prop_splitAtR
        , testProperty "chunksOf" prop_chunksOf
        , testProperty "elemIndexL" prop_elemIndexL
        , testProperty "elemIndicesL" prop_elemIndicesL
@@ -788,6 +791,29 @@ prop_splitAt n xs =
   (toList ys, toList zs) === Prelude.splitAt n (toList xs)
   where
     (ys, zs) = splitAt n xs
+
+prop_takeR :: Int -> Seq A -> Property
+prop_takeR n xs =
+  valid ys .&&.
+  toList ys === Prelude.reverse (Prelude.take n (Prelude.reverse (toList xs)))
+  where
+    ys = takeR n xs
+
+prop_dropR :: Int -> Seq A -> Property
+prop_dropR n xs =
+  valid ys .&&.
+  toList ys === Prelude.reverse (Prelude.drop n (Prelude.reverse (toList xs)))
+  where
+    ys = dropR n xs
+
+prop_splitAtR :: Int -> Seq A -> Property
+prop_splitAtR n xs =
+  valid ys .&&.
+  valid zs .&&.
+  (toList ys, toList zs) === (Prelude.reverse rl, Prelude.reverse rr)
+  where
+    (ys, zs) = splitAtR n xs
+    (rr, rl) = Prelude.splitAt n (Prelude.reverse (toList xs))
 
 prop_chunksOf :: Seq A -> Property
 prop_chunksOf xs =

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -15,7 +15,7 @@
 
 * Add `takeR`, `dropR` and `splitAtR` for `Seq`. (Phil Crissman)
   (see [#159](https://github.com/haskell/containers/issues/159))
-  ([#NNNN](https://github.com/haskell/containers/pull/NNNN))
+  ([#1222](https://github.com/haskell/containers/pull/1222))
 
 ### Performance improvements
 

--- a/containers/changelog.md
+++ b/containers/changelog.md
@@ -13,6 +13,10 @@
 * Add `fromSetA` for `Map` and `IntMap`. (L0neGamer)
   ([#1163](https://github.com/haskell/containers/pull/1163))
 
+* Add `takeR`, `dropR` and `splitAtR` for `Seq`. (Phil Crissman)
+  (see [#159](https://github.com/haskell/containers/issues/159))
+  ([#NNNN](https://github.com/haskell/containers/pull/NNNN))
+
 ### Performance improvements
 
 * Improved performance for `Data.IntMap.restrictKeys` and

--- a/containers/src/Data/Sequence.hs
+++ b/containers/src/Data/Sequence.hs
@@ -210,10 +210,13 @@ module Data.Sequence (
     adjust',        -- :: (a -> a) -> Int -> Seq a -> Seq a
     update,         -- :: Int -> a -> Seq a -> Seq a
     take,           -- :: Int -> Seq a -> Seq a
+    takeR,          -- :: Int -> Seq a -> Seq a
     drop,           -- :: Int -> Seq a -> Seq a
+    dropR,          -- :: Int -> Seq a -> Seq a
     insertAt,       -- :: Int -> a -> Seq a -> Seq a
     deleteAt,       -- :: Int -> Seq a -> Seq a
     splitAt,        -- :: Int -> Seq a -> (Seq a, Seq a)
+    splitAtR,       -- :: Int -> Seq a -> (Seq a, Seq a)
     -- ** Indexing with predicates
     -- | These functions perform sequential searches from the left
     -- or right ends of the sequence, returning indices of matching

--- a/containers/src/Data/Sequence/Internal.hs
+++ b/containers/src/Data/Sequence/Internal.hs
@@ -136,10 +136,13 @@ module Data.Sequence.Internal (
     adjust',        -- :: (a -> a) -> Int -> Seq a -> Seq a
     update,         -- :: Int -> a -> Seq a -> Seq a
     take,           -- :: Int -> Seq a -> Seq a
+    takeR,          -- :: Int -> Seq a -> Seq a
     drop,           -- :: Int -> Seq a -> Seq a
+    dropR,          -- :: Int -> Seq a -> Seq a
     insertAt,       -- :: Int -> a -> Seq a -> Seq a
     deleteAt,       -- :: Int -> Seq a -> Seq a
     splitAt,        -- :: Int -> Seq a -> (Seq a, Seq a)
+    splitAtR,       -- :: Int -> Seq a -> (Seq a, Seq a)
     -- ** Indexing with predicates
     -- | These functions perform sequential searches from the left
     -- or right ends of the sequence, returning indices of matching
@@ -3478,6 +3481,15 @@ take i xs@(Seq t)
   | i <= 0 = empty
   | otherwise = xs
 
+-- | \( O(\log(\min(i,n-i))) \). The last @i@ elements of a sequence.
+-- If @i@ is negative, @'takeR' i s@ yields the empty sequence.
+-- If the sequence contains fewer than @i@ elements, the whole sequence
+-- is returned.
+--
+-- @since FIXME
+takeR :: Int -> Seq a -> Seq a
+takeR i xs = drop (length xs - i) xs
+
 takeTreeE :: Int -> FingerTree (Elem a) -> FingerTree (Elem a)
 takeTreeE !_i EmptyT = EmptyT
 takeTreeE i t@(Single _)
@@ -3639,6 +3651,15 @@ drop i xs@(Seq t)
       Seq (takeTreeER (length xs - i) t)
   | i <= 0 = xs
   | otherwise = empty
+
+-- | \( O(\log(\min(i,n-i))) \). Elements of a sequence before the last @i@.
+-- If @i@ is negative, @'dropR' i s@ yields the whole sequence.
+-- If the sequence contains fewer than @i@ elements, the empty sequence
+-- is returned.
+--
+-- @since FIXME
+dropR :: Int -> Seq a -> Seq a
+dropR i xs = take (length xs - i) xs
 
 -- We implement `drop` using a "take from the rear" strategy.  There's no
 -- particular technical reason for this; it just lets us reuse the arithmetic
@@ -3808,6 +3829,14 @@ splitAt i xs@(Seq t)
         l :*: r -> (Seq l, Seq r)
   | i <= 0 = (empty, xs)
   | otherwise = (xs, empty)
+
+-- | \( O(\log(\min(i,n-i))) \). Split a sequence at a given position,
+-- with the position being counted from the last (rightmost) element.
+-- @'splitAtR' i s = ('dropR' i s, 'takeR' i s)@.
+--
+-- @since FIXME
+splitAtR :: Int -> Seq a -> (Seq a, Seq a)
+splitAtR i xs = splitAt (length xs - i) xs
 
 -- | \( O(\log(\min(i,n-i))) \) A version of 'splitAt' that does not attempt to
 -- enhance sharing when the split point is less than or equal to 0, and that


### PR DESCRIPTION
Adding takeR, dropR, and splitAtR for Sequence.
All are implemented in terms of the existing take, drop, or splitAt functions.
See [#159](https://github.com/haskell/containers/issues/159)