### PR TITLE
Add fromSetMaybe and fromSetMaybeA for maps

### DIFF
--- a/containers-tests/tests/intmap-properties.hs
+++ b/containers-tests/tests/intmap-properties.hs
@@ -37,6 +37,7 @@ import qualified Prelude (map, filter)
 import Data.List (nub,sort)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
+import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -223,7 +224,9 @@ main = defaultMain $ testGroup "intmap-properties"
                  prop_FoldableTraversableCompat
              , testProperty "keysSet"              prop_keysSet
              , testProperty "fromSet"              prop_fromSet
-             , testProperty "fromSetA eval order"  prop_fromSetA_action_order
+             , testProperty "fromSetA"             prop_fromSetA
+             , testProperty "fromSetMaybe"         prop_fromSetMaybe
+             , testProperty "fromSetMaybeA"        prop_fromSetMaybeA
              , testProperty "restrictKeys"         prop_restrictKeys
              , testProperty "withoutKeys"          prop_withoutKeys
              , testProperty "traverseWithKey identity"              prop_traverseWithKey_identity
@@ -304,6 +307,10 @@ instance Arbitrary a => Arbitrary (IntMap a) where
     where
       go kgen = fromList <$> listOf ((,) <$> kgen <*> arbitrary)
   shrink = fmap fromList . shrink . toAscList
+
+instance Arbitrary IntSet where
+  arbitrary = IntSet.fromList <$> arbitrary
+  shrink = fmap IntSet.fromList . shrink . IntSet.toList
 
 newtype NonEmptyIntMap a = NonEmptyIntMap {getNonEmptyIntMap :: IntMap a} deriving (Eq, Show)
 
@@ -1807,27 +1814,43 @@ prop_keysSet :: [Int] -> Property
 prop_keysSet keys =
   keysSet (fromList (fmap (, ()) keys)) === IntSet.fromList keys
 
-prop_fromSet :: [Int] -> Fun Int A -> Property
+prop_fromSet :: IntSet -> Fun Int A -> Property
 prop_fromSet keys funF =
   let f = apply funF
-      m = fromSet f (IntSet.fromList keys)
+      m = fromSet f keys
   in
     valid m .&&.
-    m === fromList (fmap (id &&& f) keys)
+    toList m === fmap (id &&& f) (IntSet.toList keys)
 
-prop_fromSetA_action_order :: [Int] -> Fun Int A -> Property
-prop_fromSetA_action_order keys funF =
-  let set = IntSet.fromList keys
-      setList = IntSet.toList set
+prop_fromSetA :: IntSet -> Fun Int A -> Property
+prop_fromSetA keys funF =
+  let setList = IntSet.toList keys
       f = apply funF
       action = \k ->
         let v = f k
         in tell [v] $> v
-      (writtenMap, writtenOutput) = runWriter (fromSetA action set)
+      (writtenMap, writtenOutput) = runWriter (fromSetA action keys)
   in
     valid writtenMap .&&.
     writtenOutput === List.map f setList .&&.
     toList writtenMap === fmap (id &&& f) setList
+
+prop_fromSetMaybe :: IntSet -> Fun Int (Maybe A) -> Property
+prop_fromSetMaybe keys f =
+  valid m .&&.
+  toList m ===
+    Maybe.mapMaybe (\k -> (,) k <$> applyFun f k) (IntSet.toList keys)
+  where
+    m = fromSetMaybe (applyFun f) keys
+
+prop_fromSetMaybeA :: IntSet -> Fun Int (Maybe A) -> Property
+prop_fromSetMaybeA keys f =
+  valid m .&&.
+  ks === IntSet.toList keys .&&.
+  toList m ===
+    Maybe.mapMaybe (\k -> (,) k <$> applyFun f k) (IntSet.toList keys)
+  where
+    (ks, m) = fromSetMaybeA (\k -> ([k], applyFun f k)) keys
 
 newtype Identity a = Identity a
     deriving (Eq, Show)

--- a/containers-tests/tests/intmap-strictness.hs
+++ b/containers-tests/tests/intmap-strictness.hs
@@ -104,6 +104,32 @@ prop_fromSetA_equiv_strictness fun set =
   bottomOn = (===) `on` isBottom . getSolo
   f = MkSolo . applyFunc fun
 
