### PR TITLE
Inline IntMap.alterF

### DIFF
--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -1175,6 +1175,7 @@ alterF f k m = (<$> f mv) $ \fres ->
     Nothing -> maybe m (const (delete k m)) mv
     Just v' -> insert k v' m
   where mv = lookup k m
+{-# INLINE alterF #-}
 
 {--------------------------------------------------------------------
   Union

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -631,7 +631,7 @@ alterF f k m = (<$> f mv) $ \fres ->
     Nothing -> maybe m (const (delete k m)) mv
     Just !v' -> insert k v' m
   where mv = lookup k m
-
+{-# INLINE alterF #-}
 
 {--------------------------------------------------------------------
   Union


### PR DESCRIPTION
GHC seems happy to inline it anyway, but this makes our intent explicit. Inlining allows GHC to optimize it based on the altering function and likely avoids the Maybe allocations.

For #1209