+prop_strictFromSetMaybe :: Func Int (Maybe (Bot A)) -> IntSet -> Property
+prop_strictFromSetMaybe fun s =
+  isBottom (M.fromSetMaybe f s) === any isBottom (mapMaybe f (IntSet.toList s))
+  where
+    f = coerce (applyFunc fun) :: Int -> Maybe A
+
+prop_lazyFromSetMaybe :: Func Int (Maybe (Bot A)) -> IntSet -> Property
+prop_lazyFromSetMaybe fun s = isNotBottomProp (L.fromSetMaybe f s)
+  where
+    f = coerce (applyFunc fun) :: Int -> Maybe A
+
+prop_strictFromSetMaybeA
+  :: Func Int (Identity (Maybe (Bot A))) -> IntSet -> Property
+prop_strictFromSetMaybeA fun s =
+  isBottom (runIdentity (M.fromSetMaybeA f s)) ===
+    any isBottom (mapMaybe (runIdentity . f) (IntSet.toList s))
+  where
+    f = coerce (applyFunc fun) :: Int -> Identity (Maybe A)
+
+prop_lazyFromSetMaybeA
+  :: Func Int (Identity (Maybe (Bot A))) -> IntSet -> Property
+prop_lazyFromSetMaybeA fun s =
+  isNotBottomProp (runIdentity (L.fromSetMaybeA f s))
+  where
+    f = coerce (applyFunc fun) :: Int -> Identity (Maybe A)
+
 prop_strictFromList :: [(Key, Bot A)] -> Property
 prop_strictFromList kvs =
   isBottom (M.fromList kvs') === any (isBottom . snd) kvs'
@@ -1107,6 +1133,8 @@ tests =
       , testPropStrictLazy "fromSet" prop_strictFromSet prop_lazyFromSet
       , testPropStrictLazy "fromSetA" prop_strictFromSetA prop_lazyFromSetA
       , testProperty       "fromSetA equivalences" prop_fromSetA_equiv_strictness
+      , testPropStrictLazy "fromSetMaybe" prop_strictFromSetMaybe prop_lazyFromSetMaybe
+      , testPropStrictLazy "fromSetMaybeA" prop_strictFromSetMaybeA prop_lazyFromSetMaybeA
       , testPropStrictLazy "fromList" prop_strictFromList prop_lazyFromList
       , testPropStrictLazy "fromListWith" prop_strictFromListWith prop_lazyFromListWith
       , testPropStrictLazy "fromListWithKey" prop_strictFromListWithKey prop_lazyFromListWithKey

--- a/containers-tests/tests/map-properties.hs
+++ b/containers-tests/tests/map-properties.hs
@@ -36,7 +36,9 @@ import Prelude hiding (lookup, null, map, filter, foldr, foldl, foldl', take, dr
 import qualified Prelude
 
 import Data.List (nub,sort)
+import qualified Data.Maybe as Maybe
 import qualified Data.List as List
+import Data.Set (Set)
 import qualified Data.Set as Set
 
 import Test.Tasty
@@ -46,8 +48,8 @@ import Test.QuickCheck.Function (apply)
 import Test.QuickCheck.Poly (A, B, C, OrdA)
 import qualified Test.QuickCheck.Classes.Base as Laws
 
-import Utils.ArbitrarySetMap (mkArbMap)
-import Utils.QuickCheck (NubSortedOnFst(..), SortedOnFst(..))
+import Utils.ArbitrarySetMap (mkArbMap, setFromList)
+import Utils.QuickCheck (NubSorted(..), NubSortedOnFst(..), SortedOnFst(..))
 import Utils.QuickCheckClasses (testLaws)
 
 default (Int)
@@ -270,7 +272,9 @@ main = defaultMain $ testGroup "map-properties"
          , testProperty "keysSet"              prop_keysSet
          , testProperty "argSet"               prop_argSet
          , testProperty "fromSet"              prop_fromSet
-         , testProperty "fromSetA eval order"  prop_fromSetA_action_order
+         , testProperty "fromSetA"             prop_fromSetA
+         , testProperty "fromSetMaybe"         prop_fromSetMaybe
+         , testProperty "fromSetMaybeA"        prop_fromSetMaybeA
          , testProperty "fromArgSet"           prop_fromArgSet
          , testProperty "takeWhileAntitone"    prop_takeWhileAntitone
          , testProperty "dropWhileAntitone"    prop_dropWhileAntitone
@@ -392,6 +396,11 @@ instance (IsInt k, Arbitrary v) => Arbitrary (Map k v) where
         let i' = i + diff
         put i'
         pure (fromInt i')
+
+instance (Arbitrary a, Ord a) => Arbitrary (Set a) where
+  arbitrary = do
+    NubSorted xs <- arbitrary
+    setFromList xs
 
 -- A type with a peculiar Eq instance designed to make sure keys
 -- come from where they're supposed to.
@@ -1837,27 +1846,41 @@ prop_argSet :: [(OrdA, B)] -> Property
 prop_argSet xs =
   argSet (fromList xs) === Set.fromList (List.map (uncurry Arg) xs)
 
-prop_fromSet :: [OrdA] -> Fun OrdA B -> Property
+prop_fromSet :: Set OrdA -> Fun OrdA B -> Property
 prop_fromSet keys funF =
   let f = apply funF
-      m = fromSet f (Set.fromList keys)
+      m = fromSet f keys
   in
     valid m .&&.
-    m === fromList (fmap (id &&& f) keys)
+    toList m === fmap (id &&& f) (Set.toList keys)
 
-prop_fromSetA_action_order :: [OrdA] -> Fun OrdA B -> Property
-prop_fromSetA_action_order keys funF =
-  let set = Set.fromList keys
-      setList = Set.toList set
+prop_fromSetA :: Set OrdA -> Fun OrdA B -> Property
+prop_fromSetA keys funF =
+  let setList = Set.toList keys
       f = apply funF
       action = \k ->
         let v = f k
         in tell [v] $> v
-      (writtenMap, writtenOutput) = runWriter (fromSetA action set)
+      (writtenMap, writtenOutput) = runWriter (fromSetA action keys)
   in
     valid writtenMap .&&.
     writtenOutput === List.map f setList .&&.
     toList writtenMap === fmap (id &&& f) setList
+
+prop_fromSetMaybe :: Set OrdA -> Fun OrdA (Maybe B) -> Property
+prop_fromSetMaybe keys f =
+  valid m .&&.
+  toList m === Maybe.mapMaybe (\k -> (,) k <$> applyFun f k) (Set.toList keys)
+  where
+    m = fromSetMaybe (applyFun f) keys
+
+prop_fromSetMaybeA :: Set OrdA -> Fun OrdA (Maybe B) -> Property
+prop_fromSetMaybeA keys f =
+  valid m .&&.
+  ks === Set.toList keys .&&.
+  toList m === Maybe.mapMaybe (\k -> (,) k <$> applyFun f k) (Set.toList keys)
+  where
+    (ks, m) = fromSetMaybeA (\k -> ([k], applyFun f k)) keys
 
 prop_fromArgSet :: [(OrdA, B)] -> Property
 prop_fromArgSet ys =

--- a/containers-tests/tests/map-strictness.hs
+++ b/containers-tests/tests/map-strictness.hs
@@ -168,6 +168,32 @@ prop_fromSetA_equiv_strictness fun set =
   bottomOn = (===) `on` isBottom . getSolo
   f = MkSolo . applyFunc fun
 
+prop_strictFromSetMaybe :: Func OrdA (Maybe (Bot A)) -> Set OrdA -> Property
+prop_strictFromSetMaybe fun s =
+  isBottom (M.fromSetMaybe f s) === any isBottom (mapMaybe f (Set.toList s))
+  where
+    f = coerce (applyFunc fun) :: OrdA -> Maybe A
+
+prop_lazyFromSetMaybe :: Func OrdA (Maybe (Bot A)) -> Set OrdA -> Property
+prop_lazyFromSetMaybe fun s = isNotBottomProp (L.fromSetMaybe f s)
+  where
+    f = coerce (applyFunc fun) :: OrdA -> Maybe A
+
+prop_strictFromSetMaybeA
+  :: Func OrdA (Identity (Maybe (Bot A))) -> Set OrdA -> Property
+prop_strictFromSetMaybeA fun s =
+  isBottom (runIdentity (M.fromSetMaybeA f s)) ===
+    any isBottom (mapMaybe (runIdentity . f) (Set.toList s))
+  where
+    f = coerce (applyFunc fun) :: OrdA -> Identity (Maybe A)
+
+prop_lazyFromSetMaybeA
+  :: Func OrdA (Identity (Maybe (Bot A))) -> Set OrdA -> Property
+prop_lazyFromSetMaybeA fun s =
+  isNotBottomProp (runIdentity (L.fromSetMaybeA f s))
+  where
+    f = coerce (applyFunc fun) :: OrdA -> Identity (Maybe A)
+
 prop_strictFromArgSet :: Func OrdA (Bot A) -> Set OrdA -> Property
 prop_strictFromArgSet fun set =
   isBottom (M.fromArgSet set') ===
@@ -1234,6 +1260,8 @@ tests =
       , testPropStrictLazy "fromSetA" prop_strictFromSetA prop_lazyFromSetA
       , testProperty       "fromSetA equivalences" prop_fromSetA_equiv_strictness
       , testPropStrictLazy "fromArgSet" prop_strictFromArgSet prop_lazyFromArgSet
+      , testPropStrictLazy "fromSetMaybe" prop_strictFromSetMaybe prop_lazyFromSetMaybe
+      , testPropStrictLazy "fromSetMaybeA" prop_strictFromSetMaybeA prop_lazyFromSetMaybeA
       , testPropStrictLazy "fromList" prop_strictFromList prop_lazyFromList
       , testPropStrictLazy "fromListWith" prop_strictFromListWith prop_lazyFromListWith
       , testPropStrictLazy "fromListWithKey" prop_strictFromListWithKey prop_lazyFromListWithKey

--- a/containers/src/Data/IntMap/Internal.hs
+++ b/containers/src/Data/IntMap/Internal.hs
@@ -105,6 +105,8 @@ module Data.IntMap.Internal (
     , singleton
     , fromSet
     , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
 
     -- ** Insertion
     , insert
@@ -305,6 +307,7 @@ module Data.IntMap.Internal (
     , finishB
     , moveToB
     , MoveResult(..)
+    , treeFromIntSetTip
 
     -- * Used by "IntMap.Merge.Lazy" and "IntMap.Merge.Strict"
     , mapWhenMissing
@@ -3337,31 +3340,80 @@ keysSet (Bin p l r)
         computeBm acc (Tip kx _) = acc .|. IntSet.bitmapOf kx
         computeBm _   Nil = error "Data.IntSet.keysSet: Nil"
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value.
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key computes its value.
 --
 -- > fromSet (\k -> replicate k 'a') (Data.IntSet.fromList [3, 5]) == fromList [(5,"aaaaa"), (3,"aaa")]
--- > fromSet undefined Data.IntSet.empty == empty
-
 fromSet :: (Key -> a) -> IntSet -> IntMap a
 #ifdef __GLASGOW_HASKELL__
-fromSet f = runIdentity . fromSetA (coerce f)
+fromSet =
+  (coerce :: ((Key -> Identity a) -> IntSet -> Identity (IntMap a))
+          -> (Key -> a) -> IntSet -> IntMap a)
+    fromSetA
 #else
 fromSet f = runIdentity . fromSetA (pure . f)
 #endif
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value, while within an 'Applicative' context.
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key computes its value, while within an 'Applicative' context.
 --
--- > fromSetA (\k -> pure $ replicate k 'a') (Data.IntSet.fromList [3, 5]) == pure (fromList [(5,"aaaaa"), (3,"aaa")])
--- > fromSetA undefined Data.IntSet.empty == pure empty
-
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- > let f k = if k == 0 then Nothing else Just (6 `div` k)
+-- > fromSetA f (Data.Set.fromList [1,2,3,4]) == Just (fromList [(1,6),(2,3),(3,2),(4,1)])
+-- > fromSetA f (Data.Set.fromList [0,1,2]) == Nothing
+--
+-- @since FIXME
 fromSetA :: Applicative f => (Key -> f a) -> IntSet -> f (IntMap a)
 fromSetA _ IntSet.Nil = pure Nil
 fromSetA f (IntSet.Bin p l r)
   | signBranch p = liftA2 (flip (Bin p)) (fromSetA f r) (fromSetA f l)
   | otherwise = liftA2 (Bin p) (fromSetA f l) (fromSetA f r)
-fromSetA f (IntSet.Tip kx bm) = buildTree f kx bm (IntSet.suffixBitMask + 1)
+fromSetA f (IntSet.Tip kx bm) =
+  treeFromIntSetTip (\kx' -> Tip kx' <$> f kx') (\p -> liftA2 (Bin p)) kx bm
+{-# INLINABLE fromSetA #-}
+
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for each
+-- key optionally computes its value.
+--
+-- > let f k = if even k then Just (replicate k 'a') else Nothing
+-- > fromSetMaybe f (Data.IntSet.fromList [1,2,3,4]) == fromList [(2,"aa"), (4,"aaaa")]
+--
+-- @since FIXME
+fromSetMaybe :: (Key -> Maybe a) -> IntSet -> IntMap a
+#ifdef __GLASGOW_HASKELL__
+fromSetMaybe =
+  (coerce :: ((Key -> Identity (Maybe a)) -> IntSet -> Identity (IntMap a))
+          -> (Key -> Maybe a) -> IntSet -> IntMap a)
+    fromSetMaybeA
+#else
+fromSetMaybe f s = runIdentity (fromSetMaybeA (Identity . f) s)
+#endif
+
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key optionally computes its value in an 'Applicative' context.
+--
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- @since FIXME
+fromSetMaybeA :: Applicative f => (Key -> f (Maybe a)) -> IntSet -> f (IntMap a)
+fromSetMaybeA f = go
+  where
+   go IntSet.Nil = pure Nil
+   go (IntSet.Bin p l r)
+     | signBranch p = liftA2 (flip (bin p)) (go r) (go l)
+     | otherwise = liftA2 (bin p) (go l) (go r)
+   go (IntSet.Tip kx bm) =
+     treeFromIntSetTip
+       (\kx' -> maybe Nil (Tip kx') <$> f kx')
+       (\p -> liftA2 (bin p))
+       kx
+       bm
+{-# INLINABLE fromSetMaybeA #-}
+
+-- Internal helper used by fromSet and friends.
+treeFromIntSetTip :: (Int -> a) -> (Prefix -> a -> a -> a) -> Int -> Word -> a
+treeFromIntSetTip tipf binf kx bm = buildTree kx bm (IntSet.suffixBitMask + 1)
   where
     -- This is slightly complicated, as we to convert the dense
     -- representation of IntSet into tree representation of IntMap.
@@ -3371,20 +3423,19 @@ fromSetA f (IntSet.Tip kx bm) = buildTree f kx bm (IntSet.suffixBitMask + 1)
     -- to left and right subtree. If they are both nonempty, we
     -- create a Bin node, otherwise exactly one of them is nonempty
     -- and we construct the IntMap from that half.
-    buildTree g !prefix !bmask bits = case bits of
-      0 -> Tip prefix <$> (g prefix)
+    buildTree !prefix !bmask bits = case bits of
+      0 -> tipf prefix
       _ -> case bits `iShiftRL` 1 of
         bits2
           | bmask .&. ((1 `shiftLL` bits2) - 1) == 0 ->
-              buildTree g (prefix + bits2) (bmask `shiftRL` bits2) bits2
+              buildTree (prefix + bits2) (bmask `shiftRL` bits2) bits2
           | (bmask `shiftRL` bits2) .&. ((1 `shiftLL` bits2) - 1) == 0 ->
-              buildTree g prefix bmask bits2
+              buildTree prefix bmask bits2
           | otherwise ->
-              liftA2
-                (Bin (Prefix (prefix .|. bits2)))
-                  (buildTree g prefix bmask bits2)
-                  (buildTree g (prefix + bits2) (bmask `shiftRL` bits2) bits2)
-{-# INLINABLE fromSetA #-}
+             binf (Prefix (prefix .|. bits2))
+                  (buildTree prefix bmask bits2)
+                  (buildTree (prefix + bits2) (bmask `shiftRL` bits2) bits2)
+{-# INLINE treeFromIntSetTip #-}
 
 {--------------------------------------------------------------------
   Lists

--- a/containers/src/Data/IntMap/Lazy.hs
+++ b/containers/src/Data/IntMap/Lazy.hs
@@ -100,8 +100,6 @@ module Data.IntMap.Lazy (
     -- * Construction
     , empty
     , singleton
-    , fromSet
-    , fromSetA
 
     -- ** From Unordered Lists
     , fromList
@@ -117,6 +115,12 @@ module Data.IntMap.Lazy (
     , fromDistinctAscList
     , fromDescList
     , fromDescListUpsert
+
+    -- * From @IntSet@
+    , fromSet
+    , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
 
     -- * Insertion
     , insert

--- a/containers/src/Data/IntMap/Strict.hs
+++ b/containers/src/Data/IntMap/Strict.hs
@@ -118,8 +118,6 @@ module Data.IntMap.Strict (
     -- * Construction
     , empty
     , singleton
-    , fromSet
-    , fromSetA
 
     -- ** From Unordered Lists
     , fromList
@@ -135,6 +133,12 @@ module Data.IntMap.Strict (
     , fromDistinctAscList
     , fromDescList
     , fromDescListUpsert
+
+    -- * From @IntSet@
+    , fromSet
+    , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
 
     -- * Insertion
     , insert

--- a/containers/src/Data/IntMap/Strict/Internal.hs
+++ b/containers/src/Data/IntMap/Strict/Internal.hs
@@ -60,6 +60,8 @@ module Data.IntMap.Strict.Internal (
     , singleton
     , fromSet
     , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
 
     -- ** From Unordered Lists
     , fromList
@@ -232,10 +234,9 @@ import Utils.Containers.Internal.Prelude hiding
   (lookup,map,filter,foldr,foldl,foldl',null)
 import Prelude ()
 
-import Data.Bits
 import qualified Data.IntMap.Internal as L
 import Data.IntSet.Internal.IntTreeCommons
-  (Key, Prefix(..), nomatch, left, signBranch, branchMask)
+  (Key, nomatch, left, signBranch, branchMask)
 import Data.IntMap.Internal
   ( IntMap (..)
   , bin
@@ -257,6 +258,7 @@ import Data.IntMap.Internal
   , finishB
   , moveToB
   , MoveResult(..)
+  , treeFromIntSetTip
 
   , (\\)
   , (!)
@@ -331,8 +333,8 @@ import Data.IntMap.Internal
   , unions
   , withoutKeys
   )
+import Data.IntSet.Internal (IntSet)
 import qualified Data.IntSet.Internal as IntSet
-import Utils.Containers.Internal.BitUtil (iShiftRL, shiftLL, shiftRL)
 import Utils.Containers.Internal.Strict (StrictPair(..), toPair)
 import qualified Data.Foldable as Foldable
 import Data.Functor.Identity (Identity (..))
@@ -1066,66 +1068,81 @@ mapEitherWithKey f0 t0 = toPair $ go f0 t0
   Conversions
 --------------------------------------------------------------------}
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value.
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key computes its value.
 --
 -- > fromSet (\k -> replicate k 'a') (Data.IntSet.fromList [3, 5]) == fromList [(5,"aaaaa"), (3,"aaa")]
--- > fromSet undefined Data.IntSet.empty == empty
 
-fromSet :: (Key -> a) -> IntSet.IntSet -> IntMap a
+fromSet :: (Key -> a) -> IntSet -> IntMap a
 #ifdef __GLASGOW_HASKELL__
-fromSet f = runIdentity . fromSetA (coerce f)
+fromSet =
+  (coerce :: ((Key -> Identity a) -> IntSet -> Identity (IntMap a))
+          -> (Key -> a) -> IntSet -> IntMap a)
+    fromSetA
 #else
 fromSet f = runIdentity . fromSetA (pure . f)
 #endif
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value, while within an 'Applicative' context.
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key computes its value, while within an 'Applicative' context.
 --
--- This can only be as strict as the 'Applicative' allows it to be.
+-- The @Applicative@ actions are sequenced in order of increasing key.
 --
--- > fromSetA (\k -> pure $ replicate k 'a') (Data.IntSet.fromList [3, 5]) == pure (fromList [(5,"aaaaa"), (3,"aaa")])
--- > fromSetA undefined Data.IntSet.empty == pure empty
+-- > let f k = if k == 0 then Nothing else Just (6 `div` k)
+-- > fromSetA f (Data.Set.fromList [1,2,3,4]) == Just (fromList [(1,6),(2,3),(3,2),(4,1)])
+-- > fromSetA f (Data.Set.fromList [0,1,2]) == Nothing
 --
--- The following strictness properties hold:
---
--- > fromSetA f = fmap forceValues . Data.Map.Lazy.fromSetA f
--- >   where
--- >     forceValues xs = foldr (\ !_ r -> r) () xs `seq` xs
---
--- > fromSetA f =
--- >   fmap getSolo .
--- >   getCompose .
--- >   Data.Map.Lazy.fromSetA (Compose . fmap (MkSolo $!) . f)
-
-fromSetA :: Applicative f => (Key -> f a) -> IntSet.IntSet -> f (IntMap a)
+-- @since FIXME
+fromSetA :: Applicative f => (Key -> f a) -> IntSet -> f (IntMap a)
 fromSetA _ IntSet.Nil = pure Nil
 fromSetA f (IntSet.Bin p l r)
   | signBranch p = liftA2 (flip (Bin p)) (fromSetA f r) (fromSetA f l)
   | otherwise = liftA2 (Bin p) (fromSetA f l) (fromSetA f r)
-fromSetA f (IntSet.Tip kx bm) = buildTree f kx bm (IntSet.suffixBitMask + 1)
-  where
-    -- This is slightly complicated, as we to convert the dense
-    -- representation of IntSet into tree representation of IntMap.
-    --
-    -- We are given a nonzero bit mask 'bmask' of 'bits' bits with prefix 'prefix'.
-    -- We split bmask into halves corresponding to left and right subtree.
-    -- If they are both nonempty, we create a Bin node, otherwise exactly
-    -- one of them is nonempty and we construct the IntMap from that half.
-    buildTree g !prefix !bmask bits = case bits of
-      0 -> (Tip prefix $!) <$> g prefix
-      _ -> case bits `iShiftRL` 1 of
-        bits2
-          | bmask .&. ((1 `shiftLL` bits2) - 1) == 0 ->
-              buildTree g (prefix + bits2) (bmask `shiftRL` bits2) bits2
-          | (bmask `shiftRL` bits2) .&. ((1 `shiftLL` bits2) - 1) == 0 ->
-              buildTree g prefix bmask bits2
-          | otherwise ->
-              liftA2
-                (Bin (Prefix (prefix .|. bits2)))
-                  (buildTree g prefix bmask bits2)
-                  (buildTree g (prefix + bits2) (bmask `shiftRL` bits2) bits2)
+fromSetA f (IntSet.Tip kx bm) =
+  treeFromIntSetTip
+    (\kx' -> (Tip kx' $!) <$> f kx')
+    (\p -> liftA2 (Bin p))
+    kx
+    bm
 {-# INLINABLE fromSetA #-}
+
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for each
+-- key optionally computes its value.
+--
+-- > let f k = if even k then Just (replicate k 'a') else Nothing
+-- > fromSetMaybe f (Data.IntSet.fromList [1,2,3,4]) == fromList [(2,"aa"), (4,"aaaa")]
+--
+-- @since FIXME
+fromSetMaybe :: (Key -> Maybe a) -> IntSet -> IntMap a
+#ifdef __GLASGOW_HASKELL__
+fromSetMaybe =
+  (coerce :: ((Key -> Identity (Maybe a)) -> IntSet -> Identity (IntMap a))
+          -> (Key -> Maybe a) -> IntSet -> IntMap a)
+    fromSetMaybeA
+#else
+fromSetMaybe f s = runIdentity (fromSetMaybeA (Identity . f) s)
+#endif
+
+-- | \(O(n)\). Build a map from an 'IntSet' of keys and a function which for
+-- each key optionally computes its value in an 'Applicative' context.
+--
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- @since FIXME
+fromSetMaybeA :: Applicative f => (Key -> f (Maybe a)) -> IntSet -> f (IntMap a)
+fromSetMaybeA f = go
+  where
+   go IntSet.Nil = pure Nil
+   go (IntSet.Bin p l r)
+     | signBranch p = liftA2 (flip (bin p)) (go r) (go l)
+     | otherwise = liftA2 (bin p) (go l) (go r)
+   go (IntSet.Tip kx bm) =
+     treeFromIntSetTip
+       (\kx' -> maybe Nil (Tip kx' $!) <$> f kx')
+       (\p -> liftA2 (bin p))
+       kx
+       bm
+{-# INLINABLE fromSetMaybeA #-}
 
 {--------------------------------------------------------------------
   Lists

--- a/containers/src/Data/Map/Internal.hs
+++ b/containers/src/Data/Map/Internal.hs
@@ -264,6 +264,8 @@ module Data.Map.Internal (
     , argSet
     , fromSet
     , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
     , fromArgSet
 
     -- ** Lists
@@ -3353,30 +3355,67 @@ argSet :: Map k a -> Set.Set (Arg k a)
 argSet Tip = Set.Tip
 argSet (Bin sz kx x l r) = Set.Bin sz (Arg kx x) (argSet l) (argSet r)
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value.
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key computes its value.
 --
--- > fromSet (\k -> replicate k 'a') (Data.Set.fromList [3, 5]) == fromList [(5,"aaaaa"), (3,"aaa")]
--- > fromSet undefined Data.Set.empty == empty
+-- > fromSet (\k -> replicate k 'a') (Data.Set.fromList [3,5]) == fromList [(3,"aaa"), (5,"aaaaa")]
 
-fromSet :: (k -> a) -> Set.Set k -> Map k a
+fromSet :: (k -> a) -> Set k -> Map k a
 #ifdef __GLASGOW_HASKELL__
-fromSet f = runIdentity . fromSetA (coerce f)
+fromSet =
+  (coerce :: ((k -> Identity a) -> Set k -> Identity (Map k a))
+          -> (k -> a) -> Set k -> Map k a)
+    fromSetA
 #else
 fromSet f = runIdentity . fromSetA (pure . f)
 #endif
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value in an 'Applicative' context.
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key computes its value in an 'Applicative' context.
 --
--- > fromSetA (\k -> pure $ replicate k 'a') (Data.Set.fromList [3, 5]) == pure (fromList [(5,"aaaaa"), (3,"aaa")])
--- > fromSetA undefined Data.Set.empty == pure empty
-
-fromSetA :: Applicative f => (k -> f a) -> Set.Set k -> f (Map k a)
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- > let f k = if k == 0 then Nothing else Just (6 `div` k)
+-- > fromSetA f (Data.Set.fromList [1,2,3,4]) == Just (fromList [(1,6),(2,3),(3,2),(4,1)])
+-- > fromSetA f (Data.Set.fromList [0,1,2]) == Nothing
+--
+-- @since FIXME
+fromSetA :: Applicative f => (k -> f a) -> Set k -> f (Map k a)
 fromSetA _ Set.Tip = pure Tip
 fromSetA f (Set.Bin sz x l r) =
   liftA3 (flip (Bin sz x)) (fromSetA f l) (f x) (fromSetA f r)
 {-# INLINABLE fromSetA #-}
+
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key optionally computes its value.
+--
+-- > let f k = if even k then Just (replicate k 'a') else Nothing
+-- > fromSetMaybe f (Data.Set.fromList [1,2,3,4]) == fromList [(2,"aa"), (4,"aaaa")]
+--
+-- @since FIXME
+fromSetMaybe :: (k -> Maybe a) -> Set k -> Map k a
+#ifdef __GLASGOW_HASKELL__
+fromSetMaybe =
+  (coerce :: ((k -> Identity (Maybe a)) -> Set k -> Identity (Map k a))
+          -> (k -> Maybe a) -> Set k -> Map k a)
+     fromSetMaybeA
+#else
+fromSetMaybe f s = runIdentity (fromSetMaybeA (Identity . f) s)
+#endif
+
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key optionally computes its values in an 'Applicative' context.
+--
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- @since FIXME
+fromSetMaybeA :: Applicative f => (k -> f (Maybe a)) -> Set k -> f (Map k a)
+fromSetMaybeA f = go
+  where
+    go Set.Tip = pure Tip
+    go (Set.Bin _ k l r) =
+      liftA3 (\l' mx r' -> maybe link2 (link k) mx l' r') (go l) (f k) (go r)
+{-# INLINABLE fromSetMaybeA #-}
 
 -- | \(O(n)\). Build a map from a set of elements contained inside 'Arg's.
 --

--- a/containers/src/Data/Map/Lazy.hs
+++ b/containers/src/Data/Map/Lazy.hs
@@ -107,9 +107,6 @@ module Data.Map.Lazy (
     -- * Construction
     , empty
     , singleton
-    , fromSet
-    , fromSetA
-    , fromArgSet
 
     -- ** From Unordered Lists
     , fromList
@@ -130,6 +127,13 @@ module Data.Map.Lazy (
     , fromDescListWithKey
     , fromDescListUpsert
     , fromDistinctDescList
+
+    -- ** From @Set@
+    , fromSet
+    , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
+    , fromArgSet
 
     -- * Insertion
     , insert

--- a/containers/src/Data/Map/Strict.hs
+++ b/containers/src/Data/Map/Strict.hs
@@ -121,9 +121,6 @@ module Data.Map.Strict
     -- * Construction
     , empty
     , singleton
-    , fromSet
-    , fromSetA
-    , fromArgSet
 
     -- ** From Unordered Lists
     , fromList
@@ -144,6 +141,13 @@ module Data.Map.Strict
     , fromDescListWithKey
     , fromDescListUpsert
     , fromDistinctDescList
+
+    -- ** From @Set@
+    , fromSet
+    , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
+    , fromArgSet
 
     -- * Insertion
     , insert

--- a/containers/src/Data/Map/Strict/Internal.hs
+++ b/containers/src/Data/Map/Strict/Internal.hs
@@ -215,6 +215,8 @@ module Data.Map.Strict.Internal
     , argSet
     , fromSet
     , fromSetA
+    , fromSetMaybe
+    , fromSetMaybeA
     , fromArgSet
 
     -- ** Lists
@@ -414,6 +416,7 @@ import Data.Map.Internal.Debug (valid)
 
 import Control.Applicative (Const (..), liftA3)
 import Data.Semigroup (Arg (..))
+import Data.Set.Internal (Set)
 import qualified Data.Set.Internal as Set
 import qualified Data.Map.Internal as L
 import Utils.Containers.Internal.Strict (StrictPair(..), toPair)
@@ -1397,43 +1400,67 @@ mapAssocsMonotonic f = go
   Conversions
 --------------------------------------------------------------------}
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value.
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key computes its value.
 --
 -- > fromSet (\k -> replicate k 'a') (Data.Set.fromList [3, 5]) == fromList [(5,"aaaaa"), (3,"aaa")]
--- > fromSet undefined Data.Set.empty == empty
 
-fromSet :: (k -> a) -> Set.Set k -> Map k a
+fromSet :: (k -> a) -> Set k -> Map k a
 #ifdef __GLASGOW_HASKELL__
-fromSet f = runIdentity . fromSetA (coerce f)
+fromSet =
+  (coerce :: ((k -> Identity a) -> Set k -> Identity (Map k a))
+          -> (k -> a) -> Set k -> Map k a)
+    fromSetA
 #else
 fromSet f = runIdentity . fromSetA (pure . f)
 #endif
 
--- | \(O(n)\). Build a map from a set of keys and a function which for each key
--- computes its value in an 'Applicative' context.
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key computes its value in an 'Applicative' context.
 --
--- This can only be as strict as the 'Applicative' allows it to be.
+-- The @Applicative@ actions are sequenced in order of increasing key.
 --
--- > fromSetA (\k -> pure $ replicate k 'a') (Data.Set.fromList [3, 5]) == pure (fromList [(5,"aaaaa"), (3,"aaa")])
--- > fromSetA undefined Data.Set.empty == pure empty
+-- > let f k = if k == 0 then Nothing else Just (6 `div` k)
+-- > fromSetA f (Data.Set.fromList [1,2,3,4]) == Just (fromList [(1,6),(2,3),(3,2),(4,1)])
+-- > fromSetA f (Data.Set.fromList [0,1,2]) == Nothing
 --
--- The following strictness properties hold:
---
--- > fromSetA f = fmap forceValues . Data.Map.Lazy.fromSetA f
--- >   where
--- >     forceValues xs = foldr (\ !_ r -> r) () xs `seq` xs
---
--- > fromSetA f =
--- >   fmap getSolo .
--- >   getCompose .
--- >   Data.Map.Lazy.fromSetA (Compose . fmap (MkSolo $!) . f)
-
-fromSetA :: Applicative f => (k -> f a) -> Set.Set k -> f (Map k a)
+-- @since FIXME
+fromSetA :: Applicative f => (k -> f a) -> Set k -> f (Map k a)
 fromSetA _ Set.Tip = pure Tip
 fromSetA f (Set.Bin sz x l r) = 
   liftA3 (flip (Bin sz x $!)) (fromSetA f l) (f x) (fromSetA f r)
 {-# INLINABLE fromSetA #-}
+
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key optionally computes its value.
+--
+-- > let f k = if even k then Just (replicate k 'a') else Nothing
+-- > fromSetMaybe f (Data.Set.fromList [1,2,3,4]) == fromList [(2,"aa"), (4,"aaaa")]
+--
+-- @since FIXME
+fromSetMaybe :: (k -> Maybe a) -> Set k -> Map k a
+#ifdef __GLASGOW_HASKELL__
+fromSetMaybe =
+  (coerce :: ((k -> Identity (Maybe a)) -> Set k -> Identity (Map k a))
+          -> (k -> Maybe a) -> Set k -> Map k a)
+     fromSetMaybeA
+#else
+fromSetMaybe f s = runIdentity (fromSetMaybeA (Identity . f) s)
+#endif
+
+-- | \(O(n)\). Build a map from a 'Set' of keys and a function which for each
+-- key optionally computes its values in an 'Applicative' context.
+--
+-- The @Applicative@ actions are sequenced in order of increasing key.
+--
+-- @since FIXME
+fromSetMaybeA :: Applicative f => (k -> f (Maybe a)) -> Set k -> f (Map k a)
+fromSetMaybeA f = go
+  where
+    go Set.Tip = pure Tip
+    go (Set.Bin _ k l r) =
+      liftA3 (\l' mx r' -> maybe link2 (link k $!) mx l' r') (go l) (f k) (go r)
+{-# INLINABLE fromSetMaybeA #-}
 
 -- | \(O(n)\). Build a map from a set of elements contained inside 'Arg's.
 --


### PR DESCRIPTION
These are like the existing fromSet and fromSetA, but allow dropping
some keys from the input set. These functions will also be used by the
in-progress Map-Set merge API.

Also adjust fromSet and fromSetA docs to make it consistent with the new
functions.

Closes #1232